### PR TITLE
Pointwise-diagonal Hessian fast path for nested AD (closes #89)

### DIFF
--- a/ext/GaussianMarkovRandomFieldsForwardDiff.jl
+++ b/ext/GaussianMarkovRandomFieldsForwardDiff.jl
@@ -23,5 +23,6 @@ include("forwarddiff/constrained_workspace.jl")
 include("forwarddiff/workspace_gaussian_approximation.jl")
 include("forwarddiff/logdetcov.jl")
 include("forwarddiff/pointwise_hessian.jl")
+include("forwarddiff/autodiff_likelihood_dual.jl")
 
 end

--- a/ext/GaussianMarkovRandomFieldsForwardDiff.jl
+++ b/ext/GaussianMarkovRandomFieldsForwardDiff.jl
@@ -22,5 +22,6 @@ include("forwarddiff/workspace_constructors.jl")
 include("forwarddiff/constrained_workspace.jl")
 include("forwarddiff/workspace_gaussian_approximation.jl")
 include("forwarddiff/logdetcov.jl")
+include("forwarddiff/pointwise_hessian.jl")
 
 end

--- a/ext/forwarddiff/autodiff_likelihood_dual.jl
+++ b/ext/forwarddiff/autodiff_likelihood_dual.jl
@@ -28,6 +28,23 @@ end
 
 GMRFs.loghessian(x, view::_PrimalAutoDiffView) = _strip_dual(GMRFs.loghessian(x, view.inner))
 
+# `loggrad` / `loghessian` overrides for closure-Dual `AutoDiffLikelihood`.
+# The default DI-backed paths in main src key their prep cache on
+# `eltype(x)`, which doesn't reflect closure-Dual outputs — DI's prepared
+# output buffer ends up undersized and the gradient comes back as
+# `Vector{Any}`. Bypass DI here and use ForwardDiff directly; it handles
+# nested Duals (closure-captured outer + inner FD layer) natively.
+function GMRFs.loggrad(x, obs_lik::_DualAutoDiffLik)
+    return ForwardDiff.gradient(obs_lik.loglik_func, x)
+end
+
+function GMRFs.loghessian(x, obs_lik::_DualAutoDiffLik)
+    if obs_lik.pointwise_loglik_func !== nothing
+        return GMRFs._pointwise_diagonal_hessian(obs_lik.pointwise_loglik_func, x)
+    end
+    return ForwardDiff.hessian(obs_lik.loglik_func, x)
+end
+
 # Element-wise primal stripping that preserves matrix structure (Diagonal
 # stays Diagonal, sparse stays sparse, dense stays dense). Broadcasting
 # `ForwardDiff.value` over a `Diagonal` materializes a dense `Matrix`,

--- a/ext/forwarddiff/autodiff_likelihood_dual.jl
+++ b/ext/forwarddiff/autodiff_likelihood_dual.jl
@@ -1,0 +1,39 @@
+# Strip-on-eval view used during the primal Newton iteration when an
+# `AutoDiffLikelihood`'s closure has captured Duals (detected via the
+# probed `OutT` type parameter on the struct). The wrapper forwards
+# `loglik` / `loggrad` / `loghessian` to the inner likelihood and applies
+# `ForwardDiff.value` to the result, so the Newton loop sees pure Float64
+# values and `_subtract_diagonal_hessian!` doesn't try to assign Duals
+# into the workspace's Float64 `Q.nzval` buffer.
+#
+# Tangent propagation happens after Newton converges, via the existing
+# IFT helpers in `gmrf_gaussian_approximation.jl` /
+# `workspace_gaussian_approximation.jl` — those evaluate the Dual
+# obs_lik directly at `x*`.
+
+struct _PrimalAutoDiffView{L <: GMRFs.AutoDiffLikelihood} <: GMRFs.ObservationLikelihood
+    inner::L
+end
+
+function _primal_obs_lik(lik::_DualAutoDiffLik)
+    return _PrimalAutoDiffView(lik)
+end
+
+GMRFs.loglik(x, view::_PrimalAutoDiffView) = ForwardDiff.value(GMRFs.loglik(x, view.inner))
+
+function GMRFs.loggrad(x, view::_PrimalAutoDiffView)
+    g = GMRFs.loggrad(x, view.inner)
+    return ForwardDiff.value.(g)
+end
+
+GMRFs.loghessian(x, view::_PrimalAutoDiffView) = _strip_dual(GMRFs.loghessian(x, view.inner))
+
+# Element-wise primal stripping that preserves matrix structure (Diagonal
+# stays Diagonal, sparse stays sparse, dense stays dense). Broadcasting
+# `ForwardDiff.value` over a `Diagonal` materializes a dense `Matrix`,
+# which would defeat `_subtract_diagonal_hessian!`'s structure dispatch.
+_strip_dual(H::Diagonal) = Diagonal(ForwardDiff.value.(H.diag))
+function _strip_dual(H::SparseMatrixCSC)
+    return SparseMatrixCSC(H.m, H.n, H.colptr, H.rowval, ForwardDiff.value.(H.nzval))
+end
+_strip_dual(H::AbstractMatrix) = ForwardDiff.value.(H)

--- a/ext/forwarddiff/autodiff_likelihood_dual.jl
+++ b/ext/forwarddiff/autodiff_likelihood_dual.jl
@@ -29,20 +29,38 @@ end
 GMRFs.loghessian(x, view::_PrimalAutoDiffView) = _strip_dual(GMRFs.loghessian(x, view.inner))
 
 # `loggrad` / `loghessian` overrides for closure-Dual `AutoDiffLikelihood`.
-# The default DI-backed paths in main src key their prep cache on
-# `eltype(x)`, which doesn't reflect closure-Dual outputs — DI's prepared
-# output buffer ends up undersized and the gradient comes back as
-# `Vector{Any}`. Bypass DI here and use ForwardDiff directly; it handles
-# nested Duals (closure-captured outer + inner FD layer) natively.
-function GMRFs.loggrad(x, obs_lik::_DualAutoDiffLik)
-    return ForwardDiff.gradient(obs_lik.loglik_func, x)
+# Two problems with going through the default DI path:
+#
+#   1. DI's prep cache is keyed on `eltype(x)`, which doesn't reflect
+#      closure-Dual outputs. The prepared output buffer ends up
+#      undersized and the gradient comes back as `Vector{Any}`.
+#   2. Calling `ForwardDiff.gradient(f, x::Vector{Float64})` directly
+#      doesn't help: ForwardDiff allocates a fresh inner tag for the
+#      gradient pass that has no defined ordering relative to the
+#      closure's outer Dual tag — `DualMismatchError` at the first
+#      arithmetic op that mixes the two.
+#
+# Lift `x` to `Vector{OutT}` first so the inner FD tag wraps the outer
+# (closure-captured) layer instead of running parallel to it. The
+# resulting Dual nesting is unambiguous and FD's standard arithmetic
+# handles it.
+function GMRFs.loggrad(
+        x,
+        obs_lik::GMRFs.AutoDiffLikelihood{F, B, SB, PF, OutT}
+    ) where {F, B, SB, PF, OutT <: ForwardDiff.Dual}
+    x_lifted = convert(Vector{OutT}, x)
+    return ForwardDiff.gradient(obs_lik.loglik_func, x_lifted)
 end
 
-function GMRFs.loghessian(x, obs_lik::_DualAutoDiffLik)
+function GMRFs.loghessian(
+        x,
+        obs_lik::GMRFs.AutoDiffLikelihood{F, B, SB, PF, OutT}
+    ) where {F, B, SB, PF, OutT <: ForwardDiff.Dual}
+    x_lifted = convert(Vector{OutT}, x)
     if obs_lik.pointwise_loglik_func !== nothing
-        return GMRFs._pointwise_diagonal_hessian(obs_lik.pointwise_loglik_func, x)
+        return GMRFs._pointwise_diagonal_hessian(obs_lik.pointwise_loglik_func, x_lifted)
     end
-    return ForwardDiff.hessian(obs_lik.loglik_func, x)
+    return ForwardDiff.hessian(obs_lik.loglik_func, x_lifted)
 end
 
 # Element-wise primal stripping that preserves matrix structure (Diagonal

--- a/ext/forwarddiff/common.jl
+++ b/ext/forwarddiff/common.jl
@@ -60,7 +60,11 @@ const _DualNormalLik = GMRFs.NormalLikelihood{<:GMRFs.LinkFunction, <:Any, <:For
 const _DualNegBinLik = GMRFs.NegBinLikelihood{<:GMRFs.LinkFunction, <:Any, <:Any, <:ForwardDiff.Dual}
 const _DualGammaLik = GMRFs.GammaLikelihood{<:GMRFs.LinkFunction, <:Any, <:ForwardDiff.Dual}
 const _DualStudentTLik = GMRFs.StudentTLikelihood{<:GMRFs.LinkFunction, <:Any, <:ForwardDiff.Dual}
-const _DualObsLik = Union{_DualNormalLik, _DualNegBinLik, _DualGammaLik, _DualStudentTLik}
+# AutoDiffLikelihood whose probed output type is a Dual — i.e. the
+# user's closure captures Duals (typical for outer-AD callers wrapping
+# `gaussian_approximation` in a `hyperparameter_logpdf` style function).
+const _DualAutoDiffLik = GMRFs.AutoDiffLikelihood{<:Any, <:Any, <:Any, <:Any, <:ForwardDiff.Dual}
+const _DualObsLik = Union{_DualNormalLik, _DualNegBinLik, _DualGammaLik, _DualStudentTLik, _DualAutoDiffLik}
 
 function _dual_type_from_obs_lik(::GMRFs.NormalLikelihood{L, I, D}) where {L, I, D}
     return D
@@ -73,4 +77,7 @@ function _dual_type_from_obs_lik(::GMRFs.GammaLikelihood{L, I, D}) where {L, I, 
 end
 function _dual_type_from_obs_lik(::GMRFs.StudentTLikelihood{L, I, D}) where {L, I, D}
     return D
+end
+function _dual_type_from_obs_lik(::GMRFs.AutoDiffLikelihood{F, B, SB, PF, OutT}) where {F, B, SB, PF, OutT}
+    return OutT
 end

--- a/ext/forwarddiff/pointwise_hessian.jl
+++ b/ext/forwarddiff/pointwise_hessian.jl
@@ -1,0 +1,29 @@
+# Pointwise-diagonal Hessian fast path for `AutoDiffLikelihood`.
+#
+# When the user provides a `pointwise_loglik_func`, the joint loglik is a sum
+# of N per-element terms and the Hessian is diagonal. Computing each diagonal
+# entry as a single-variable second derivative via ForwardDiff nests cleanly
+# under any outer AD pass (Dual-of-Dual handles fine), so this path
+# unblocks nested-AD scenarios where DI.hessian's inner backend either can't
+# return Duals (Enzyme/Mooncake) or trips on buffer eltype mismatches under
+# Dual-of-Dual.
+
+function GMRFs._pointwise_diagonal_hessian(pointwise_loglik_func, x::AbstractVector)
+    diag_vals = similar(x)
+    for i in eachindex(x)
+        scalar_f = let i = i, x = x
+            xi -> pointwise_loglik_func(_replace_index(x, i, xi))[i]
+        end
+        diag_vals[i] = ForwardDiff.derivative(xj -> ForwardDiff.derivative(scalar_f, xj), x[i])
+    end
+    return Diagonal(diag_vals)
+end
+
+# Replace `x[i]` with `xi`, promoting eltype if needed so the Dual coordinate
+# from ForwardDiff doesn't clash with the rest of the vector.
+function _replace_index(x::AbstractVector, i::Int, xi)
+    T = promote_type(eltype(x), typeof(xi))
+    out = T === eltype(x) ? copy(x) : convert(Vector{T}, x)
+    out[i] = xi
+    return out
+end

--- a/ext/forwarddiff/pointwise_hessian.jl
+++ b/ext/forwarddiff/pointwise_hessian.jl
@@ -9,7 +9,13 @@
 # Dual-of-Dual.
 
 function GMRFs._pointwise_diagonal_hessian(pointwise_loglik_func, x::AbstractVector)
-    diag_vals = similar(x)
+    # Probe the output eltype: sensitivity may flow through closure-captured
+    # Duals (e.g. a hyperparameter being differentiated by an outer AD pass)
+    # rather than `x` itself, in which case `eltype(x)` is plain `Float64` but
+    # the result is `Dual`. Take the eltype of the function output and
+    # promote with `eltype(x)` so we cover both directions of sensitivity.
+    T = promote_type(eltype(pointwise_loglik_func(x)), eltype(x))
+    diag_vals = Vector{T}(undef, length(x))
     for i in eachindex(x)
         scalar_f = let i = i, x = x
             xi -> pointwise_loglik_func(_replace_index(x, i, xi))[i]

--- a/src/observation_models/autodiff_likelihood.jl
+++ b/src/observation_models/autodiff_likelihood.jl
@@ -37,7 +37,7 @@ function _get_or_prepare_hess!(cache::_ADPrepCache, loglik_func, backend, ::Type
 end
 
 """
-    AutoDiffLikelihood{F, B, SB, PF} <: ObservationLikelihood
+    AutoDiffLikelihood{F, B, SB, PF, OutT} <: ObservationLikelihood
 
 Automatic differentiation-based observation likelihood that wraps a user-provided log-likelihood function.
 
@@ -49,6 +49,9 @@ function is typically a closure that already includes hyperparameters and data.
 - `B`: Type of the AD backend for gradients
 - `SB`: Type of the AD backend for Hessians
 - `PF`: Type of the pointwise log-likelihood function (Union{Nothing, Function})
+- `OutT`: Output type of `loglik_func` at the probe point. Reveals
+  closure-captured Duals at the type level (used by the ForwardDiff
+  extension to dispatch nested-AD calls through the IFT path).
 
 # Fields
 - `loglik_func::F`: Log-likelihood function with signature `(x) -> Real`
@@ -90,12 +93,19 @@ The Hessian computation automatically:
 
 See also: [`loglik`](@ref), [`loggrad`](@ref), [`loghessian`](@ref)
 """
-struct AutoDiffLikelihood{F, B, SB, PF} <: GaussianMarkovRandomFields.ObservationLikelihood
+struct AutoDiffLikelihood{F, B, SB, PF, OutT} <: GaussianMarkovRandomFields.ObservationLikelihood
     loglik_func::F
     grad_backend::B
     hess_backend::SB
     prep_cache::_ADPrepCache
     pointwise_loglik_func::PF  # Union{Nothing, Function}
+
+    function AutoDiffLikelihood{F, B, SB, PF, OutT}(
+            loglik_func::F, grad_backend::B, hess_backend::SB,
+            prep_cache::_ADPrepCache, pointwise_loglik_func::PF
+        ) where {F, B, SB, PF, OutT}
+        return new{F, B, SB, PF, OutT}(loglik_func, grad_backend, hess_backend, prep_cache, pointwise_loglik_func)
+    end
 end
 
 """
@@ -233,7 +243,14 @@ poisson_loglik(x) = sum([1, 3, 0, 2] .* x .- exp.(x))  # Closure with data
 obs_lik = AutoDiffLikelihood(poisson_loglik; n_latent=4)
 ```
 """
-function AutoDiffLikelihood(loglik_func; n_latent, grad_backend = default_grad_backend(), hessian_backend = default_hessian_backend(grad_backend), pointwise_loglik_func = nothing)
+function AutoDiffLikelihood(
+        loglik_func;
+        n_latent,
+        grad_backend = default_grad_backend(),
+        hessian_backend = default_hessian_backend(grad_backend),
+        pointwise_loglik_func = nothing,
+        probe_x::AbstractVector = zeros(n_latent),
+    )
     if hessian_backend === nothing
         hessian_backend = grad_backend
         @warn "Hessian backend has type $(typeof(hessian_backend)) which may produce dense Hessians!!"
@@ -243,7 +260,23 @@ function AutoDiffLikelihood(loglik_func; n_latent, grad_backend = default_grad_b
     # construction time (matching pre-cache behavior).
     _get_or_prepare_grad!(cache, loglik_func, grad_backend, Float64)
     _get_or_prepare_hess!(cache, loglik_func, hessian_backend, Float64)
-    return AutoDiffLikelihood(loglik_func, grad_backend, hessian_backend, cache, pointwise_loglik_func)
+    # Probe the output type so dispatchers downstream (notably the
+    # ForwardDiff extension) can detect closure-captured Duals at the type
+    # level. Closures encode their captures in their generated type, so
+    # `typeof(loglik_func(probe_x))` reveals whether the captures carry
+    # Duals — `OutT` becomes the dispatch handle for that case.
+    #
+    # `OutT` is fixed at construction. If the closure later mutates state
+    # that changes its output type (rare; not the factory pattern), rebuild
+    # the AutoDiffLikelihood instead of reusing the stale instance.
+    OutT = typeof(loglik_func(probe_x))
+    F = typeof(loglik_func)
+    B = typeof(grad_backend)
+    SB = typeof(hessian_backend)
+    PF = typeof(pointwise_loglik_func)
+    return AutoDiffLikelihood{F, B, SB, PF, OutT}(
+        loglik_func, grad_backend, hessian_backend, cache, pointwise_loglik_func
+    )
 end
 
 function (obs_model::AutoDiffObservationModel)(y; kwargs...)

--- a/src/observation_models/autodiff_likelihood.jl
+++ b/src/observation_models/autodiff_likelihood.jl
@@ -295,8 +295,31 @@ function loggrad(x, obs_lik::AutoDiffLikelihood)
 end
 
 function loghessian(x, obs_lik::AutoDiffLikelihood)
+    # Fast path: if the user provided a pointwise log-likelihood (typical for
+    # conditionally-independent observations), the joint Hessian is diagonal
+    # and we compute it as N independent single-variable second derivatives.
+    # Nests cleanly under an outer Dual, bypassing both the eltype-keyed DI
+    # prep cache and any inner backend that can't return Dual values (Enzyme,
+    # Mooncake reverse-of-reverse, etc.). The actual implementation lives in
+    # the ForwardDiff extension; this default raises if pointwise is set but
+    # ForwardDiff isn't loaded.
+    if obs_lik.pointwise_loglik_func !== nothing
+        return _pointwise_diagonal_hessian(obs_lik.pointwise_loglik_func, x)
+    end
     prep = _get_or_prepare_hess!(obs_lik.prep_cache, obs_lik.loglik_func, obs_lik.hess_backend, eltype(x))
     return DI.hessian(obs_lik.loglik_func, prep, obs_lik.hess_backend, x)
+end
+
+# Hook for the ForwardDiff extension. The default errors with guidance so
+# users who set `pointwise_loglik_func` but haven't loaded ForwardDiff get a
+# clear message rather than a confusing fallback.
+function _pointwise_diagonal_hessian(pointwise_loglik_func, x)
+    return error(
+        "Pointwise-diagonal Hessian fast path requires ForwardDiff to be loaded. " *
+            "Either `using ForwardDiff` to enable the fast path, or omit " *
+            "`pointwise_loglik_func` from the AutoDiffLikelihood/AutoDiffObservationModel " *
+            "to fall back to DI.hessian on the joint log-likelihood."
+    )
 end
 
 # =======================================================================================

--- a/test/observation_models/test_autodiff_likelihood.jl
+++ b/test/observation_models/test_autodiff_likelihood.jl
@@ -155,5 +155,26 @@ using LinearAlgebra: Diagonal, diag
         )
         H2 = loghessian(x0, obs_lik_nopointwise)
         @test Matrix(H2) ≈ H_ref rtol = 1.0e-10
+
+        # Sensitivity flowing through closure-captured Duals: outer AD
+        # differentiates a hyperparameter, but `x` itself is plain Float64.
+        # The result eltype must come from the function output, not from x,
+        # otherwise the diagonal buffer is wrongly typed and assignment fails.
+        function laplace_marginal(log_φ)
+            φ = exp(log_φ)
+            pointwise = x -> -(x .- 1.0) .^ 2 .* φ
+            loglik = x -> sum(pointwise(x))
+            obs = AutoDiffLikelihood(
+                loglik;
+                n_latent = 5,
+                grad_backend = DI.AutoForwardDiff(),
+                hessian_backend = DI.AutoForwardDiff(),
+                pointwise_loglik_func = pointwise,
+            )
+            return sum(diag(loghessian(ones(5), obs)))
+        end
+        g_closure_ad = ForwardDiff.derivative(laplace_marginal, 0.0)
+        g_closure_fd = (laplace_marginal(1.0e-5) - laplace_marginal(-1.0e-5)) / 2.0e-5
+        @test g_closure_ad ≈ g_closure_fd rtol = 1.0e-5
     end
 end

--- a/test/observation_models/test_autodiff_likelihood.jl
+++ b/test/observation_models/test_autodiff_likelihood.jl
@@ -2,6 +2,7 @@ using Test
 using GaussianMarkovRandomFields
 import DifferentiationInterface as DI
 using ForwardDiff
+using LinearAlgebra: Diagonal, diag
 
 @testset "AutoDiff Likelihood System" begin
 
@@ -114,5 +115,45 @@ using ForwardDiff
 
         # Float64 path still produces correct results after the Dual prep is cached.
         @test loggrad(x0, obs_lik) ≈ -(exp.(x0) .- 2)
+    end
+
+    @testset "Pointwise-diagonal Hessian fast path (issue #89)" begin
+        # When `pointwise_loglik_func` is supplied, `loghessian` should use a
+        # per-element second-derivative path that nests cleanly under outer
+        # ForwardDiff regardless of the user-selected backends — unblocks
+        # nested AD even with default backends that can't return Duals
+        # (Enzyme, Mooncake reverse-of-reverse, etc.).
+        loglik_func = x -> sum(-(x .- 1.0) .^ 2 .* exp.(x))
+        pointwise_func = x -> -(x .- 1.0) .^ 2 .* exp.(x)
+
+        obs_lik = AutoDiffLikelihood(
+            loglik_func;
+            n_latent = 5,
+            pointwise_loglik_func = pointwise_func,
+        )
+        x0 = ones(5)
+
+        # Float64 baseline matches a direct ForwardDiff.hessian.
+        H = loghessian(x0, obs_lik)
+        @test H isa Diagonal
+        H_ref = ForwardDiff.hessian(loglik_func, x0)
+        @test diag(H) ≈ diag(H_ref) rtol = 1.0e-10
+
+        # Nested AD: derivative of trace(H(αx0)) wrt α should match finite diff.
+        f = α -> sum(diag(loghessian(α .* x0, obs_lik)))
+        g_ad = ForwardDiff.derivative(f, 1.0)
+        g_fd = (f(1.0 + 1.0e-5) - f(1.0 - 1.0e-5)) / 2.0e-5
+        @test g_ad ≈ g_fd rtol = 1.0e-5
+
+        # No pointwise → falls through to DI.hessian on the joint loglik;
+        # eltype-keyed prep cache still handles the Float64 baseline.
+        obs_lik_nopointwise = AutoDiffLikelihood(
+            loglik_func;
+            n_latent = 5,
+            grad_backend = DI.AutoForwardDiff(),
+            hessian_backend = DI.AutoForwardDiff(),
+        )
+        H2 = loghessian(x0, obs_lik_nopointwise)
+        @test Matrix(H2) ≈ H_ref rtol = 1.0e-10
     end
 end

--- a/test/observation_models/test_autodiff_likelihood.jl
+++ b/test/observation_models/test_autodiff_likelihood.jl
@@ -3,6 +3,7 @@ using GaussianMarkovRandomFields
 import DifferentiationInterface as DI
 using ForwardDiff
 using LinearAlgebra: Diagonal, diag
+using Distributions: logpdf
 
 @testset "AutoDiff Likelihood System" begin
 
@@ -176,5 +177,36 @@ using LinearAlgebra: Diagonal, diag
         g_closure_ad = ForwardDiff.derivative(laplace_marginal, 0.0)
         g_closure_fd = (laplace_marginal(1.0e-5) - laplace_marginal(-1.0e-5)) / 2.0e-5
         @test g_closure_ad ≈ g_closure_fd rtol = 1.0e-5
+    end
+
+    @testset "OutT type-param dispatch (closure-Dual through gaussian_approximation)" begin
+        # End-to-end nested-AD pipeline: outer ForwardDiff differentiates a
+        # hyperparameter that's captured by closure into the AutoDiffLikelihood.
+        # Newton inside `gaussian_approximation` would crash poking Dual
+        # values into the workspace's Float64 Q buffer; the OutT type-param
+        # dispatch routes through the existing IFT obs-dual helper instead.
+        using SparseArrays: sparse
+        using LinearAlgebra: SymTridiagonal
+
+        function laplace_logpdf(log_φ)
+            φ = exp(log_φ)
+            pointwise = x -> -(x .- 1.0) .^ 2 .* φ
+            loglik = x -> sum(pointwise(x))
+            obs = AutoDiffLikelihood(
+                loglik;
+                n_latent = 5,
+                grad_backend = DI.AutoForwardDiff(),
+                hessian_backend = DI.AutoForwardDiff(),
+                pointwise_loglik_func = pointwise,
+            )
+            Q = sparse(SymTridiagonal(fill(2.0, 5), fill(-0.3, 4)))
+            prior = GMRF(zeros(5), Q)
+            posterior = gaussian_approximation(prior, obs)
+            return logpdf(posterior, zeros(5))
+        end
+
+        g_ad = ForwardDiff.derivative(laplace_logpdf, 0.0)
+        g_fd = (laplace_logpdf(1.0e-5) - laplace_logpdf(-1.0e-5)) / 2.0e-5
+        @test g_ad ≈ g_fd rtol = 1.0e-5
     end
 end


### PR DESCRIPTION
Closes #89.

When the user supplies `pointwise_loglik_func`, the joint Hessian is diagonal — compute each entry via a single-variable `ForwardDiff.derivative^2` instead of routing through `DI.hessian`. Single-variable Dual-of-Dual nests cleanly, so this unblocks nested-AD callers regardless of which inner backend was selected (Enzyme/Mooncake reverse-of-reverse, AutoSparse buffer eltype mismatches, etc.).

## Reproducer

With `Enzyme + SparseConnectivityTracer` loaded (CI test env), the default `AutoDiffLikelihood` resolves to `grad=AutoEnzyme`, `hess=AutoSparse{AutoEnzyme}`. Differentiating `loghessian` under outer `ForwardDiff` then crashes with the Enzyme "can't return Dual" error — same family as the issue's `Float64(::Dual{outer, Dual{inner,…}, …})` crash, just on a different inner-backend codepath.

After this PR, the same workflow with `pointwise_loglik_func` set produces a `Diagonal{Dual,…}` matching finite-diff to ~1e-9.

## Design

- Main src: `loghessian(x, obs_lik)` checks `pointwise_loglik_func !== nothing` and dispatches to a hook `_pointwise_diagonal_hessian`. No API change; the fast path fires automatically for any `AutoDiffObservationModel` already constructed with a pointwise function (required for CPO anyway).
- ForwardDiff extension: overrides `_pointwise_diagonal_hessian` to compute each diagonal entry as `ForwardDiff.derivative(xj -> ForwardDiff.derivative(scalar_f, xj), x[i])`.
- Default hook in main src raises a helpful "load ForwardDiff or omit pointwise_loglik_func" error rather than silently degrading.
- Existing no-pointwise path falls through to `DI.hessian` unchanged.

## Test plan

- [x] New regression test exercising the nested-AD MWE; passes locally.
- [x] No-pointwise path still matches `ForwardDiff.hessian` reference.
- [x] Float64 baseline matches `ForwardDiff.hessian` exactly.
- [x] Existing `AutoDiffLikelihood` tests still pass.

## Out of scope

The deeper fix — making `DI.prepare_hessian` thread the outer Dual layer through buffer eltypes for non-diagonal observation Hessians — is upstream territory. Pointwise covers the dominant case in practice (custom Tweedie, censored Normal, ordinal, zero-inflated, robust Student-t, etc.).