### PR TITLE
Add kwargs... to latent and obs model methods

### DIFF
--- a/src/latent_models/ar1.jl
+++ b/src/latent_models/ar1.jl
@@ -57,7 +57,7 @@ function _validate_ar1_parameters(; τ::Real, ρ::Real)
     return nothing
 end
 
-function precision_matrix(model::AR1Model; τ::Real, ρ::Real)
+function precision_matrix(model::AR1Model; τ::Real, ρ::Real, kwargs...)
     _validate_ar1_parameters(; τ = τ, ρ = ρ)
 
     n = model.n

--- a/src/latent_models/besag.jl
+++ b/src/latent_models/besag.jl
@@ -154,7 +154,7 @@ function _compute_normalization(Q::AbstractMatrix, connected_comps, ::Val{true},
 end
 _compute_normalization(::AbstractMatrix, connected_comps, ::Val{false}, singleton_policy; kwargs...) = I
 
-function precision_matrix(model::BesagModel; τ::Real)
+function precision_matrix(model::BesagModel; τ::Real, kwargs...)
     _validate_besag_parameters(; τ = τ)
     Q = model.normalization_factor * τ * model.Q  # Scale by τ first
     Q += model.regularization * I  # Add regularization

--- a/src/latent_models/iid.jl
+++ b/src/latent_models/iid.jl
@@ -55,7 +55,7 @@ function _validate_iid_parameters(; τ::Real)
     return nothing
 end
 
-function precision_matrix(model::IIDModel; τ::Real)
+function precision_matrix(model::IIDModel; τ::Real, kwargs...)
     _validate_iid_parameters(; τ = τ)
 
     n = model.n

--- a/src/latent_models/matern.jl
+++ b/src/latent_models/matern.jl
@@ -131,7 +131,7 @@ function _validate_matern_parameters(; range::Real)
     return nothing
 end
 
-function precision_matrix(model::MaternModel{F, S}; range::Real) where {F, S}
+function precision_matrix(model::MaternModel{F, S}; range::Real, kwargs...) where {F, S}
     _validate_matern_parameters(; range = range)
 
     # Extract dimension from discretization

--- a/src/latent_models/rw1.jl
+++ b/src/latent_models/rw1.jl
@@ -61,7 +61,7 @@ function _validate_rw1_parameters(; τ::Real)
     return nothing
 end
 
-function precision_matrix(model::RW1Model; τ::Real)
+function precision_matrix(model::RW1Model; τ::Real, kwargs...)
     _validate_rw1_parameters(; τ = τ)
 
     n = model.n

--- a/src/observation_models/nonlinear_least_squares.jl
+++ b/src/observation_models/nonlinear_least_squares.jl
@@ -45,7 +45,7 @@ end
 # Factory pattern: make the model callable to materialize a likelihood
 # -------------------------------------------------------------------------------------------------
 
-function (model::NonlinearLeastSquaresModel)(y::AbstractVector; σ)
+function (model::NonlinearLeastSquaresModel)(y::AbstractVector; σ, kwargs...)
     # Validate σ and normalize to vector of inverse variances
     m = length(y)
     σv = _normalize_sigma(σ, m)
@@ -107,7 +107,7 @@ function loghessian(x::AbstractVector, lik::NonlinearLeastSquaresLikelihood)
     return Symmetric(H)
 end
 
-function conditional_distribution(model::NonlinearLeastSquaresModel, x::AbstractVector; σ)
+function conditional_distribution(model::NonlinearLeastSquaresModel, x::AbstractVector; σ, kwargs...)
     ŷ = model.f(x)
     if σ isa AbstractVector
         length(σ) == length(ŷ) || error("Length of σ vector must match f(x)")


### PR DESCRIPTION
Allows methods in latent models (precision_matrix) and observation models (factory methods, conditional_distribution) to accept and ignore arbitrary extra hyperparameters via kwargs.
This enables users to carry a single hyperparameter vector in optimization loops and splat it into all downstream methods for convenience.