### PR TITLE
Add x0 warm-start keyword to gaussian_approx

### DIFF
--- a/src/arithmetic/condition/gaussian_approximation.jl
+++ b/src/arithmetic/condition/gaussian_approximation.jl
@@ -89,6 +89,7 @@ posterior_gmrf = gaussian_approximation(prior_gmrf, obs_lik; adaptive_stepsize=f
 function gaussian_approximation(
         prior_gmrf::Union{GMRF, ConstrainedGMRF},
         obs_lik::ObservationLikelihood;
+        x0::Union{Nothing, AbstractVector} = nothing,
         max_iter::Int = 50,
         mean_change_tol::Real = 1.0e-4,
         newton_dec_tol::Real = 1.0e-5,
@@ -100,8 +101,8 @@ function gaussian_approximation(
     base_gmrf = _base_gmrf(prior_gmrf)
     constraints = _extract_constraints(prior_gmrf)
 
-    # Initialize with prior mean
-    x_k = mean(prior_gmrf)
+    # Initialize with provided starting point or prior mean
+    x_k = x0 === nothing ? mean(prior_gmrf) : copy(x0)
 
     cache = deepcopy(linsolve_cache(base_gmrf))
     Q_base = cache.A

--- a/test/gaussian_approximation/test_gaussian_approximation.jl
+++ b/test/gaussian_approximation/test_gaussian_approximation.jl
@@ -347,6 +347,43 @@ using Distributions
         @test precision_matrix(result)[1, 1] > 0
     end
 
+    @testset "Warm-start with x0 keyword" begin
+        # Setup: Poisson with moderate counts so Newton needs a few iterations
+        n = 6
+        Q_prior = Diagonal(1.0 * ones(n))
+        prior_gmrf = GMRF(zeros(n), Q_prior)
+
+        obs_model = ExponentialFamily(Poisson)
+        y = PoissonObservations([5, 12, 2, 8, 15, 3])
+        obs_lik = obs_model(y)
+
+        # Cold-start result (baseline)
+        result_cold = gaussian_approximation(prior_gmrf, obs_lik)
+        x_star = mean(result_cold)
+
+        @testset "x0 produces equivalent result when starting from converged mode" begin
+            result_warm = gaussian_approximation(prior_gmrf, obs_lik; x0 = x_star)
+            @test mean(result_warm) ≈ x_star atol = 1.0e-3
+            @test precision_matrix(result_warm) ≈ precision_matrix(result_cold) atol = 1.0e-2
+        end
+
+        @testset "x0 = nothing gives same result as default" begin
+            result_default = gaussian_approximation(prior_gmrf, obs_lik; x0 = nothing)
+            @test mean(result_default) ≈ x_star atol = 1.0e-10
+        end
+
+        @testset "warm-start converges faster" begin
+            # Warm start from the converged mode should be faster than cold start
+            t_cold = @elapsed for _ in 1:20
+                gaussian_approximation(prior_gmrf, obs_lik)
+            end
+            t_warm = @elapsed for _ in 1:20
+                gaussian_approximation(prior_gmrf, obs_lik; x0 = x_star)
+            end
+            @test t_warm < t_cold
+        end
+    end
+
     @testset "Adaptive stepsize - multiple extreme Poisson" begin
         # Multi-dimensional case with varying extreme counts
         n = 5


### PR DESCRIPTION
Allows callers to provide a starting point for Newton iteration instead of always starting from the prior mean.