### PR TITLE
Add τ (field precision) hyperparameter to MaternModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ points = [0.1 0.0; -0.3 0.55; 0.2 0.8; -0.1 -0.2]  # N×2 matrix
 
 # Create Matérn latent model (automatically generates mesh and discretization)
 model = MaternModel(points; smoothness = 1)
-x = model(range = 0.3)  # Construct GMRF with specified range
+x = model(τ = 1.0, range = 0.3)  # Construct GMRF with specified parameters
 ```
 
 `x` is a Gaussian distribution, and we can compute all the things Gaussians are

--- a/docs/src/literate-tutorials/bernoulli_spatial_classification.jl
+++ b/docs/src/literate-tutorials/bernoulli_spatial_classification.jl
@@ -73,7 +73,7 @@ X_test, y_test = X[test_idcs, :], y[test_idcs]
 # - `range`: controls the distance over which the field exhibits strong correlation.
 #   As a rule of thumb, set it to a fraction of the spatial extent of your data.
 latent = MaternModel(X; smoothness = 1)
-u = latent(range = 0.2)  # tune this to your dataset's scale
+u = latent(τ = 1.0, range = 0.2)  # tune this to your dataset's scale
 
 # ## Bernoulli observations (logit link)
 # We connect the latent field to point-wise labels using a Bernoulli exponential

--- a/docs/src/literate-tutorials/spatial_modelling_spdes.jl
+++ b/docs/src/literate-tutorials/spatial_modelling_spdes.jl
@@ -63,7 +63,7 @@ size(X_train, 1), size(X_test, 1)
 # This architecture makes it easy to construct the same GMRF structure many times for different hyperparameter values.
 using GaussianMarkovRandomFields
 latent_model = MaternModel(X; smoothness = 1)
-u_matern = latent_model(range = 400.0)
+u_matern = latent_model(τ = 1.0, range = 400.0)
 
 # Next, we create an observation model for function value observations at the training points.
 # `PointEvaluationObsModel` expresses that we're observing the value of our latent field at some specified points.

--- a/docs/src/reference/formula.md
+++ b/docs/src/reference/formula.md
@@ -174,8 +174,8 @@ comp = build_formula_components(
     family = Normal
 )
 
-# Instantiate the GMRF — 'range' controls spatial correlation distance
-gmrf = comp.combined_model(range_matern=2.0)
+# Instantiate the GMRF — τ controls field precision, range controls correlation distance
+gmrf = comp.combined_model(τ_matern=1.0, range_matern=2.0)
 ```
 
 ### Pre-built Discretization
@@ -206,7 +206,8 @@ comp = build_formula_components(
 
 ### Hyperparameters
 
-The Matérn formula term exposes a single hyperparameter:
+The Matérn formula term exposes two hyperparameters:
+- `τ_matern`: Field precision (τ > 0) controlling marginal variance (~1/τ)
 - `range_matern`: Range parameter (range > 0) controlling spatial correlation distance
 
 ### When to Use Manual vs Formula

--- a/docs/src/reference/latent_models.md
+++ b/docs/src/reference/latent_models.md
@@ -78,7 +78,7 @@ gmrf = ar1(τ=2.0, ρ=0.8)
 # Spatial Matérn model from points (stores observation coordinates)
 points = [0.0 0.0; 1.0 0.0; 0.5 1.0]  # N×2 matrix
 matern = MaternModel(points; smoothness = 2)
-gmrf = matern(range=1.5)
+gmrf = matern(τ=1.0, range=1.5)
 
 # Convenience: evaluation matrix and observation model from stored points
 A = evaluation_matrix(matern)
@@ -114,7 +114,7 @@ points = generate_observation_points()
 spatial_matern = MaternModel(points; smoothness = 1)
 independent_effects = IIDModel(length(points))
 combined = CombinedModel(spatial_matern, independent_effects)
-gmrf = combined(range=2.0, τ_iid=0.1)
+gmrf = combined(τ_matern=1.0, range_matern=2.0, τ_iid=0.1)
 ```
 
 ### Smart Parameter Naming

--- a/src/latent_models/matern.jl
+++ b/src/latent_models/matern.jl
@@ -146,20 +146,22 @@ function Base.length(model::MaternModel)
 end
 
 function hyperparameters(model::MaternModel)
-    return (range = Real,)
+    return (τ = Real, range = Real)
 end
 
-function _validate_matern_parameters(; range::Real)
+function _validate_matern_parameters(; τ::Real, range::Real)
+    τ > 0 || throw(ArgumentError("Precision parameter τ must be positive, got τ=$τ"))
     range > 0 || throw(ArgumentError("Range parameter must be positive, got range=$range"))
     return nothing
 end
 
-function precision_matrix(model::MaternModel{F, S}; range::Real, kwargs...) where {F, S}
-    _validate_matern_parameters(; range = range)
+function precision_matrix(model::MaternModel{F, S}; τ::Real, range::Real, kwargs...) where {F, S}
+    _validate_matern_parameters(; τ = τ, range = range)
     D = ndim(model.discretization)
     ν = smoothness_to_ν(model.smoothness, D)
     κ = range_to_κ(range, ν)
-    return matern_precision_only(model.discretization, model.smoothness, κ)
+    Q_unscaled = matern_precision_only(model.discretization, model.smoothness, κ)
+    return τ * Q_unscaled
 end
 
 function mean(model::MaternModel; kwargs...)

--- a/src/latent_models/matern.jl
+++ b/src/latent_models/matern.jl
@@ -42,19 +42,19 @@ This leads to a Matérn covariance function with range and smoothness parameters
 # Direct construction
 disc = FEMDiscretization(grid, interpolation, quadrature)
 model = MaternModel(disc; smoothness = 2)
-gmrf = model(range=2.0)
+gmrf = model(τ=1.0, range=2.0)
 
 # Automatic construction from points (stores observation_points)
 points = [0.0 0.0; 1.0 0.0; 0.5 1.0]  # N×2 matrix
 model = MaternModel(points; smoothness = 1, element_order = 1)
-gmrf = model(range=2.0)
+gmrf = model(τ=1.0, range=2.0)
 
 # Convenience: evaluation matrix from stored points
 A = evaluation_matrix(model)
 
 # With custom algorithm
 model = MaternModel(disc; smoothness = 2, alg = LDLtFactorization())
-gmrf = model(range=2.0)
+gmrf = model(τ=1.0, range=2.0)
 ```
 """
 struct MaternModel{F <: FEMDiscretization, S <: Integer, Alg, C, P} <: LatentModel

--- a/test/autodiff/test_forwarddiff_extension.jl
+++ b/test/autodiff/test_forwarddiff_extension.jl
@@ -491,7 +491,7 @@ using Test
             model = MaternModel(points; smoothness = s)
 
             # Derivative of sum(Q) w.r.t. range
-            f(r) = sum(precision_matrix(model; range = r))
+            f(r) = sum(precision_matrix(model; τ = 1.0, range = r))
             range_val = 1.5
             grad_fwd = ForwardDiff.derivative(f, range_val)
             grad_fin = FiniteDiff.finite_difference_derivative(f, range_val)
@@ -499,7 +499,7 @@ using Test
             @test abs(grad_fwd - grad_fin) / (abs(grad_fin) + 1.0e-10) < 5.0e-2
 
             # Derivative of tr(Q)
-            g(r) = tr(Matrix(precision_matrix(model; range = r)))
+            g(r) = tr(Matrix(precision_matrix(model; τ = 1.0, range = r)))
             grad_fwd2 = ForwardDiff.derivative(g, range_val)
             grad_fin2 = FiniteDiff.finite_difference_derivative(g, range_val)
             @test isfinite(grad_fwd2)
@@ -512,6 +512,13 @@ using Test
                 @test isfinite(d)
                 @test abs(d - d_fin) / (abs(d_fin) + 1.0e-10) < 5.0e-2
             end
+
+            # Derivative w.r.t. τ
+            h(t) = sum(precision_matrix(model; τ = t, range = 1.5))
+            grad_tau_fwd = ForwardDiff.derivative(h, 2.0)
+            grad_tau_fin = FiniteDiff.finite_difference_derivative(h, 2.0)
+            @test isfinite(grad_tau_fwd)
+            @test abs(grad_tau_fwd - grad_tau_fin) / (abs(grad_tau_fin) + 1.0e-10) < 5.0e-2
         end
 
         @testset "Full pipeline: MaternModel → GMRF → gaussian_approximation" begin
@@ -523,7 +530,7 @@ using Test
 
             function matern_pipeline(log_range)
                 range = exp(log_range)
-                Q = precision_matrix(model; range = range)
+                Q = precision_matrix(model; τ = 1.0, range = range)
                 prior = GMRF(zeros(n), Q)
                 obs_lik = LinearlyTransformedLikelihood(
                     ExponentialFamily(Poisson)(y), A
@@ -542,7 +549,7 @@ using Test
         @testset "Primal path consistency" begin
             # Ensure the Q-only path matches the original discretize path
             model = MaternModel(points; smoothness = 1)
-            Q_new = precision_matrix(model; range = 1.5)
+            Q_new = precision_matrix(model; τ = 1.0, range = 1.5)
             @test Q_new isa Symmetric
             @test size(Q_new, 1) == length(model)
 

--- a/test/formula/test_formula_interface.jl
+++ b/test/formula/test_formula_interface.jl
@@ -124,15 +124,16 @@ end
         @test comp.meta.n_random == 1
         @test comp.meta.n_fixed == 0
 
-        # Hyperparameters should include range
+        # Hyperparameters should include τ and range
         ks = Set(keys(comp.hyperparams))
+        @test :τ_matern in ks
         @test :range_matern in ks
 
         # Latent dimension must match design matrix columns
         @test length(comp.combined_model) == size(comp.A, 2)
 
         # Should produce a valid GMRF
-        gmrf = comp.combined_model(range_matern = 1.0)
+        gmrf = comp.combined_model(τ_matern = 1.0, range_matern = 1.0)
         @test length(gmrf) == size(comp.A, 2)
     end
 
@@ -165,6 +166,7 @@ end
 
         @test size(comp.A, 1) == n_pts
         ks = Set(keys(comp.hyperparams))
+        @test :τ_matern in ks
         @test :range_matern in ks
     end
 end

--- a/test/latent_models/test_matern.jl
+++ b/test/latent_models/test_matern.jl
@@ -85,7 +85,7 @@ using Ferrite
 
             # hyperparameters method
             params = hyperparameters(model)
-            @test params == (range = Real,)
+            @test params == (τ = Real, range = Real)
 
             # model_name method
             @test model_name(model) == :matern
@@ -93,14 +93,22 @@ using Ferrite
 
         @testset "Parameter Validation" begin
             # Valid range should work
-            @test precision_matrix(model; range = 1.0) isa AbstractMatrix
-            @test precision_matrix(model; range = 0.1) isa AbstractMatrix
-            @test precision_matrix(model; range = 10.0) isa AbstractMatrix
+            @test precision_matrix(model; τ = 1.0, range = 1.0) isa AbstractMatrix
+            @test precision_matrix(model; τ = 1.0, range = 0.1) isa AbstractMatrix
+            @test precision_matrix(model; τ = 1.0, range = 10.0) isa AbstractMatrix
 
             # Invalid range should throw
-            @test_throws ArgumentError precision_matrix(model; range = 0.0)
-            @test_throws ArgumentError precision_matrix(model; range = -1.0)
-            @test_throws ArgumentError precision_matrix(model; range = -0.1)
+            @test_throws ArgumentError precision_matrix(model; τ = 1.0, range = 0.0)
+            @test_throws ArgumentError precision_matrix(model; τ = 1.0, range = -1.0)
+
+            # Invalid τ should throw
+            @test_throws ArgumentError precision_matrix(model; τ = 0.0, range = 1.0)
+            @test_throws ArgumentError precision_matrix(model; τ = -1.0, range = 1.0)
+
+            # τ scales precision matrix
+            Q1 = precision_matrix(model; τ = 1.0, range = 1.0)
+            Q2 = precision_matrix(model; τ = 2.0, range = 1.0)
+            @test Matrix(Q2) ≈ 2.0 * Matrix(Q1)
         end
 
         @testset "Mean Vector" begin
@@ -128,7 +136,7 @@ using Ferrite
             range_vals = [0.5, 1.0, 2.0]
 
             for range in range_vals
-                Q = precision_matrix(model; range = range)
+                Q = precision_matrix(model; τ = 1.0, range = range)
 
                 # Should be square matrix
                 @test size(Q, 1) == size(Q, 2)
@@ -152,14 +160,14 @@ using Ferrite
 
         # Construct GMRF
         range = 2.0
-        gmrf = model(range = range)
+        gmrf = model(τ = 1.0, range = range)
 
         @test gmrf isa GMRF  # Should return GMRF, not ConstrainedGMRF
         @test length(gmrf) == length(model)
         @test all(mean(gmrf) .== 0.0)
 
         # Precision matrix should match
-        Q_model = precision_matrix(model; range = range)
+        Q_model = precision_matrix(model; τ = 1.0, range = range)
         Q_gmrf = precision_map(gmrf)
         @test Matrix(Q_model) ≈ Matrix(Q_gmrf)
     end
@@ -175,8 +183,8 @@ using Ferrite
         model_auto = MaternModel(points; smoothness = 1)
 
         # Both should work and produce reasonable results
-        gmrf_direct = model_direct(range = 1.0)
-        gmrf_auto = model_auto(range = 1.0)
+        gmrf_direct = model_direct(τ = 1.0, range = 1.0)
+        gmrf_auto = model_auto(τ = 1.0, range = 1.0)
 
         @test gmrf_direct isa GMRF
         @test gmrf_auto isa GMRF
@@ -200,7 +208,7 @@ using Ferrite
             @test model.smoothness == smoothness
 
             # Should be able to construct GMRF
-            gmrf = model(range = range)
+            gmrf = model(τ = 1.0, range = range)
             @test gmrf isa GMRF
             @test length(gmrf) == length(model)
 
@@ -220,7 +228,7 @@ using Ferrite
         precision_matrices = []
 
         for range in ranges
-            Q = precision_matrix(model; range = range)
+            Q = precision_matrix(model; τ = 1.0, range = range)
             push!(precision_matrices, Q)
 
             # All should be valid precision matrices
@@ -241,14 +249,14 @@ using Ferrite
         model = MaternModel(discretization; smoothness = 1)
 
         # Test with different numeric types
-        Q_float64 = precision_matrix(model; range = 1.0)
-        Q_int = precision_matrix(model; range = 1)
+        Q_float64 = precision_matrix(model; τ = 1.0, range = 1.0)
+        Q_int = precision_matrix(model; τ = 1.0, range = 1)
 
         @test eltype(Matrix(Q_float64)) == Float64
         @test eltype(Matrix(Q_int)) == Float64  # Should promote
 
         # GMRF construction should be type stable
-        gmrf = model(range = 1.0)
+        gmrf = model(τ = 1.0, range = 1.0)
         @test gmrf isa GMRF{Float64}
     end
 
@@ -316,13 +324,13 @@ using Ferrite
         @test length(model_1d) > 0
 
         # Test GMRF construction in 1D
-        gmrf_1d = model_1d(range = 2.0)
+        gmrf_1d = model_1d(τ = 1.0, range = 2.0)
         @test gmrf_1d isa GMRF
         @test length(gmrf_1d) == length(model_1d)
         @test all(mean(gmrf_1d) .== 0.0)
 
         # Test precision matrix properties in 1D
-        Q_1d = precision_matrix(model_1d; range = 1.0)
+        Q_1d = precision_matrix(model_1d; τ = 1.0, range = 1.0)
         Q_1d_mat = Matrix(Q_1d)
         @test size(Q_1d_mat, 1) == length(model_1d)
         @test Q_1d_mat ≈ Q_1d_mat'  # Should be symmetric


### PR DESCRIPTION
MaternModel now exposes both τ and range as hyperparameters, matching the convention of IIDModel, RWModel, etc. The precision matrix is Q = τ * Q_unscaled(range), allowing independent control of field amplitude and spatial correlation distance.