### PR TITLE
Add per-component kwarg routing for CompositeObservationModel

### DIFF
--- a/docs/src/reference/observation_models.md
+++ b/docs/src/reference/observation_models.md
@@ -440,17 +440,35 @@ For multiple observation types in a single model:
 # Multiple observation vectors
 count_data = [1, 3, 0, 2]
 binary_data = [0, 1, 1, 0]
-obs = CompositeObservations(count_data, binary_data)
+obs = CompositeObservations((count_data, binary_data))
 
 # Corresponding models for each observation type
 poisson_model = ExponentialFamily(Poisson)
-bernoulli_model = ExponentialFamily(Bernoulli) 
-composite_model = CompositeObservationModel(poisson_model, bernoulli_model)
+bernoulli_model = ExponentialFamily(Bernoulli)
+composite_model = CompositeObservationModel((poisson_model, bernoulli_model))
 
 obs_lik = composite_model(obs)
 # Latent field x now corresponds to concatenated observations
 ll = loglik(x, obs_lik)
 ```
+
+When components share an internal kwarg name (e.g. two `ExponentialFamily(Normal)`
+components both expecting `σ`), pass per-component routes binding the inner name
+to a distinct outer hyperparameter:
+
+```julia
+m_phys = ExponentialFamily(Normal)
+m_data = ExponentialFamily(Normal)
+composite_model = CompositeObservationModel(
+    (m_phys, m_data),
+    ((σ = :σ_phys,), (σ = :σ_data,)),
+)
+obs_lik = composite_model(obs; σ_phys = 0.1, σ_data = 5.0)
+```
+
+A `nothing` route keeps the legacy passthrough behaviour for that component, so
+the single-arg constructor remains the right choice when component kwarg names
+are already disjoint.
 
 ## API Reference
 

--- a/src/observation_models/composite/composite_observation_model.jl
+++ b/src/observation_models/composite/composite_observation_model.jl
@@ -1,13 +1,38 @@
 """
-    CompositeObservationModel{T<:Tuple} <: ObservationModel
+    CompositeObservationModel{T<:Tuple, R<:Tuple} <: ObservationModel
 
 An observation model that combines multiple component observation models.
 
-This type follows the factory pattern - it stores component observation models and 
-creates `CompositeLikelihood` instances when called with observation data and hyperparameters.
+This type follows the factory pattern - it stores component observation models and
+creates `CompositeLikelihood` instances when called with observation data and
+hyperparameters.
 
 # Fields
 - `components::T`: Tuple of component observation models for type stability
+- `routes::R`:     Tuple of per-component kwarg routes. Each entry is either
+  `nothing` (forward the full kwargs bag to that component, the default) or a
+  `NamedTuple{inner_names}(outer_names)` mapping the component's *internal*
+  kwarg names to the outer hyperparameter names exposed by the composite.
+
+# Routing
+
+When two components share an internal kwarg name but should bind to different
+outer hyperparameters (e.g. two `ExponentialFamily(Normal)` components needing
+distinct `σ` values), supply a route per component:
+
+```julia
+m_phys = ExponentialFamily(Normal)
+m_data = ExponentialFamily(Normal)
+composite = CompositeObservationModel(
+    (m_phys, m_data),
+    ((σ = :σ_phys,), (σ = :σ_data,)),
+)
+composite(y; σ_phys = 0.1, σ_data = 5.0)
+```
+
+A `nothing` entry preserves the legacy behaviour of forwarding the full kwargs
+bag to that component, so the single-arg constructor remains a drop-in for the
+common case where component kwarg names are disjoint.
 
 # Example
 ```julia
@@ -15,21 +40,31 @@ gaussian_model = ExponentialFamily(Normal)
 poisson_model = ExponentialFamily(Poisson)
 composite_model = CompositeObservationModel((gaussian_model, poisson_model))
 
-# Materialize with data and hyperparameters
-y_composite = CompositeObservations(([1.0, 2.0], [3, 4]))
-composite_lik = composite_model(y_composite; σ=1.5)
+y_composite = CompositeObservations(([1.0, 2.0], PoissonObservations([3, 4])))
+composite_lik = composite_model(y_composite; σ = 1.5)
 ```
 """
-struct CompositeObservationModel{T <: Tuple} <: ObservationModel
+struct CompositeObservationModel{T <: Tuple, R <: Tuple} <: ObservationModel
     components::T
+    routes::R
 
-    function CompositeObservationModel(components::T) where {T <: Tuple}
+    function CompositeObservationModel(components::T, routes::R) where {T <: Tuple, R <: Tuple}
         if isempty(components)
             throw(ArgumentError("CompositeObservationModel cannot be empty"))
         end
-        return new{T}(components)
+        if length(components) != length(routes)
+            throw(
+                ArgumentError(
+                    "Number of routes ($(length(routes))) must match number of components ($(length(components)))"
+                )
+            )
+        end
+        return new{T, R}(components, routes)
     end
 end
+
+CompositeObservationModel(components::Tuple) =
+    CompositeObservationModel(components, ntuple(_ -> nothing, length(components)))
 
 """
     CompositeLikelihood{T<:Tuple} <: ObservationLikelihood
@@ -51,30 +86,52 @@ struct CompositeLikelihood{T <: Tuple} <: ObservationLikelihood
     end
 end
 
-# Factory pattern implementation - make CompositeObservationModel callable
+@inline _materialize_component(component, ::Nothing, y_comp, kwargs::NamedTuple) =
+    component(y_comp; kwargs...)
+
+@inline function _materialize_component(
+        component,
+        route::NamedTuple{inner_names, <:Tuple{Vararg{Symbol}}},
+        y_comp,
+        kwargs::NamedTuple,
+    ) where {inner_names}
+    inner_vals = map(outer_name -> getfield(kwargs, outer_name), values(route))
+    inner = NamedTuple{inner_names}(inner_vals)
+    return component(y_comp; inner...)
+end
+
 function (composite_model::CompositeObservationModel)(y::CompositeObservations; kwargs...)
-    # Validate that number of components matches
     if length(composite_model.components) != length(y.components)
         throw(ArgumentError("Number of model components ($(length(composite_model.components))) must match number of observation components ($(length(y.components)))"))
     end
 
-    # Materialize each component likelihood
-    component_likelihoods = map(composite_model.components, y.components) do model, y_comp
-        # Pass all hyperparameters to each component - they'll take what they need
-        model(y_comp; kwargs...)
+    nt = values(kwargs)
+    component_likelihoods = map(
+        composite_model.components, composite_model.routes, y.components,
+    ) do model, route, y_comp
+        _materialize_component(model, route, y_comp, nt)
     end
 
     return CompositeLikelihood(component_likelihoods)
 end
 
 # COV_EXCL_START
-# Show methods for nice display
 function Base.show(io::IO, model::CompositeObservationModel)
     n_components = length(model.components)
     print(io, "CompositeObservationModel with $n_components component$(n_components == 1 ? "" : "s"):")
+    show_routes = any(r -> r !== nothing, model.routes)
     for (i, component) in enumerate(model.components)
         print(io, "\n  [$i] ")
         show(io, component)
+        if show_routes
+            route = model.routes[i]
+            if route === nothing
+                print(io, "  [route: passthrough]")
+            else
+                pairs_str = join(("$k=:$(getfield(route, k))" for k in keys(route)), ", ")
+                print(io, "  [route: ", pairs_str, "]")
+            end
+        end
     end
     return
 end

--- a/test/observation_models/composite/runtests.jl
+++ b/test/observation_models/composite/runtests.jl
@@ -1,4 +1,5 @@
 include("test_composite_observations.jl")
 include("test_composite_model.jl")
 include("test_composite_likelihood.jl")
+include("test_composite_routing.jl")
 include("test_integration.jl")

--- a/test/observation_models/composite/test_composite_routing.jl
+++ b/test/observation_models/composite/test_composite_routing.jl
@@ -1,0 +1,137 @@
+using Distributions: Normal, Poisson
+
+@testset "CompositeObservationModel routing" begin
+    @testset "Backward compat: single-arg constructor, disjoint kwargs" begin
+        gaussian_model = ExponentialFamily(Normal)
+        poisson_model = ExponentialFamily(Poisson)
+        composite_model = CompositeObservationModel((gaussian_model, poisson_model))
+
+        @test composite_model.routes === (nothing, nothing)
+
+        y_composite = CompositeObservations(([1.0, 2.0], PoissonObservations([3, 4])))
+        composite_lik = composite_model(y_composite; σ = 1.5)
+        @test composite_lik isa CompositeLikelihood
+
+        x = randn(2)
+        ll_composite = loglik(x, composite_lik)
+        ll_manual = loglik(x, gaussian_model([1.0, 2.0]; σ = 1.5)) +
+            loglik(x, poisson_model(PoissonObservations([3, 4])))
+        @test ll_composite ≈ ll_manual
+    end
+
+    @testset "Backward compat: shared kwarg, two Normals see same σ" begin
+        gaussian_model = ExponentialFamily(Normal)
+        composite_model = CompositeObservationModel((gaussian_model, gaussian_model))
+
+        y_composite = CompositeObservations(([1.0, 2.0], [3.0, 4.0]))
+        composite_lik = composite_model(y_composite; σ = 2.0)
+
+        x = randn(2)
+        ll_composite = loglik(x, composite_lik)
+        ll_manual = loglik(x, gaussian_model([1.0, 2.0]; σ = 2.0)) +
+            loglik(x, gaussian_model([3.0, 4.0]; σ = 2.0))
+        @test ll_composite ≈ ll_manual
+    end
+
+    @testset "Routes resolve σ collision between two Normals" begin
+        m_phys = ExponentialFamily(Normal)
+        m_data = ExponentialFamily(Normal)
+        composite_model = CompositeObservationModel(
+            (m_phys, m_data),
+            ((σ = :σ_phys,), (σ = :σ_data,)),
+        )
+
+        y_composite = CompositeObservations(([0.5, 1.5], [10.0, 20.0]))
+        composite_lik = composite_model(y_composite; σ_phys = 0.1, σ_data = 5.0)
+
+        x = randn(2)
+        ll_composite = loglik(x, composite_lik)
+        ll_manual = loglik(x, m_phys([0.5, 1.5]; σ = 0.1)) +
+            loglik(x, m_data([10.0, 20.0]; σ = 5.0))
+        @test ll_composite ≈ ll_manual
+
+        grad_composite = loggrad(x, composite_lik)
+        grad_manual = loggrad(x, m_phys([0.5, 1.5]; σ = 0.1)) +
+            loggrad(x, m_data([10.0, 20.0]; σ = 5.0))
+        @test grad_composite ≈ grad_manual
+
+        hess_composite = loghessian(x, composite_lik)
+        hess_manual = loghessian(x, m_phys([0.5, 1.5]; σ = 0.1)) +
+            loghessian(x, m_data([10.0, 20.0]; σ = 5.0))
+        @test hess_composite ≈ hess_manual
+
+        # Distinct σ values must produce distinct results
+        flipped_lik = composite_model(y_composite; σ_phys = 5.0, σ_data = 0.1)
+        @test loglik(x, flipped_lik) ≉ ll_composite
+    end
+
+    @testset "Mixed routing: one component routed, other passthrough" begin
+        gaussian_model = ExponentialFamily(Normal)
+        poisson_model = ExponentialFamily(Poisson)
+        composite_model = CompositeObservationModel(
+            (gaussian_model, poisson_model),
+            ((σ = :σ_obs,), nothing),
+        )
+
+        y_composite = CompositeObservations(([1.0, 2.0], PoissonObservations([3, 4])))
+        composite_lik = composite_model(y_composite; σ_obs = 0.7)
+
+        x = randn(2)
+        ll_composite = loglik(x, composite_lik)
+        ll_manual = loglik(x, gaussian_model([1.0, 2.0]; σ = 0.7)) +
+            loglik(x, poisson_model(PoissonObservations([3, 4])))
+        @test ll_composite ≈ ll_manual
+    end
+
+    @testset "Validation" begin
+        gaussian_model = ExponentialFamily(Normal)
+        poisson_model = ExponentialFamily(Poisson)
+
+        @test_throws ArgumentError CompositeObservationModel(
+            (gaussian_model, poisson_model),
+            ((σ = :σ_only,),),  # length mismatch
+        )
+
+        composite_model = CompositeObservationModel(
+            (gaussian_model, poisson_model),
+            ((σ = :σ_obs,), nothing),
+        )
+        y_composite = CompositeObservations(([1.0], PoissonObservations([2])))
+        @test_throws ErrorException composite_model(y_composite; σ_other = 1.0)
+    end
+
+    @testset "Type stability with routes" begin
+        m_phys = ExponentialFamily(Normal)
+        m_data = ExponentialFamily(Normal)
+        composite_model = CompositeObservationModel(
+            (m_phys, m_data),
+            ((σ = :σ_phys,), (σ = :σ_data,)),
+        )
+
+        y_composite = CompositeObservations(([1.0], [2.0]))
+        composite_lik = composite_model(y_composite; σ_phys = 0.5, σ_data = 1.5)
+
+        x = randn(1)
+        @inferred loglik(x, composite_lik)
+        @inferred loggrad(x, composite_lik)
+        @inferred loghessian(x, composite_lik)
+    end
+
+    @testset "Show method skips trivial routes, displays explicit ones" begin
+        gaussian_model = ExponentialFamily(Normal)
+        poisson_model = ExponentialFamily(Poisson)
+
+        bc_model = CompositeObservationModel((gaussian_model, poisson_model))
+        bc_str = sprint(show, bc_model)
+        @test !occursin("σ_phys", bc_str)
+        @test !occursin("route", lowercase(bc_str))
+
+        routed_model = CompositeObservationModel(
+            (gaussian_model, gaussian_model),
+            ((σ = :σ_phys,), (σ = :σ_data,)),
+        )
+        routed_str = sprint(show, routed_model)
+        @test occursin("σ_phys", routed_str)
+        @test occursin("σ_data", routed_str)
+    end
+end


### PR DESCRIPTION
## Summary
- Add `routes::R` field to `CompositeObservationModel`. Each per-component entry is either `nothing` (forward the full kwargs bag, the legacy default) or a `NamedTuple{inner_names}(outer_names)` mapping the component's *internal* kwarg name to an outer hyperparameter name.
- Resolves the σ-collision case — e.g. two `ExponentialFamily(Normal)` components needing distinct noise levels — without introducing a new trait or wrapper layer.
- Single-arg constructor unchanged behaviourally; existing call sites with disjoint kwarg names keep working.

## Test plan
- [x] New `test/observation_models/composite/test_composite_routing.jl` (15 cases: BC for single-arg constructor, σ-collision resolution, mixed routed/passthrough, validation errors, type stability, show output)
- [x] Full Composite suite: 70 / 70
- [x] Broader observation-model suite: 254 / 254 (Composite + ExponentialFamily + AutoDiff + Custom + LinearlyTransformed + FEM + Pointwise + NegBin + Gamma + Student-t + neighbours)
- [x] `@code_warntype` clean on both routed and passthrough materialiser paths

## Follow-ups (filed separately, not addressed here)
- Hessian type promotion in `composite_evaluation.jl` — pre-existing bug where in-place `.+=` between mismatched matrix types (e.g. `Diagonal` and `SparseMatrixCSC`) silently misbehaves.
- Composite of `LinearlyTransformedObservationModel` components — augmentation indexing assumes a single LTM in the obs path.
- Single-component kwarg aliasing sugar in `ExponentialFamily` (orthogonal to composite routing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)