### PR TITLE
Fix CompositeLikelihood Hessian type promotion (#97)

### DIFF
--- a/src/observation_models/composite/composite_evaluation.jl
+++ b/src/observation_models/composite/composite_evaluation.jl
@@ -47,16 +47,11 @@ Each component contributes its Hessian with respect to the full latent field `x`
 For overlapping dependencies, Hessians are automatically summed element-wise.
 """
 function loghessian(x, composite_lik::CompositeLikelihood)
-    # Start with zero Hessian - let first component determine type/structure
-    first_hess = loghessian(x, composite_lik.components[1])
-    total_hess = copy(first_hess)
-
-    # Sum contributions from remaining components
-    for i in 2:length(composite_lik.components)
-        total_hess .+= loghessian(x, composite_lik.components[i])
-    end
-
-    return total_hess
+    # Use out-of-place `+` so the accumulator type follows the promotion of the
+    # component Hessians (e.g. `Diagonal` + `SparseMatrixCSC` -> `SparseMatrixCSC`).
+    # In-place `.+=` would either error or silently drop contributions outside
+    # the first component's sparsity pattern.
+    return sum(comp -> loghessian(x, comp), composite_lik.components)
 end
 
 """

--- a/test/observation_models/composite/test_composite_likelihood.jl
+++ b/test/observation_models/composite/test_composite_likelihood.jl
@@ -1,4 +1,6 @@
 using Distributions: Normal, Poisson
+using LinearAlgebra: Diagonal
+using SparseArrays: SparseMatrixCSC
 
 @testset "CompositeLikelihood evaluation" begin
     @testset "Basic loglik summation" begin
@@ -90,6 +92,49 @@ using Distributions: Normal, Poisson
 
         hess = loghessian(x, composite_lik)
         @test size(hess) == (2, 2)
+    end
+
+    @testset "Hessian sum across mismatched component types" begin
+        # AutoDiffObservationModel with default sparse Hessian backend returns
+        # SparseMatrixCSC; ExponentialFamily(Normal) returns Diagonal. The
+        # accumulator must promote correctly regardless of component order.
+        function band_loglik(x; y)
+            ll = 0.0
+            for i in eachindex(y)
+                ll += -0.5 * (x[i] - y[i])^2
+                if i > 1
+                    ll += -0.1 * x[i - 1] * x[i]
+                end
+            end
+            return ll
+        end
+        autodiff_model = AutoDiffObservationModel(band_loglik; n_latent = 4)
+        gaussian_model = ExponentialFamily(Normal)
+
+        y_ad = [0.5, 1.5, 2.5, 3.5]
+        y_g = [1.0, 2.0, 3.0, 4.0]
+
+        ad_lik = autodiff_model(y_ad)
+        g_lik = gaussian_model(y_g; σ = 1.0)
+        @test loghessian(zeros(4), ad_lik) isa SparseMatrixCSC
+        @test loghessian(zeros(4), g_lik) isa Diagonal
+
+        x = randn(4)
+        hess_manual = loghessian(x, ad_lik) + loghessian(x, g_lik)
+
+        # Sparse first, then Diagonal — route σ only to the gaussian component.
+        composite_lik_a = CompositeObservationModel(
+            (autodiff_model, gaussian_model),
+            (NamedTuple(), (σ = :σ,)),
+        )(CompositeObservations((y_ad, y_g)); σ = 1.0)
+        @test loghessian(x, composite_lik_a) ≈ hess_manual
+
+        # Diagonal first, then Sparse
+        composite_lik_b = CompositeObservationModel(
+            (gaussian_model, autodiff_model),
+            ((σ = :σ,), NamedTuple()),
+        )(CompositeObservations((y_g, y_ad)); σ = 1.0)
+        @test loghessian(x, composite_lik_b) ≈ hess_manual
     end
 
     @testset "Type stability" begin

--- a/test/observation_models/composite/test_integration.jl
+++ b/test/observation_models/composite/test_integration.jl
@@ -1,4 +1,5 @@
 using Distributions: Normal, Poisson
+using SparseArrays: sparse
 
 @testset "Composite Likelihood Integration Tests" begin
     @testset "End-to-end workflow with indexed models" begin
@@ -118,5 +119,37 @@ using Distributions: Normal, Poisson
         @inferred loglik(x, composite_lik)
         @inferred loggrad(x, composite_lik)
         @inferred loghessian(x, composite_lik)
+    end
+
+    @testset "LTM-wrapped components" begin
+        # Two channels observe distinct linear projections of the same latent field.
+        A1 = sparse(
+            [
+                1.0 0.0 0.5 0.0;
+                0.0 1.0 0.5 0.0;
+                0.0 0.0 1.0 0.5
+            ]
+        )
+        A2 = sparse(
+            [
+                1.0 0.0 0.0 1.0;
+                0.0 1.0 0.0 1.0
+            ]
+        )
+
+        ltm1 = LinearlyTransformedObservationModel(ExponentialFamily(Normal), A1)
+        ltm2 = LinearlyTransformedObservationModel(ExponentialFamily(Poisson), A2)
+        composite_model = CompositeObservationModel((ltm1, ltm2))
+
+        y_composite = CompositeObservations(([1.0, 2.0, 1.5], PoissonObservations([2, 3])))
+        composite_lik = composite_model(y_composite; σ = 0.8)
+        lik1 = ltm1([1.0, 2.0, 1.5]; σ = 0.8)
+        lik2 = ltm2(PoissonObservations([2, 3]); σ = 0.8)
+
+        x = [0.9, 2.1, 1.4, 0.3]
+
+        @test loglik(x, composite_lik) ≈ loglik(x, lik1) + loglik(x, lik2)
+        @test loggrad(x, composite_lik) ≈ loggrad(x, lik1) + loggrad(x, lik2)
+        @test loghessian(x, composite_lik) ≈ loghessian(x, lik1) + loghessian(x, lik2)
     end
 end


### PR DESCRIPTION
## Summary
- `loghessian(x, ::CompositeLikelihood)` accumulated component Hessians by copying the first one and `.+=`-ing the rest. When the first component returns `Diagonal{Float64}` and a later one returns `SparseMatrixCSC{Float64}`, the in-place broadcast either errors (`Diagonal` → `Sparse`) or silently writes only into the first component's sparsity pattern (`Sparse` → `Diagonal`), dropping off-pattern contributions.
- Replaces the in-place loop with `sum(comp -> loghessian(x, comp), composite_lik.components)`, letting Julia's `+` dispatch handle promotion (`Diagonal + SparseMatrixCSC -> SparseMatrixCSC`, etc.). Order-independent and correct.
- Adds a regression test that combines an `AutoDiffObservationModel` (sparse Hessian) with `ExponentialFamily(Normal)` (`Diagonal` Hessian) in both component orders and checks the result against the hand-rolled sum.

Closes #97.

## Test plan
- [x] `./test_only.sh "Composite"` — 74 / 74 pass
- [x] `./test_only.sh "Hessian"` — 25 / 25 pass (covers AutoDiff, custom, and workspace consumers)