### PR TITLE
Add per-hyperparameter kwarg aliasing for ExponentialFamily

### DIFF
--- a/src/observation_models/exponential_family/exponential_family.jl
+++ b/src/observation_models/exponential_family/exponential_family.jl
@@ -76,10 +76,11 @@ Non-canonical links use general chain rule formulations which may be slower.
 
 See also: [`LinkFunction`](@ref), [`loglik`](@ref), [`conditional_distribution`](@ref)
 """
-struct ExponentialFamily{F <: Distribution, L <: LinkFunction, I} <: ObservationModel
+struct ExponentialFamily{F <: Distribution, L <: LinkFunction, I, A} <: ObservationModel
     family::Type{F}
     link::L
     indices::I  # Can be Nothing, UnitRange, or Vector{Int}
+    kwarg_aliases::A  # Nothing or NamedTuple{inner_names}(outer_name_symbols)
 end
 
 """
@@ -109,11 +110,17 @@ bernoulli_model = ExponentialFamily(Bernoulli) # Uses LogitLink
 
 See also: [`ExponentialFamily`](@ref)
 """
-# Main constructor with optional indices
-ExponentialFamily(family::Type{<:Distribution}; indices = nothing) = ExponentialFamily(family, _default_link(family), indices)
+# Main constructor with optional indices and per-hyperparameter kwarg aliases
+function ExponentialFamily(family::Type{<:Distribution}; indices = nothing, kwargs...)
+    aliases = _build_kwarg_aliases(family, NamedTuple(kwargs))
+    return ExponentialFamily(family, _default_link(family), indices, aliases)
+end
 
-# Constructor with explicit link function and optional indices
-ExponentialFamily(family::Type{<:Distribution}, link::LinkFunction; indices = nothing) = ExponentialFamily(family, link, indices)
+# Constructor with explicit link function and optional indices and aliases
+function ExponentialFamily(family::Type{<:Distribution}, link::LinkFunction; indices = nothing, kwargs...)
+    aliases = _build_kwarg_aliases(family, NamedTuple(kwargs))
+    return ExponentialFamily(family, link, indices, aliases)
+end
 
 _default_link(::Type{<:Normal}) = IdentityLink()
 _default_link(::Type{<:Poisson}) = LogLink()
@@ -122,6 +129,45 @@ _default_link(::Type{<:Binomial}) = LogitLink()
 _default_link(::Type{<:NegativeBinomial}) = LogLink()
 _default_link(::Type{<:Gamma}) = LogLink()
 _default_link(::Type{<:TDist}) = IdentityLink()
+
+# Hyperparameter names that may be aliased per family.
+_hyperparameter_names(::Type{<:Normal}) = (:σ,)
+_hyperparameter_names(::Type{<:Bernoulli}) = ()
+_hyperparameter_names(::Type{<:Binomial}) = ()
+_hyperparameter_names(::Type{<:Poisson}) = ()
+_hyperparameter_names(::Type{<:NegativeBinomial}) = (:r,)
+_hyperparameter_names(::Type{<:Gamma}) = (:phi,)
+_hyperparameter_names(::Type{<:TDist}) = (:σ, :ν)
+
+function _build_kwarg_aliases(family::Type{<:Distribution}, kwargs::NamedTuple{names}) where {names}
+    isempty(names) && return nothing
+    valid = _hyperparameter_names(family)
+    for k in names
+        k in valid || throw(
+            ArgumentError(
+                "`$k` is not a hyperparameter of $family. Valid hyperparameters: $valid",
+            )
+        )
+    end
+    for v in values(kwargs)
+        v isa Symbol || throw(
+            ArgumentError(
+                "ExponentialFamily kwarg aliases must map to Symbol values, got $(typeof(v))",
+            )
+        )
+    end
+    return kwargs
+end
+
+@inline _resolve_aliases(::Nothing, nt::NamedTuple) = nt
+
+@inline function _resolve_aliases(
+        aliases::NamedTuple{inner_names, <:Tuple{Vararg{Symbol}}},
+        nt::NamedTuple,
+    ) where {inner_names}
+    inner_vals = map(outer -> getfield(nt, outer), values(aliases))
+    return merge(nt, NamedTuple{inner_names}(inner_vals))
+end
 
 """
     conditional_distribution(obs_model::ExponentialFamily, x; θ_named...) -> Distribution
@@ -163,6 +209,12 @@ y_new = rand(dist)                  # Sample new data
 ```
 """
 function conditional_distribution(obs_model::ExponentialFamily, x; kwargs...)
+    nt = values(kwargs)
+    resolved = _resolve_aliases(obs_model.kwarg_aliases, nt)
+    return _conditional_distribution(obs_model, x; resolved...)
+end
+
+function _conditional_distribution(obs_model::ExponentialFamily, x; kwargs...)
     η = x  # Linear predictor
     μ = apply_invlink.(Ref(obs_model.link), η)
     return _conditional_distribution_family(obs_model.family, μ; kwargs...)
@@ -184,7 +236,7 @@ function _conditional_distribution_family(::Type{<:Binomial}, μ; n, kwargs...)
     return product_distribution(Binomial.(n, μ))
 end
 
-function conditional_distribution(obs_model::ExponentialFamily{NegativeBinomial}, x; r, offset = nothing, kwargs...)
+function _conditional_distribution(obs_model::ExponentialFamily{NegativeBinomial}, x; r, offset = nothing, kwargs...)
     if (offset !== nothing) && !(obs_model.link isa LogLink)
         throw(ArgumentError("offset is only supported for NegativeBinomial with LogLink"))
     end
@@ -207,7 +259,7 @@ function _conditional_distribution_family(::Type{<:TDist}, μ; σ, ν, kwargs...
     return product_distribution(μ .+ σ_eff .* TDist(ν))
 end
 
-function conditional_distribution(obs_model::ExponentialFamily{Poisson}, x; offset = nothing, kwargs...)
+function _conditional_distribution(obs_model::ExponentialFamily{Poisson}, x; offset = nothing, kwargs...)
     # Offsets are only supported for Poisson with LogLink (log-exposure)
     if (offset !== nothing) && !(obs_model.link isa LogLink)
         throw(ArgumentError("offset is only supported for Poisson with LogLink"))
@@ -226,27 +278,33 @@ end
 # FACTORY PATTERN: Make ExponentialFamily callable to create materialized likelihoods
 # =======================================================================================
 
-function (obs_model::ExponentialFamily{Normal, L, I})(y; σ, kwargs...) where {L, I}
+@inline function (obs_model::ExponentialFamily)(y; kwargs...)
+    nt = values(kwargs)
+    resolved = _resolve_aliases(obs_model.kwarg_aliases, nt)
+    return _materialize(obs_model, y; resolved...)
+end
+
+function _materialize(obs_model::ExponentialFamily{Normal}, y; σ, kwargs...)
     return NormalLikelihood(obs_model.link, Float64.(y), σ, one(σ) / (σ^2), log(σ), obs_model.indices)
 end
 
-function (obs_model::ExponentialFamily{Poisson, L, I})(y::PoissonObservations; kwargs...) where {L, I}
+function _materialize(obs_model::ExponentialFamily{Poisson}, y::PoissonObservations; kwargs...)
     return PoissonLikelihood(obs_model.link, y.counts, obs_model.indices, y.logexposure)
 end
 
-function (obs_model::ExponentialFamily{Bernoulli, L, I})(y; kwargs...) where {L, I}
+function _materialize(obs_model::ExponentialFamily{Bernoulli}, y; kwargs...)
     return BernoulliLikelihood(obs_model.link, Int.(y), obs_model.indices)
 end
 
-function (obs_model::ExponentialFamily{Binomial, L, I})(y::BinomialObservations; kwargs...) where {L, I}
+function _materialize(obs_model::ExponentialFamily{Binomial}, y::BinomialObservations; kwargs...)
     return BinomialLikelihood(obs_model.link, successes(y), trials(y), obs_model.indices)
 end
 
-function (obs_model::ExponentialFamily{NegativeBinomial, L, I})(y::NegativeBinomialObservations; r, kwargs...) where {L, I}
+function _materialize(obs_model::ExponentialFamily{NegativeBinomial}, y::NegativeBinomialObservations; r, kwargs...)
     return NegBinLikelihood(obs_model.link, y.counts, r, obs_model.indices, y.logexposure)
 end
 
-function (obs_model::ExponentialFamily{Gamma, L, I})(y; phi, kwargs...) where {L, I}
+function _materialize(obs_model::ExponentialFamily{Gamma}, y; phi, kwargs...)
     phi > 0 || error("Gamma shape parameter phi must be positive (got $phi)")
     y_f64 = Float64.(y)
     for i in eachindex(y_f64)
@@ -257,7 +315,7 @@ function (obs_model::ExponentialFamily{Gamma, L, I})(y; phi, kwargs...) where {L
     return GammaLikelihood(obs_model.link, y_f64, phi, obs_model.indices)
 end
 
-function (obs_model::ExponentialFamily{TDist, L, I})(y; σ, ν, kwargs...) where {L, I}
+function _materialize(obs_model::ExponentialFamily{TDist}, y; σ, ν, kwargs...)
     σ > 0 || error("Student-t scale parameter σ must be positive (got $σ)")
     ν > 2 || error("Student-t degrees of freedom ν must be > 2 for finite variance (got $ν)")
     T = promote_type(typeof(σ), typeof(ν))
@@ -269,14 +327,9 @@ function (obs_model::ExponentialFamily{TDist, L, I})(y; σ, ν, kwargs...) where
     return StudentTLikelihood(obs_model.link, Float64.(y), σ_T, ν_T, w, νp1, σ_eff, obs_model.indices)
 end
 
-# Hyperparameter interface implementations
-hyperparameters(::ExponentialFamily{<:Normal}) = (:σ,)
-hyperparameters(::ExponentialFamily{<:Bernoulli}) = ()
-hyperparameters(::ExponentialFamily{<:Binomial}) = ()  # No hyperparameters - trials are data
-hyperparameters(::ExponentialFamily{<:Poisson}) = ()
-hyperparameters(::ExponentialFamily{<:NegativeBinomial}) = (:r,)
-hyperparameters(::ExponentialFamily{<:Gamma}) = (:phi,)
-hyperparameters(::ExponentialFamily{<:TDist}) = (:σ, :ν)
+# Hyperparameter interface — names reflect what the materialiser destructures internally,
+# regardless of any user-supplied aliases.
+hyperparameters(::ExponentialFamily{F}) where {F <: Distribution} = _hyperparameter_names(F)
 
 """
     latent_dimension(ef::ExponentialFamily, y::AbstractVector) -> Int
@@ -287,3 +340,19 @@ For ExponentialFamily models, there is a direct 1:1 mapping between observations
 and latent field components, so the latent dimension equals the observation dimension.
 """
 latent_dimension(ef::ExponentialFamily, y::AbstractVector) = length(y)
+
+# COV_EXCL_START
+function Base.show(io::IO, model::ExponentialFamily)
+    print(io, "ExponentialFamily(", nameof(model.family), ", ", model.link)
+    if model.indices !== nothing
+        print(io, ", indices=", model.indices)
+    end
+    aliases = model.kwarg_aliases
+    if aliases !== nothing
+        pairs_str = join(("$k=:$(getfield(aliases, k))" for k in keys(aliases)), ", ")
+        print(io, ", aliases=(", pairs_str, ")")
+    end
+    print(io, ")")
+    return
+end
+# COV_EXCL_STOP

--- a/test/observation_models/runtests.jl
+++ b/test/observation_models/runtests.jl
@@ -1,5 +1,6 @@
 include("test_link_functions.jl")
 include("test_exponential_family.jl")
+include("test_exponential_family_aliasing.jl")
 include("test_custom_models.jl")
 include("test_type_stability.jl")
 include("test_likelihood.jl")

--- a/test/observation_models/test_exponential_family_aliasing.jl
+++ b/test/observation_models/test_exponential_family_aliasing.jl
@@ -1,0 +1,157 @@
+using Distributions
+using ForwardDiff
+using LinearAlgebra
+using Random
+
+@testset "ExponentialFamily kwarg aliasing" begin
+    @testset "Backward compat: no aliases" begin
+        ef = ExponentialFamily(Normal)
+        @test ef.kwarg_aliases === nothing
+        @test hyperparameters(ef) == (:σ,)
+
+        y = [0.5, 1.0, -0.3]
+        lik = ef(y; σ = 0.7)
+        x = randn(3)
+        @test isfinite(loglik(x, lik))
+    end
+
+    @testset "Normal: σ → outer name" begin
+        ef_alias = ExponentialFamily(Normal; σ = :σ_phys)
+        ef_plain = ExponentialFamily(Normal)
+
+        y = [0.5, 1.0, -0.3]
+        x = randn(3)
+
+        lik_alias = ef_alias(y; σ_phys = 0.7)
+        lik_plain = ef_plain(y; σ = 0.7)
+
+        @test loglik(x, lik_alias) ≈ loglik(x, lik_plain)
+        @test loggrad(x, lik_alias) ≈ loggrad(x, lik_plain)
+        @test Matrix(loghessian(x, lik_alias)) ≈ Matrix(loghessian(x, lik_plain))
+    end
+
+    @testset "Normal alias preserves indices" begin
+        ef = ExponentialFamily(Normal; σ = :σ_obs, indices = 2:4)
+        @test ef.indices == 2:4
+        @test ef.kwarg_aliases === (σ = :σ_obs,)
+
+        y = [1.0, 2.0, 3.0]
+        lik = ef(y; σ_obs = 1.5)
+        @test lik.indices == 2:4
+        @test lik.σ == 1.5
+    end
+
+    @testset "Gamma: phi → outer name" begin
+        ef_alias = ExponentialFamily(Gamma; phi = :phi_obs)
+        ef_plain = ExponentialFamily(Gamma)
+
+        y = [1.5, 0.3, 4.2]
+        x = log.([1.0, 2.0, 3.0])  # LogLink: μ = exp(x) > 0
+
+        lik_alias = ef_alias(y; phi_obs = 2.0)
+        lik_plain = ef_plain(y; phi = 2.0)
+
+        @test loglik(x, lik_alias) ≈ loglik(x, lik_plain)
+        @test loggrad(x, lik_alias) ≈ loggrad(x, lik_plain)
+    end
+
+    @testset "TDist: both σ and ν renamed" begin
+        ef_alias = ExponentialFamily(TDist; σ = :σ_t, ν = :ν_t)
+        ef_plain = ExponentialFamily(TDist)
+
+        y = [1.5, -0.3, 4.2]
+        x = randn(3)
+
+        lik_alias = ef_alias(y; σ_t = 1.0, ν_t = 5.0)
+        lik_plain = ef_plain(y; σ = 1.0, ν = 5.0)
+
+        @test loglik(x, lik_alias) ≈ loglik(x, lik_plain)
+        @test loggrad(x, lik_alias) ≈ loggrad(x, lik_plain)
+        @test Matrix(loghessian(x, lik_alias)) ≈ Matrix(loghessian(x, lik_plain))
+    end
+
+    @testset "TDist: only one of two renamed" begin
+        ef_alias = ExponentialFamily(TDist; σ = :σ_obs)
+        ef_plain = ExponentialFamily(TDist)
+
+        y = [1.5, -0.3, 4.2]
+        x = randn(3)
+
+        lik_alias = ef_alias(y; σ_obs = 1.0, ν = 5.0)
+        lik_plain = ef_plain(y; σ = 1.0, ν = 5.0)
+
+        @test loglik(x, lik_alias) ≈ loglik(x, lik_plain)
+    end
+
+    @testset "NegativeBinomial: r → outer name" begin
+        ef_alias = ExponentialFamily(NegativeBinomial; r = :r_obs)
+        ef_plain = ExponentialFamily(NegativeBinomial)
+
+        y = NegativeBinomialObservations([2, 5, 1])
+        x = randn(3)
+
+        lik_alias = ef_alias(y; r_obs = 3.0)
+        lik_plain = ef_plain(y; r = 3.0)
+
+        @test loglik(x, lik_alias) ≈ loglik(x, lik_plain)
+        @test loggrad(x, lik_alias) ≈ loggrad(x, lik_plain)
+    end
+
+    @testset "conditional_distribution honours aliases" begin
+        ef_alias = ExponentialFamily(Normal; σ = :σ_phys)
+        ef_plain = ExponentialFamily(Normal)
+
+        x = [0.5, -0.2, 1.1]
+        d_alias = conditional_distribution(ef_alias, x; σ_phys = 0.8)
+        d_plain = conditional_distribution(ef_plain, x; σ = 0.8)
+
+        @test mean(d_alias) ≈ mean(d_plain)
+        @test var(d_alias) ≈ var(d_plain)
+    end
+
+    @testset "Validation: unknown alias key" begin
+        @test_throws ArgumentError ExponentialFamily(Normal; foo = :bar)
+        @test_throws ArgumentError ExponentialFamily(Gamma; σ = :σ_obs)
+    end
+
+    @testset "Validation: alias value must be Symbol" begin
+        @test_throws ArgumentError ExponentialFamily(Normal; σ = "σ_phys")
+        @test_throws ArgumentError ExponentialFamily(Normal; σ = 1.0)
+    end
+
+    @testset "Type stability with aliases" begin
+        ef = ExponentialFamily(Normal; σ = :σ_phys)
+        y = [0.5, 1.0]
+        lik = ef(y; σ_phys = 0.7)
+        x = randn(2)
+        @inferred ef(y; σ_phys = 0.7)
+        @inferred loglik(x, lik)
+        @inferred loggrad(x, lik)
+        @inferred loghessian(x, lik)
+    end
+
+    @testset "Routes through CompositeObservationModel still work" begin
+        # Confirms aliasing on a single component is composable with composite passthrough
+        m_aliased = ExponentialFamily(Normal; σ = :σ_inner)
+        m_plain = ExponentialFamily(Poisson)
+        composite = CompositeObservationModel((m_aliased, m_plain))
+
+        y = CompositeObservations(([1.0, 2.0], PoissonObservations([3, 4])))
+        lik = composite(y; σ_inner = 0.5)
+
+        x = randn(2)
+        ll_manual = loglik(x, m_aliased([1.0, 2.0]; σ_inner = 0.5)) +
+            loglik(x, m_plain(PoissonObservations([3, 4])))
+        @test loglik(x, lik) ≈ ll_manual
+    end
+
+    @testset "Show method displays aliases" begin
+        ef = ExponentialFamily(Normal; σ = :σ_phys)
+        s = sprint(show, ef)
+        @test occursin("σ_phys", s)
+
+        ef_plain = ExponentialFamily(Normal)
+        s_plain = sprint(show, ef_plain)
+        @test !occursin("alias", lowercase(s_plain))
+    end
+end


### PR DESCRIPTION
Closes #99.

`ExponentialFamily(Normal)` previously hardcoded its inner kwarg name
as `:σ`. Composite users could rebind via per-component routes (#96),
but single-component users were stuck with the literal kwarg. This adds
sugar:

```julia
m = ExponentialFamily(Normal; σ = :σ_phys)
m(y; σ_phys = 0.1)
```

Same mechanism for `Gamma` (`phi`), `NegativeBinomial` (`r`), and
`TDist` (`σ`, `ν`, both renamable independently).

## Design

**Storage:** `ExponentialFamily{F,L,I,A}` gains a fourth type parameter
and a `kwarg_aliases::A` field. `A` is either `Nothing` (default,
backward-compatible) or a `NamedTuple{inner_names, NTuple{N,Symbol}}`
mapping inner kwarg names to outer Symbols. This mirrors the composite
routing layout exactly, so the type system carries the mapping and the
hot path stays allocation-free.

**Constructor:** keyword-only — extra kwargs beyond `indices` are
collected into the alias map. Validated at construction:

- Each key must appear in `_hyperparameter_names(family)`.
- Each value must be a `Symbol`.

**Materializer refactor:** the per-family
`(obs_model::ExponentialFamily{F,...})(y; ...)` methods are renamed to
`_materialize`, and a single generic callable
`(obs_model::ExponentialFamily)(y; kwargs...)` first resolves aliases,
then dispatches to `_materialize`. `conditional_distribution` follows
the same shape via `_conditional_distribution`. Resolution is one
`getfield` per aliased name on a NamedTuple with statically-known keys
— no `Any` introduced.

**Backward compatibility:** call sites using the literal inner names
(no aliases passed) hit `kwarg_aliases === nothing`, `_resolve_aliases`
is the identity, and the materializer destructures the inner names
directly as before.

## Tests

`test/observation_models/test_exponential_family_aliasing.jl` covers:

- Backward compat (no aliases).
- Single rename (Normal `σ`, Gamma `phi`, NegativeBinomial `r`).
- Multi-rename (TDist `σ` and `ν`).
- Partial rename (TDist `σ` only).
- Aliasing combined with `indices`.
- `conditional_distribution` honours aliases.
- Validation errors for unknown keys and non-Symbol values.
- `@inferred` on the materialiser, `loglik`, `loggrad`, `loghessian`.
- Composite routing layered on top of an aliased component.
- `Base.show` reflects aliases when present.

All existing `ExponentialFamily Models`, composite, autodiff, and
gaussian-approximation suites continue to pass unchanged.