### PR TITLE
Separate diagonal-Hessian shortcut from pointwise-loglik availability

### DIFF
--- a/ext/forwarddiff/autodiff_likelihood_dual.jl
+++ b/ext/forwarddiff/autodiff_likelihood_dual.jl
@@ -86,6 +86,7 @@ function _rebuild_autodiff_likelihood(lik::GMRFs.AutoDiffLikelihood, hp::NamedTu
         grad_backend = lik.grad_backend,
         hessian_backend = lik.hess_backend,
         pointwise_loglik_func = lik.pointwise_loglik_func,
+        diagonal_hessian_safe = lik.diagonal_hessian_safe,
     )
 end
 

--- a/ext/forwarddiff/autodiff_likelihood_ift.jl
+++ b/ext/forwarddiff/autodiff_likelihood_ift.jl
@@ -27,11 +27,13 @@ end
 
 # ----------------------------------------------------------------------------
 # DI.hessian returns a dense Matrix even when the underlying Hessian is
-# structurally diagonal (the typical case for a sum-of-pointwise loglik).
-# Sniff for off-diagonal zeros and downcast so the IFT path can preserve
-# Q_prior's sparse pattern through `_assemble_q_post_dual`. With a
-# `pointwise_loglik_func` set, `loghessian` already returns a `Diagonal`
-# directly via the main-src fast path, so this is a defensive fallback.
+# structurally diagonal (the typical case for a sum-of-pointwise loglik
+# where each term `i` depends only on `x[i]`). Sniff for off-diagonal
+# zeros and downcast so the IFT path can preserve Q_prior's sparse
+# pattern through `_assemble_q_post_dual`. With both `pointwise_loglik_func`
+# and `diagonal_hessian_safe = true` set, `loghessian` already returns a
+# `Diagonal` directly via the main-src fast path, so this is a defensive
+# fallback.
 # ----------------------------------------------------------------------------
 
 _maybe_downcast_diagonal(H::Diagonal) = H
@@ -48,9 +50,10 @@ end
 
 # ----------------------------------------------------------------------------
 # Q_post_dual builder — preserves Q_prior's exact sparse structure for
-# diagonal Hessians (the dominant case via pointwise_loglik_func). For
-# subset-pattern sparse Hessians we still preserve Q_prior's pattern. For
-# arbitrary dense Hessians we fall back to algebraic subtraction.
+# diagonal Hessians (the dominant case when `pointwise_loglik_func` is set
+# AND `diagonal_hessian_safe = true`). For subset-pattern sparse Hessians
+# we still preserve Q_prior's pattern. For arbitrary dense Hessians we
+# fall back to algebraic subtraction.
 # ----------------------------------------------------------------------------
 
 # Allocate `nzval_dual` as a copy of Q_prior.nzval lifted to `DualT` with
@@ -138,8 +141,8 @@ function _check_h_pattern_subset(H::SparseMatrixCSC, Q_prior::SparseMatrixCSC)
                         "($row, $col) outside the prior precision sparsity pattern. The " *
                         "workspace-reuse path requires H's pattern to be a subset of Q_prior. " *
                         "Use a likelihood whose Hessian is structurally diagonal " *
-                        "(e.g. supply `pointwise_loglik_func`) or call `gaussian_approximation` " *
-                        "without a `WorkspaceGMRF` prior."
+                        "(supply `pointwise_loglik_func` AND set `diagonal_hessian_safe = true`) " *
+                        "or call `gaussian_approximation` without a `WorkspaceGMRF` prior."
                 )
             )
         end
@@ -170,10 +173,10 @@ function _assemble_q_post_dual(
                 "(eltype $(eltype(H_dual)), size $(size(H_dual))), but the " *
                 "workspace-reuse path requires a structurally diagonal or " *
                 "Q_prior-pattern-subset sparse Hessian to preserve the workspace's " *
-                "symbolic factorization. Supply `pointwise_loglik_func` to opt into " *
-                "the structured Diagonal path, use a sparse Hessian backend " *
-                "(`AutoSparse(AutoForwardDiff())`), or call `gaussian_approximation` " *
-                "with a non-`WorkspaceGMRF` prior."
+                "symbolic factorization. Supply `pointwise_loglik_func` AND set " *
+                "`diagonal_hessian_safe = true` to opt into the structured Diagonal " *
+                "path, use a sparse Hessian backend (`AutoSparse(AutoForwardDiff())`), " *
+                "or call `gaussian_approximation` with a non-`WorkspaceGMRF` prior."
         )
     )
 end

--- a/src/observation_models/autodiff_likelihood.jl
+++ b/src/observation_models/autodiff_likelihood.jl
@@ -83,11 +83,9 @@ it via dispatch and route `gaussian_approximation` through a primal-Newton
 - `pointwise_loglik_func::PF`: Optional pointwise log-likelihood, signature `(x; y, hyperparam_kwargs...) -> Vector{Real}`.
 - `y::Y`: Stored observation data.
 - `hyperparams::HP`: Stored hyperparameter values.
-- `diagonal_hessian_safe::Bool`: User assertion that the i-th pointwise term
-  depends only on `x[i]` (so the full Hessian is exactly diagonal). Gates the
-  per-element 1D second-derivative shortcut in `loghessian`. Defaults to
-  `false`; pointwise availability alone does not imply diagonal Hessian
-  structure.
+- `diagonal_hessian_safe::Bool`: When `true`, gates the per-element 1D
+  second-derivative shortcut in `loghessian`. Only set this when each
+  pointwise term `i` depends solely on `x[i]`.
 """
 struct AutoDiffLikelihood{F, B, SB, PF, Y, HP <: NamedTuple} <: GaussianMarkovRandomFields.ObservationLikelihood
     loglik_func::F
@@ -121,8 +119,9 @@ materializes a likelihood that holds those values explicitly.
 - `hess_backend::SB`: AD backend for Hessians.
 - `hyperparams::H`: Tuple of hyperparameter names.
 - `pointwise_loglik_func::PF`: Optional pointwise log-likelihood.
-- `diagonal_hessian_safe::Bool`: User assertion that the i-th pointwise term
-  depends only on `x[i]` (so the full Hessian is exactly diagonal).
+- `diagonal_hessian_safe::Bool`: When `true`, opts into the diagonal-Hessian
+  shortcut in `loghessian`. Only valid when each pointwise term `i`
+  depends solely on `x[i]`.
 
 # Usage
 ```julia
@@ -168,13 +167,10 @@ Construct an `AutoDiffObservationModel`.
 
 ## `diagonal_hessian_safe`
 
-When `pointwise_loglik_func` is provided AND `diagonal_hessian_safe = true`,
-`loghessian` takes a per-element 1D second-derivative shortcut that returns
-a `Diagonal`. This is mathematically valid only if each pointwise term `i`
-depends only on `x[i]` — i.e. the linear predictor of observation `i` is
-literally `x[i]`. Models like `y[i] ~ Family(Aᵢᵀ x)` (regression on a
-non-trivial design, additive models, link from a covariate combination)
-have a non-diagonal Hessian and must keep the default `false`.
+When both `pointwise_loglik_func` is provided AND `diagonal_hessian_safe = true`,
+`loghessian` returns a `Diagonal` via per-element 1D second derivatives.
+Only valid when the linear predictor of observation `i` is literally `x[i]`;
+models like `y[i] ~ Family(Aᵢᵀ x)` must keep the default `false`.
 """
 function AutoDiffObservationModel(loglik_func; n_latent, hyperparams = (), grad_backend = default_grad_backend(), hessian_backend = default_hessian_backend(grad_backend), pointwise_loglik_func = nothing, diagonal_hessian_safe::Bool = false)
     if hessian_backend === nothing
@@ -202,12 +198,8 @@ Two forms:
    Convenient for one-off uses but loses the nested-AD-friendly dispatch
    route — prefer form (1) when differentiating through a hyperparameter.
 
-`pointwise_loglik_func` enables the WAIC/CPO accumulator path. The
-`diagonal_hessian_safe` keyword (default `false`) is independent: it
-gates the per-element 1D second-derivative shortcut in `loghessian` and
-should only be set `true` when each pointwise term `i` depends solely on
-`x[i]` (e.g. `y[i] ~ Family(x[i])`), not when the linear predictor mixes
-latent components.
+`diagonal_hessian_safe` (default `false`) is independent of
+`pointwise_loglik_func`. See `AutoDiffObservationModel` for the contract.
 """
 function AutoDiffLikelihood(
         loglik_func;

--- a/src/observation_models/autodiff_likelihood.jl
+++ b/src/observation_models/autodiff_likelihood.jl
@@ -83,6 +83,11 @@ it via dispatch and route `gaussian_approximation` through a primal-Newton
 - `pointwise_loglik_func::PF`: Optional pointwise log-likelihood, signature `(x; y, hyperparam_kwargs...) -> Vector{Real}`.
 - `y::Y`: Stored observation data.
 - `hyperparams::HP`: Stored hyperparameter values.
+- `diagonal_hessian_safe::Bool`: User assertion that the i-th pointwise term
+  depends only on `x[i]` (so the full Hessian is exactly diagonal). Gates the
+  per-element 1D second-derivative shortcut in `loghessian`. Defaults to
+  `false`; pointwise availability alone does not imply diagonal Hessian
+  structure.
 """
 struct AutoDiffLikelihood{F, B, SB, PF, Y, HP <: NamedTuple} <: GaussianMarkovRandomFields.ObservationLikelihood
     loglik_func::F
@@ -92,6 +97,7 @@ struct AutoDiffLikelihood{F, B, SB, PF, Y, HP <: NamedTuple} <: GaussianMarkovRa
     pointwise_loglik_func::PF
     y::Y
     hyperparams::HP
+    diagonal_hessian_safe::Bool
 end
 
 """
@@ -115,6 +121,8 @@ materializes a likelihood that holds those values explicitly.
 - `hess_backend::SB`: AD backend for Hessians.
 - `hyperparams::H`: Tuple of hyperparameter names.
 - `pointwise_loglik_func::PF`: Optional pointwise log-likelihood.
+- `diagonal_hessian_safe::Bool`: User assertion that the i-th pointwise term
+  depends only on `x[i]` (so the full Hessian is exactly diagonal).
 
 # Usage
 ```julia
@@ -135,6 +143,7 @@ struct AutoDiffObservationModel{F, B, SB, H, PF} <: GaussianMarkovRandomFields.O
     hess_backend::SB
     hyperparams::H
     pointwise_loglik_func::PF
+    diagonal_hessian_safe::Bool
 end
 
 const AD_PREFERRED_ORDER = (DI.AutoEnzyme(), DI.AutoMooncake(), DI.AutoZygote(), DI.AutoForwardDiff())
@@ -150,24 +159,34 @@ function default_grad_backend()
 end
 
 """
-    AutoDiffObservationModel(loglik_func; n_latent, hyperparams=(), grad_backend, hessian_backend, pointwise_loglik_func=nothing)
+    AutoDiffObservationModel(loglik_func; n_latent, hyperparams=(), grad_backend, hessian_backend, pointwise_loglik_func=nothing, diagonal_hessian_safe=false)
 
 Construct an `AutoDiffObservationModel`.
 
 `loglik_func` should have signature `(x; y, hyperparam_kwargs...) -> Real`.
 `hyperparams` is a tuple of hyperparameter names (`Symbol`s) the model expects.
+
+## `diagonal_hessian_safe`
+
+When `pointwise_loglik_func` is provided AND `diagonal_hessian_safe = true`,
+`loghessian` takes a per-element 1D second-derivative shortcut that returns
+a `Diagonal`. This is mathematically valid only if each pointwise term `i`
+depends only on `x[i]` — i.e. the linear predictor of observation `i` is
+literally `x[i]`. Models like `y[i] ~ Family(Aᵢᵀ x)` (regression on a
+non-trivial design, additive models, link from a covariate combination)
+have a non-diagonal Hessian and must keep the default `false`.
 """
-function AutoDiffObservationModel(loglik_func; n_latent, hyperparams = (), grad_backend = default_grad_backend(), hessian_backend = default_hessian_backend(grad_backend), pointwise_loglik_func = nothing)
+function AutoDiffObservationModel(loglik_func; n_latent, hyperparams = (), grad_backend = default_grad_backend(), hessian_backend = default_hessian_backend(grad_backend), pointwise_loglik_func = nothing, diagonal_hessian_safe::Bool = false)
     if hessian_backend === nothing
         hessian_backend = grad_backend
         @warn "Hessian backend has type $(typeof(hessian_backend)) which may produce dense Hessians!!"
     end
-    return AutoDiffObservationModel(loglik_func, n_latent, grad_backend, hessian_backend, hyperparams, pointwise_loglik_func)
+    return AutoDiffObservationModel(loglik_func, n_latent, grad_backend, hessian_backend, hyperparams, pointwise_loglik_func, diagonal_hessian_safe)
 end
 
 """
-    AutoDiffLikelihood(loglik_func; n_latent, y, hyperparams, grad_backend, hessian_backend, pointwise_loglik_func)
-    AutoDiffLikelihood(closure;     n_latent, grad_backend, hessian_backend, pointwise_loglik_func)
+    AutoDiffLikelihood(loglik_func; n_latent, y, hyperparams, grad_backend, hessian_backend, pointwise_loglik_func, diagonal_hessian_safe)
+    AutoDiffLikelihood(closure;     n_latent, grad_backend, hessian_backend, pointwise_loglik_func, diagonal_hessian_safe)
 
 Direct construction of an `AutoDiffLikelihood`.
 
@@ -182,6 +201,13 @@ Two forms:
    `y`/`hyperparams` arguments. Stored with empty `y` and empty `hyperparams`.
    Convenient for one-off uses but loses the nested-AD-friendly dispatch
    route — prefer form (1) when differentiating through a hyperparameter.
+
+`pointwise_loglik_func` enables the WAIC/CPO accumulator path. The
+`diagonal_hessian_safe` keyword (default `false`) is independent: it
+gates the per-element 1D second-derivative shortcut in `loghessian` and
+should only be set `true` when each pointwise term `i` depends solely on
+`x[i]` (e.g. `y[i] ~ Family(x[i])`), not when the linear predictor mixes
+latent components.
 """
 function AutoDiffLikelihood(
         loglik_func;
@@ -191,14 +217,20 @@ function AutoDiffLikelihood(
         grad_backend = default_grad_backend(),
         hessian_backend = default_hessian_backend(grad_backend),
         pointwise_loglik_func = nothing,
+        diagonal_hessian_safe::Bool = false,
     )
     if hessian_backend === nothing
         hessian_backend = grad_backend
         @warn "Hessian backend has type $(typeof(hessian_backend)) which may produce dense Hessians!!"
     end
+    if pointwise_loglik_func !== nothing && !diagonal_hessian_safe
+        @info "AutoDiffLikelihood: `pointwise_loglik_func` provided without `diagonal_hessian_safe=true`. " *
+            "`loghessian` will compute the full Hessian via `DI.hessian`. Set `diagonal_hessian_safe=true` only " *
+            "if every pointwise term `i` depends solely on `x[i]` (e.g. `y[i] ~ Family(x[i])`)." maxlog = 1
+    end
     obs_lik = AutoDiffLikelihood(
         loglik_func, grad_backend, hessian_backend, _ADPrepCache(n_latent),
-        pointwise_loglik_func, y, hyperparams
+        pointwise_loglik_func, y, hyperparams, diagonal_hessian_safe
     )
     # Eagerly populate the Float64 prep entry. Construction and runtime calls
     # both go through `_build_call(obs_lik)` so the prep is keyed on the same
@@ -247,6 +279,7 @@ function (obs_model::AutoDiffObservationModel)(y; kwargs...)
         grad_backend = obs_model.grad_backend,
         hessian_backend = obs_model.hess_backend,
         pointwise_loglik_func = obs_model.pointwise_loglik_func,
+        diagonal_hessian_safe = obs_model.diagonal_hessian_safe,
     )
 end
 
@@ -311,7 +344,7 @@ function loggrad(x, obs_lik::AutoDiffLikelihood)
 end
 
 function loghessian(x, obs_lik::AutoDiffLikelihood)
-    if obs_lik.pointwise_loglik_func !== nothing
+    if obs_lik.diagonal_hessian_safe && obs_lik.pointwise_loglik_func !== nothing
         return _diagonal_hessian_via_pointwise(x, obs_lik)
     end
     f = _build_call(obs_lik)
@@ -319,15 +352,16 @@ function loghessian(x, obs_lik::AutoDiffLikelihood)
     return DI.hessian(f, prep, obs_lik.hess_backend, x)
 end
 
-# Pointwise structured-Hessian fast path. For conditionally-independent
-# observation likelihoods (which `pointwise_loglik_func` declares):
+# Pointwise structured-Hessian fast path. Gated on the user's
+# `diagonal_hessian_safe` assertion: only valid when each pointwise term
+# `i` depends solely on `x[i]`, so
 #
 #   loglik(x) = sum_i pointwise[i](x_i; y_i, θ)
 #
-# the Hessian is diagonal with `H[i,i] = ∂²pointwise[i]/∂x_i²`. Each entry
-# is a 1D second derivative — the cleanest case for nested AD — so this
-# path also doubles as the friction-free route for outer-AD callers (no
-# DI nested-Dual prep machinery to navigate).
+# and the Hessian is diagonal with `H[i,i] = ∂²pointwise[i]/∂x_i²`. Each
+# entry is a 1D second derivative — the cleanest case for nested AD —
+# so this path also doubles as the friction-free route for outer-AD
+# callers (no DI nested-Dual prep machinery to navigate).
 function _diagonal_hessian_via_pointwise(x, obs_lik::AutoDiffLikelihood)
     pf = _build_pointwise_call(obs_lik)
     n = length(x)

--- a/test/observation_models/test_autodiff_likelihood.jl
+++ b/test/observation_models/test_autodiff_likelihood.jl
@@ -117,11 +117,8 @@ using ForwardDiff
     end
 
     @testset "Pointwise Hessian fast path returns Diagonal" begin
-        # With BOTH `pointwise_loglik_func` and `diagonal_hessian_safe = true`,
-        # loghessian short-circuits to a per-element 1D second-derivative path
-        # that returns `Diagonal` directly — bypassing DI.hessian entirely.
-        # Doubles as the nested-AD-friendly route since 1D second derivatives
-        # nest cleanly.
+        # With both `pointwise_loglik_func` set and `diagonal_hessian_safe = true`,
+        # loghessian returns a `Diagonal` via per-element 1D second derivatives.
         using LinearAlgebra: Diagonal
 
         function loglik_sum(x; y, σ)
@@ -159,14 +156,10 @@ using ForwardDiff
     end
 
     @testset "Diagonal-Hessian shortcut is opt-in (issue #102)" begin
-        # Pointwise availability does NOT imply diagonal Hessian. For
-        # `y[i] ~ Normal(Aᵢᵀ x, σ)` the per-observation term `i` depends on
-        # every `x[j]` with `A[i,j] ≠ 0`, so the Hessian is `A' diag(...) A`,
-        # not `Diagonal(...)`. With `diagonal_hessian_safe` defaulting to
-        # `false`, `loghessian` must return the full (correct) Hessian.
+        # `y[i] ~ Normal(Aᵢᵀ x, σ)`: pointwise term `i` mixes latent components,
+        # so the Hessian is `-A'A/σ²`, not diagonal.
         using LinearAlgebra: Diagonal
 
-        # Linear predictor mixes both latent components in every observation.
         A = [
             1.0 0.5;
             0.5 1.0;
@@ -189,7 +182,6 @@ using ForwardDiff
             grad_backend = DI.AutoForwardDiff(),
             hessian_backend = DI.AutoForwardDiff(),
             pointwise_loglik_func = lp_pointwise,
-            # diagonal_hessian_safe defaults to `false`
         )
 
         y_data = [1.0, 2.0, 1.5]
@@ -200,20 +192,11 @@ using ForwardDiff
         H_full = loghessian(x, obs_lik_unsafe)
         H_expected = -A' * A / σ^2
 
-        # Default path returns the full Hessian, not a diagonal stub.
         @test !(H_full isa Diagonal)
         @test H_full ≈ H_expected
-        # Off-diagonal must be present and nonzero — the bug was returning 0 here.
         @test abs(H_full[1, 2]) > 1.0e-3
-
-        # Sanity: diagonal entries also differ from what the broken shortcut
-        # would have produced (the shortcut only sums one observation term per i).
-        # H_full[1,1] = -sum(A[:,1].^2)/σ²; broken[1,1] would have been -A[1,1]²/σ².
         @test H_full[1, 1] ≈ -sum(A[:, 1] .^ 2) / σ^2
-        @test H_full[1, 1] != -A[1, 1]^2 / σ^2
 
-        # Opting in flips back to the (now wrong-for-this-model) diagonal path.
-        # Verifies the gate, not correctness — user is asserting the safety.
         obs_model_optedin = AutoDiffObservationModel(
             lp_loglik;
             n_latent = 2,

--- a/test/observation_models/test_autodiff_likelihood.jl
+++ b/test/observation_models/test_autodiff_likelihood.jl
@@ -117,10 +117,11 @@ using ForwardDiff
     end
 
     @testset "Pointwise Hessian fast path returns Diagonal" begin
-        # When `pointwise_loglik_func` is set, loghessian short-circuits to
-        # a per-element 1D second-derivative path that returns `Diagonal`
-        # directly — bypassing DI.hessian entirely. Doubles as the
-        # nested-AD-friendly route since 1D second derivatives nest cleanly.
+        # With BOTH `pointwise_loglik_func` and `diagonal_hessian_safe = true`,
+        # loghessian short-circuits to a per-element 1D second-derivative path
+        # that returns `Diagonal` directly — bypassing DI.hessian entirely.
+        # Doubles as the nested-AD-friendly route since 1D second derivatives
+        # nest cleanly.
         using LinearAlgebra: Diagonal
 
         function loglik_sum(x; y, σ)
@@ -137,6 +138,7 @@ using ForwardDiff
             grad_backend = DI.AutoForwardDiff(),
             hessian_backend = DI.AutoForwardDiff(),
             pointwise_loglik_func = loglik_pointwise,
+            diagonal_hessian_safe = true,
         )
 
         y_data = [1.0, 2.0, 3.0, 4.0]
@@ -154,5 +156,74 @@ using ForwardDiff
         v = [1.0, 0.0, 0.0, 0.0]
         val = ForwardDiff.derivative(t -> sum(loghessian(x .+ t .* v, obs_lik)), 0.0)
         @test val ≈ 0.0  # H is constant in x for the Gaussian case
+    end
+
+    @testset "Diagonal-Hessian shortcut is opt-in (issue #102)" begin
+        # Pointwise availability does NOT imply diagonal Hessian. For
+        # `y[i] ~ Normal(Aᵢᵀ x, σ)` the per-observation term `i` depends on
+        # every `x[j]` with `A[i,j] ≠ 0`, so the Hessian is `A' diag(...) A`,
+        # not `Diagonal(...)`. With `diagonal_hessian_safe` defaulting to
+        # `false`, `loghessian` must return the full (correct) Hessian.
+        using LinearAlgebra: Diagonal
+
+        # Linear predictor mixes both latent components in every observation.
+        A = [
+            1.0 0.5;
+            0.5 1.0;
+            0.7 0.3;
+        ]
+
+        function lp_loglik(x; y, σ, A)
+            r = y .- A * x
+            return -0.5 * sum(r .^ 2) / σ^2
+        end
+        function lp_pointwise(x; y, σ, A)
+            r = y .- A * x
+            return -0.5 .* (r .^ 2) ./ σ^2
+        end
+
+        obs_model_unsafe = AutoDiffObservationModel(
+            lp_loglik;
+            n_latent = 2,
+            hyperparams = (:σ, :A),
+            grad_backend = DI.AutoForwardDiff(),
+            hessian_backend = DI.AutoForwardDiff(),
+            pointwise_loglik_func = lp_pointwise,
+            # diagonal_hessian_safe defaults to `false`
+        )
+
+        y_data = [1.0, 2.0, 1.5]
+        σ = 0.5
+        x = [0.7, 1.1]
+        obs_lik_unsafe = obs_model_unsafe(y_data; σ = σ, A = A)
+
+        H_full = loghessian(x, obs_lik_unsafe)
+        H_expected = -A' * A / σ^2
+
+        # Default path returns the full Hessian, not a diagonal stub.
+        @test !(H_full isa Diagonal)
+        @test H_full ≈ H_expected
+        # Off-diagonal must be present and nonzero — the bug was returning 0 here.
+        @test abs(H_full[1, 2]) > 1.0e-3
+
+        # Sanity: diagonal entries also differ from what the broken shortcut
+        # would have produced (the shortcut only sums one observation term per i).
+        # H_full[1,1] = -sum(A[:,1].^2)/σ²; broken[1,1] would have been -A[1,1]²/σ².
+        @test H_full[1, 1] ≈ -sum(A[:, 1] .^ 2) / σ^2
+        @test H_full[1, 1] != -A[1, 1]^2 / σ^2
+
+        # Opting in flips back to the (now wrong-for-this-model) diagonal path.
+        # Verifies the gate, not correctness — user is asserting the safety.
+        obs_model_optedin = AutoDiffObservationModel(
+            lp_loglik;
+            n_latent = 2,
+            hyperparams = (:σ, :A),
+            grad_backend = DI.AutoForwardDiff(),
+            hessian_backend = DI.AutoForwardDiff(),
+            pointwise_loglik_func = lp_pointwise,
+            diagonal_hessian_safe = true,
+        )
+        obs_lik_optedin = obs_model_optedin(y_data; σ = σ, A = A)
+        @test loghessian(x, obs_lik_optedin) isa Diagonal
     end
 end


### PR DESCRIPTION
Closes #102.

## Summary

`AutoDiffLikelihood`'s `loghessian` previously took the diagonal-only fast path whenever `pointwise_loglik_func` was set. The pointwise decomposition is *by observation*, not by latent component — `loglik(x) = ∑ᵢ ℓᵢ(x)` does not imply that `ℓᵢ` depends only on `x[i]`. For any model with a non-trivial linear predictor (`y[i] ~ Family(Aᵢᵀ x)`) the Hessian is dense, and the old shortcut returned a wrong (diagonal) Hessian — both dropping off-diagonals and miscomputing the diagonal entries (only one observation's contribution was summed into each `H[i,i]`). Downstream Laplace approximations using this Hessian got the wrong posterior precision, silently.

## Why the two concerns are conflated

A `pointwise_loglik_func` is needed for two orthogonal reasons:
1. **WAIC/CPO accumulators** want per-observation log-likelihood (always safe to ask for).
2. **Diagonal-Hessian fast path** wants a structural assertion about the model (`y[i] ~ Family(x[i])`).

Conflating them meant any user who wanted (1) silently got (2) — even when (2) was wrong for their model.

## Changes

- New `diagonal_hessian_safe::Bool` field on both `AutoDiffObservationModel` and `AutoDiffLikelihood` (default `false`).
- `loghessian` gates the per-element 1D second-derivative shortcut on `diagonal_hessian_safe && pointwise_loglik_func !== nothing`. Default behavior is now `DI.hessian` — correct, just not as fast.
- One-shot `@info` (via `maxlog=1`) when `AutoDiffLikelihood` is constructed with `pointwise_loglik_func` set but `diagonal_hessian_safe = false`, so existing users notice the change and can opt back in.
- Flag threads through the factory call (`obs_model(y; ...)`) and the IFT rebuild path (`_rebuild_autodiff_likelihood` in the ForwardDiff extension).
- Updated IFT extension error messages that previously said "supply `pointwise_loglik_func`" to now say "supply `pointwise_loglik_func` AND set `diagonal_hessian_safe = true`".

## Tests

- Existing `Pointwise Hessian fast path returns Diagonal` test now passes `diagonal_hessian_safe = true` explicitly.
- New test `Diagonal-Hessian shortcut is opt-in (issue #102)` constructs a model with a 3×2 design matrix `A` so the per-observation pointwise terms genuinely mix latent components. Verifies that:
  - The default path returns the full dense Hessian, equal to `-Aᵀ A / σ²`.
  - The off-diagonal entry is non-trivially nonzero (the bug returned 0 here).
  - The diagonal entry matches `-∑ₖ A[k,1]² / σ²` rather than the broken-shortcut's `-A[1,1]² / σ²`.
  - Opting in (`diagonal_hessian_safe = true`) flips back to a `Diagonal` return — verifying the gate, not correctness.

## Backward compatibility

Behavior changes for users who relied on the implicit shortcut. The previous behavior was silently wrong for any non-trivial design; this PR forces the user to assert structural safety. Users with `y[i] ~ Family(x[i])` setups (the only case where the shortcut was correct) recover the speed by passing `diagonal_hessian_safe = true`. The `@info` notice surfaces the change on first construction.

## Test plan

- [x] Existing tests in `test/observation_models/test_autodiff_likelihood.jl` updated and passing locally
- [x] New regression test added for non-diagonal pointwise case
- [x] IFT path tests in `test/observation_models/test_autodiff_likelihood_ift.jl` unaffected (they don't use `pointwise_loglik_func`)
- [x] `runic` pre-commit formatting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)