### PR TITLE
Fix constrained gaussian_approximation convergence

### DIFF
--- a/src/arithmetic/condition/gaussian_approximation.jl
+++ b/src/arithmetic/condition/gaussian_approximation.jl
@@ -28,6 +28,29 @@ _apply_constraints(gmrf::GMRF, constraints::NamedTuple) = ConstrainedGMRF(gmrf, 
 _base_gmrf(gmrf::GMRF) = gmrf
 _base_gmrf(constrained::ConstrainedGMRF) = constrained.base_gmrf
 
+# Compute the constrained Newton step via the KKT Schur complement.
+# Solves H⁻¹Aᵀ using the existing linsolve cache (m sparse solves, m = #constraints),
+# then removes the constraint-normal component so AΔx = 0.
+_constrain_step(step, cache, ::Nothing) = step
+function _constrain_step(step, cache, constraints::NamedTuple)
+    A = constraints.A
+    m = size(A, 1)
+    n = length(step)
+
+    # Solve H · X = Aᵀ column-by-column (reuses current cache factorization)
+    A_tilde_T = Matrix{eltype(step)}(undef, n, m)
+    saved_b = copy(cache.b)
+    for i in 1:m
+        cache.b .= @view(A[i, :])
+        A_tilde_T[:, i] .= solve!(cache).u
+    end
+    cache.b .= saved_b
+
+    # Schur complement: remove constraint-normal component
+    L_c = cholesky(Symmetric(A * A_tilde_T))
+    return step - A_tilde_T * (L_c \ (A * step))
+end
+
 # Set the matrix in the linsolve cache to Q
 _update_linsolve_cache!(cache, Q) = _update_linsolve_cache_inner!(cache, Q, cache.alg)
 
@@ -124,6 +147,11 @@ function gaussian_approximation(
         cache.b = neg_score_k
         step = solve!(cache).u
 
+        # For constrained problems, project step onto constraint tangent space
+        # via the KKT Schur complement (m sparse solves, m = #constraints).
+        # This ensures A*step = 0, so x_k - α*step stays on the manifold.
+        step = _constrain_step(step, cache, constraints)
+
         # Apply step with adaptive line search or full step
         if adaptive_stepsize
             obj_current = neg_log_posterior(base_gmrf, obs_lik, x_k)
@@ -160,24 +188,18 @@ function gaussian_approximation(
             μ_new = x_k - step
         end
 
+        # Newton decrement: dot(g, constrained_step) = -g'Δx_nt = Δx_nt'HΔx_nt ≥ 0
         newton_decrement = dot(neg_score_k, step)
 
-        # Update cache matrix and create new GMRF with updated precision
-        new_gmrf = GMRF(μ_new, Q_new; linsolve_cache = cache)
-
-        # Apply constraints if present (no-op for regular GMRF)
-        result = _apply_constraints(new_gmrf, constraints)
-
-        # Get mean for convergence check (projects if constrained)
-        x_new = mean(result)
-
+        x_new = μ_new
         mean_change = norm(x_new - x_k)
         mean_change_rel = mean_change / norm(x_k)
 
         verbose && println("  Iter $iter: Newton dec = $(round(newton_decrement, sigdigits = 3)), α = $(round(α, digits = 3))")
         if (newton_decrement < newton_dec_tol) || (mean_change < mean_change_tol) || (mean_change_rel < mean_change_tol)
             verbose && println("  Converged after $iter iterations")
-            return result
+            new_gmrf = GMRF(x_new, Q_new; linsolve_cache = cache)
+            return _apply_constraints(new_gmrf, constraints)
         end
 
         # Update for next iteration

--- a/test/test_constrained_gaussian_approximation.jl
+++ b/test/test_constrained_gaussian_approximation.jl
@@ -84,6 +84,67 @@ using Distributions
         @test A_multi * mean(result) ≈ e_multi atol = 1.0e-10
     end
 
+    @testset "Constrained Newton convergence - Poisson" begin
+        # Bug 1: Newton decrement uses unprojected gradient, so it never
+        # triggers for constrained models. Isolate by setting mean_change_tol = 0
+        # and mean_change_rel implicitly disabled (mean_change_tol = 0 handles both).
+        # Use a larger problem where the backup criterion isn't enough.
+        n_p = 25
+        W_p = spzeros(n_p, n_p)
+        for i in 1:(n_p - 1)
+            W_p[i, i + 1] = W_p[i + 1, i] = 1.0
+        end
+        besag_p = BesagModel(W_p)
+        prior_p = besag_p(τ = 2.0)
+
+        obs_model_p = ExponentialFamily(Poisson)
+        y_p = PoissonObservations(
+            [8, 3, 12, 1, 6, 15, 2, 9, 4, 11, 7, 3, 14, 5, 8, 2, 10, 6, 13, 1, 7, 4, 9, 11, 5]
+        )
+        obs_lik_p = obs_model_p(y_p)
+
+        # With mean_change_tol = 0, convergence MUST come from newton_dec_tol.
+        # Before the fix, this hits max_iter every time.
+        # After the fix, it should converge well before max_iter = 50.
+        result_50 = gaussian_approximation(
+            prior_p, obs_lik_p;
+            newton_dec_tol = 1.0e-6, mean_change_tol = 0.0, max_iter = 50
+        )
+        result_15 = gaussian_approximation(
+            prior_p, obs_lik_p;
+            newton_dec_tol = 1.0e-6, mean_change_tol = 0.0, max_iter = 15
+        )
+
+        @test result_50 isa ConstrainedGMRF
+        @test sum(mean(result_50)) ≈ 0.0 atol = 1.0e-10
+        # If newton_dec_tol actually triggers, both should give the same answer
+        @test mean(result_15) ≈ mean(result_50) atol = 1.0e-6
+    end
+
+    @testset "Constrained solution independent of max_iter" begin
+        # Bugs 1+2 combined: for a Besag + Poisson problem, the solver should
+        # converge well before 20 iters when both bugs are fixed.
+        n_m = 16
+        W_m = spzeros(n_m, n_m)
+        nr_m, nc_m = 4, 4
+        for i in 1:nr_m, j in 1:nc_m
+            node = (i - 1) * nc_m + j
+            j < nc_m && (W_m[node, node + 1] = W_m[node + 1, node] = 1.0)
+            i < nr_m && (W_m[node, node + nc_m] = W_m[node + nc_m, node] = 1.0)
+        end
+        besag_m = BesagModel(W_m)
+        prior_m = besag_m(τ = 3.0)
+
+        obs_model_m = ExponentialFamily(Poisson)
+        y_m = PoissonObservations([5, 2, 8, 1, 4, 10, 3, 6, 7, 12, 2, 9, 4, 11, 3, 8])
+        obs_lik_m = obs_model_m(y_m)
+
+        ga_20 = gaussian_approximation(prior_m, obs_lik_m; max_iter = 20)
+        ga_50 = gaussian_approximation(prior_m, obs_lik_m; max_iter = 50)
+
+        @test mean(ga_20) ≈ mean(ga_50) atol = 1.0e-8
+    end
+
     @testset "Conjugate cases" begin
         # Test linear_condition dispatch (use sparse matrices to avoid type issues)
         A_obs = sparse([1.0 0.0 1.0 0.0; 0.0 1.0 0.0 1.0])  # Observe pairs (sparse)


### PR DESCRIPTION
The Newton solver had two bugs affecting all constrained models (Besag, RW1, Separable). The solver would exhaust max_iter instead of converging:

1. The Newton decrement included Lagrange multiplier forces (A'λ), which are nonzero at the constrained optimum, so the convergence criterion never triggered.

2. The line search evaluated the objective at points violating Ax = e, causing it to reject good steps.

Fix both by computing the constrained Newton step via the KKT Schur complement before the line search. This projects the step onto the constraint tangent space (AΔx = 0), so candidates stay on the manifold and the Newton decrement is the textbook λ² = Δxᵀ H Δx ≥ 0.