### PR TITLE
Add hyperparameters trait to CompositeObservationModel and CompositeLikelihood

### DIFF
--- a/src/observation_models/composite/composite_observation_model.jl
+++ b/src/observation_models/composite/composite_observation_model.jl
@@ -77,12 +77,18 @@ contributions from all component likelihoods.
 
 # Fields
 - `components::T`: Tuple of materialized component likelihoods
+- `hyperparameter_names::Tuple{Vararg{Symbol}}`: Outer hyperparameter names that were
+  used to materialize this likelihood (matches `hyperparameters` on the source model).
 """
 struct CompositeLikelihood{T <: Tuple} <: ObservationLikelihood
     components::T
+    hyperparameter_names::Tuple{Vararg{Symbol}}
 
-    function CompositeLikelihood(components::T) where {T <: Tuple}
-        return new{T}(components)
+    function CompositeLikelihood(
+            components::T,
+            hyperparameter_names::Tuple{Vararg{Symbol}} = (),
+        ) where {T <: Tuple}
+        return new{T}(components, hyperparameter_names)
     end
 end
 
@@ -112,8 +118,26 @@ function (composite_model::CompositeObservationModel)(y::CompositeObservations; 
         _materialize_component(model, route, y_comp, nt)
     end
 
-    return CompositeLikelihood(component_likelihoods)
+    return CompositeLikelihood(component_likelihoods, hyperparameters(composite_model))
 end
+
+function hyperparameters(model::CompositeObservationModel)
+    out = Symbol[]
+    for (component, route) in zip(model.components, model.routes)
+        if route === nothing
+            for s in hyperparameters(component)
+                s in out || push!(out, s)
+            end
+        else
+            for outer in values(route)
+                outer in out || push!(out, outer)
+            end
+        end
+    end
+    return Tuple(out)
+end
+
+hyperparameters(lik::CompositeLikelihood) = lik.hyperparameter_names
 
 # COV_EXCL_START
 function Base.show(io::IO, model::CompositeObservationModel)

--- a/test/observation_models/composite/test_composite_routing.jl
+++ b/test/observation_models/composite/test_composite_routing.jl
@@ -117,6 +117,75 @@ using Distributions: Normal, Poisson
         @inferred loghessian(x, composite_lik)
     end
 
+    @testset "hyperparameters trait" begin
+        gaussian_model = ExponentialFamily(Normal)
+        poisson_model = ExponentialFamily(Poisson)
+
+        @testset "Passthrough route reports component hyperparameters" begin
+            composite_model = CompositeObservationModel((gaussian_model, poisson_model))
+            @test hyperparameters(composite_model) == (:σ,)
+
+            y_composite = CompositeObservations(([1.0, 2.0], PoissonObservations([3, 4])))
+            composite_lik = composite_model(y_composite; σ = 1.5)
+            @test hyperparameters(composite_lik) == (:σ,)
+        end
+
+        @testset "Passthrough with shared kwarg deduplicates" begin
+            composite_model = CompositeObservationModel((gaussian_model, gaussian_model))
+            @test hyperparameters(composite_model) == (:σ,)
+
+            y_composite = CompositeObservations(([1.0, 2.0], [3.0, 4.0]))
+            composite_lik = composite_model(y_composite; σ = 2.0)
+            @test hyperparameters(composite_lik) == (:σ,)
+        end
+
+        @testset "Routes report outer names" begin
+            composite_model = CompositeObservationModel(
+                (gaussian_model, gaussian_model),
+                ((σ = :σ_phys,), (σ = :σ_data,)),
+            )
+            @test hyperparameters(composite_model) == (:σ_phys, :σ_data)
+
+            y_composite = CompositeObservations(([0.5, 1.5], [10.0, 20.0]))
+            composite_lik = composite_model(y_composite; σ_phys = 0.1, σ_data = 5.0)
+            @test hyperparameters(composite_lik) == (:σ_phys, :σ_data)
+        end
+
+        @testset "Route collision deduplicates outer names" begin
+            composite_model = CompositeObservationModel(
+                (gaussian_model, gaussian_model),
+                ((σ = :σ_shared,), (σ = :σ_shared,)),
+            )
+            @test hyperparameters(composite_model) == (:σ_shared,)
+
+            y_composite = CompositeObservations(([1.0, 2.0], [3.0, 4.0]))
+            composite_lik = composite_model(y_composite; σ_shared = 1.0)
+            @test hyperparameters(composite_lik) == (:σ_shared,)
+        end
+
+        @testset "Mixed routing combines outer names and passthrough hps" begin
+            composite_model = CompositeObservationModel(
+                (gaussian_model, poisson_model),
+                ((σ = :σ_obs,), nothing),
+            )
+            @test hyperparameters(composite_model) == (:σ_obs,)
+
+            y_composite = CompositeObservations(([1.0, 2.0], PoissonObservations([3, 4])))
+            composite_lik = composite_model(y_composite; σ_obs = 0.7)
+            @test hyperparameters(composite_lik) == (:σ_obs,)
+        end
+
+        @testset "Passthrough preserves component hp despite identical name in route" begin
+            # Component 1 has a route σ -> :σ; component 2 is passthrough with σ.
+            # Both ultimately surface :σ as the outer name; result should dedupe.
+            composite_model = CompositeObservationModel(
+                (gaussian_model, gaussian_model),
+                ((σ = :σ,), nothing),
+            )
+            @test hyperparameters(composite_model) == (:σ,)
+        end
+    end
+
     @testset "Show method skips trivial routes, displays explicit ones" begin
         gaussian_model = ExponentialFamily(Normal)
         poisson_model = ExponentialFamily(Poisson)


### PR DESCRIPTION
## Summary

- Adds `hyperparameters(::CompositeObservationModel)` returning the union of routed outer names and passthrough-component hps, deduplicated.
- Adds `hyperparameters(::CompositeLikelihood)` so introspection works on the materialized likelihood. The hp name tuple is captured at materialization time and stored on the likelihood.
- New testset covers passthrough, shared-kwarg dedup, routed outer names, route collision dedup, mixed routing, and a route+passthrough name-clash edge case.

## Why

`hyperparameters(::ObservationModel)` was already defined for every concrete subtype (`ExponentialFamily`, `LinearlyTransformedObservationModel`, `AutoDiffObservationModel`, `NonlinearLeastSquaresModel`) except `CompositeObservationModel`. Code that uses the trait to validate an hp spec against the model (e.g. checking required hps are present) would hit `MethodError` on composite models. With the per-component routing API landed in #96, the natural answer is the union of outer kwarg names — `Symbol[]` accumulator with `s in out || push!(out, s)` for dedupe.

## Notes for reviewer

- `CompositeLikelihood` gained one field, `hyperparameter_names::Tuple{Vararg{Symbol}}`. The inner constructor defaults it to `()`, so any external code constructing a `CompositeLikelihood` directly without the new arg keeps working (and reports no hps, matching the field default). The only internal caller — the model materialization — passes `hyperparameters(composite_model)`.
- No type parameter change; `CompositeLikelihood{T}` is unchanged. Type stability of `loglik`/`loggrad`/`loghessian` is unaffected (verified by the existing `@inferred` testset).
- Closes #103.

## Test plan

- [x] Added `hyperparameters trait` testset under `CompositeObservationModel routing` covering the four acceptance criteria.
- [x] Ran the full `test/observation_models/composite/` suite — 77/77 pass.
- [x] End-to-end smoke check confirms `pointwise_loglik` on a `CompositeLikelihood` still iterates components correctly with the new field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)