### PR TITLE
Fix Hessian accumulation in composite-of-LTM components (closes #98)

### DIFF
--- a/src/observation_models/composite/composite_evaluation.jl
+++ b/src/observation_models/composite/composite_evaluation.jl
@@ -47,15 +47,13 @@ Each component contributes its Hessian with respect to the full latent field `x`
 For overlapping dependencies, Hessians are automatically summed element-wise.
 """
 function loghessian(x, composite_lik::CompositeLikelihood)
-    # Start with zero Hessian - let first component determine type/structure
-    first_hess = loghessian(x, composite_lik.components[1])
-    total_hess = copy(first_hess)
-
-    # Sum contributions from remaining components
+    # Non-in-place accumulation: some component Hessians (e.g. `Symmetric` from
+    # `LinearlyTransformedLikelihood`) reject broadcasted `setindex!` on
+    # off-diagonal entries.
+    total_hess = loghessian(x, composite_lik.components[1])
     for i in 2:length(composite_lik.components)
-        total_hess .+= loghessian(x, composite_lik.components[i])
+        total_hess = total_hess + loghessian(x, composite_lik.components[i])
     end
-
     return total_hess
 end
 

--- a/test/observation_models/composite/test_integration.jl
+++ b/test/observation_models/composite/test_integration.jl
@@ -1,4 +1,5 @@
 using Distributions: Normal, Poisson
+using SparseArrays: sparse
 
 @testset "Composite Likelihood Integration Tests" begin
     @testset "End-to-end workflow with indexed models" begin
@@ -118,5 +119,59 @@ using Distributions: Normal, Poisson
         @inferred loglik(x, composite_lik)
         @inferred loggrad(x, composite_lik)
         @inferred loghessian(x, composite_lik)
+    end
+
+    @testset "LTM-wrapped components" begin
+        # Two channels observe distinct linear projections of the same latent field.
+        n_latent = 5
+        A1 = sparse(
+            [
+                1.0 0.0 0.5 0.0 0.0;
+                0.0 1.0 0.5 0.0 0.0;
+                0.0 0.0 1.0 0.5 0.0;
+                0.0 0.0 0.0 1.0 0.5
+            ]
+        )
+        A2 = sparse(
+            [
+                1.0 0.0 0.0 0.0 1.0;
+                0.0 1.0 0.0 0.0 1.0;
+                0.0 0.0 1.0 0.0 1.0
+            ]
+        )
+
+        gaussian_base = ExponentialFamily(Normal)
+        poisson_base = ExponentialFamily(Poisson)
+
+        ltm_gaussian = LinearlyTransformedObservationModel(gaussian_base, A1)
+        ltm_poisson = LinearlyTransformedObservationModel(poisson_base, A2)
+
+        composite_model = CompositeObservationModel((ltm_gaussian, ltm_poisson))
+
+        y_gaussian = [1.0, 2.0, 1.5, 0.7]
+        y_poisson = PoissonObservations([2, 3, 1])
+        y_composite = CompositeObservations((y_gaussian, y_poisson))
+
+        composite_lik = composite_model(y_composite; σ = 0.8)
+
+        x = [0.9, 2.1, 1.4, 0.3, -0.6]
+
+        ltm_lik1 = ltm_gaussian(y_gaussian; σ = 0.8)
+        ltm_lik2 = ltm_poisson(y_poisson; σ = 0.8)
+
+        ll = loglik(x, composite_lik)
+        ll_manual = loglik(x, ltm_lik1) + loglik(x, ltm_lik2)
+        @test ll isa Float64
+        @test ll ≈ ll_manual
+
+        grad = loggrad(x, composite_lik)
+        grad_manual = loggrad(x, ltm_lik1) + loggrad(x, ltm_lik2)
+        @test length(grad) == n_latent
+        @test grad ≈ grad_manual
+
+        hess = loghessian(x, composite_lik)
+        hess_manual = loghessian(x, ltm_lik1) + loghessian(x, ltm_lik2)
+        @test size(hess) == (n_latent, n_latent)
+        @test hess ≈ hess_manual
     end
 end


### PR DESCRIPTION
## Summary

- Bug: `CompositeLikelihood.loghessian` accumulates with `total_hess .+= ...`, which fails when a component returns a `Symmetric` matrix — `LinearlyTransformedLikelihood` does this for `Aᵀ H A`. `Symmetric` rejects `setindex!` on off-diagonal entries, so the broadcast errors out as soon as the first off-diagonal write happens.
- Fix: switch to non-in-place `+` so per-type `+` methods handle the accumulation correctly. The cost is a few extra allocations in the hot path; the benefit is generic correctness.
- Test: new `LTM-wrapped components` integration testset wraps each component of a `CompositeObservationModel` in a `LinearlyTransformedObservationModel` with distinct sparse design matrices `A1`, `A2` over a shared 5-dim latent field, and cross-checks `loglik` / `loggrad` / `loghessian` against manual summation.

This was a real bug: writing the test surfaced an `ArgumentError: Cannot set a non-diagonal index in a symmetric matrix` from `loghessian`. Without the fix, composite-of-LTMs would error on every Hessian evaluation.

Closes [#98](https://github.com/timweiland/GaussianMarkovRandomFields.jl/issues/98).

## Test plan

- [x] `./test_only.sh "Composite Likelihood Integration"` — green (16/16)
- [x] `./test_only.sh "Composite"` — all composite tests still green (76/76)
- [x] `./test_only.sh "LinearlyTransformed"` — LTM tests still green