### PR TITLE
Recurse through LinearlyTransformedLikelihood in IFT helpers

### DIFF
--- a/ext/forwarddiff/autodiff_likelihood_dual.jl
+++ b/ext/forwarddiff/autodiff_likelihood_dual.jl
@@ -82,3 +82,10 @@ _primal_obs_lik(lik::GMRFs.AutoDiffLikelihood) =
 function _primal_obs_lik(lik::GMRFs.CompositeLikelihood)
     return GMRFs.CompositeLikelihood(map(_primal_obs_lik, lik.components))
 end
+
+function _primal_obs_lik(lik::GMRFs.LinearlyTransformedLikelihood)
+    return GMRFs.LinearlyTransformedLikelihood(
+        _primal_obs_lik(lik.base_likelihood),
+        lik.design_matrix,
+    )
+end

--- a/ext/forwarddiff/autodiff_likelihood_ift.jl
+++ b/ext/forwarddiff/autodiff_likelihood_ift.jl
@@ -50,6 +50,8 @@ _lik_carries_dual_hp(lik::GMRFs.AutoDiffLikelihood) = _is_dual_autodifflik(lik)
 _lik_carries_dual_hp(::_DualObsLik) = true
 _lik_carries_dual_hp(lik::GMRFs.CompositeLikelihood) =
     any(_lik_carries_dual_hp, lik.components)
+_lik_carries_dual_hp(lik::GMRFs.LinearlyTransformedLikelihood) =
+    _lik_carries_dual_hp(lik.base_likelihood)
 
 # ----------------------------------------------------------------------------
 # DI.hessian returns a dense Matrix even when the underlying Hessian is
@@ -64,6 +66,10 @@ _lik_carries_dual_hp(lik::GMRFs.CompositeLikelihood) =
 
 _maybe_downcast_diagonal(H::Diagonal) = H
 _maybe_downcast_diagonal(H::SparseMatrixCSC) = H
+# `LinearlyTransformedLikelihood.loghessian` returns `Symmetric(A' * hess_η * A)`,
+# whose underlying matrix is fully populated by the multiplication. Unwrap so the
+# downstream sparse-vs-dense dispatch sees the real storage type.
+_maybe_downcast_diagonal(H::Symmetric) = _maybe_downcast_diagonal(parent(H))
 function _maybe_downcast_diagonal(H::AbstractMatrix)
     n = size(H, 1)
     n == size(H, 2) || return H
@@ -232,6 +238,9 @@ function _lik_dual_tag_npartials(lik::_DualObsLik)
     D = _dual_type_from_obs_lik(lik)
     return ForwardDiff.tagtype(D), ForwardDiff.npartials(D)
 end
+
+_lik_dual_tag_npartials(lik::GMRFs.LinearlyTransformedLikelihood) =
+    _lik_dual_tag_npartials(lik.base_likelihood)
 
 function _lik_dual_tag_npartials(lik::GMRFs.CompositeLikelihood)
     Tag, N = nothing, nothing

--- a/test/observation_models/test_workspace_dualhp_ift.jl
+++ b/test/observation_models/test_workspace_dualhp_ift.jl
@@ -484,6 +484,53 @@ using FiniteDiff, ForwardDiff
         @test maximum(abs.(grad_fwd - grad_fd)) < 1.0e-3
     end
 
+    @testset "Float64 prior + Composite of LTL-wrapped Dual NormalLikelihood (issue #110)" begin
+        # The unified IFT helpers must recurse through `LinearlyTransformedLikelihood`.
+        # Each composite component is `LTL(NormalLikelihood{Dual})`; without LTL
+        # recursion in `_lik_carries_dual_hp` / `_primal_obs_lik` the dispatch
+        # falls back to the primal Newton path and dies on a Dual Hessian
+        # `setindex!` into the Float64 workspace.
+        Random.seed!(160)
+        n_latent = 3
+        k_phys, k_data = 8, 5
+        A_phys = sparse(randn(k_phys, n_latent))
+        A_data = sparse(randn(k_data, n_latent))
+        y_phys = randn(k_phys)
+        y_data = randn(k_data)
+        x_eval = randn(n_latent)
+
+        # Prior Q must have a sparsity pattern that subsumes the LTL-induced
+        # `A' diag(...) A` Hessian (dense `n_latent × n_latent`). A diagonal
+        # prior would trip the `_sparse_hessian_map` pattern check before the
+        # IFT recursion ever runs.
+        Q_prior = sparse(2.0I + 0.1 * (ones(n_latent, n_latent) - I))
+        ws = GMRFWorkspace(Q_prior)
+        prior = WorkspaceGMRF(zeros(n_latent), Q_prior, ws)
+
+        m_norm = ExponentialFamily(Normal)
+        components = (
+            LinearlyTransformedObservationModel(m_norm, A_phys),
+            LinearlyTransformedObservationModel(m_norm, A_data),
+        )
+        composite = CompositeObservationModel(
+            components,
+            ((σ = :σ_phys,), (σ = :σ_data,)),
+        )
+        y_composite = CompositeObservations((y_phys, y_data))
+
+        function pipeline(θ)
+            obs_lik = composite(y_composite; σ_phys = exp(θ[1]), σ_data = exp(θ[2]))
+            posterior = gaussian_approximation(prior, obs_lik)
+            return logpdf(posterior, x_eval)
+        end
+
+        θ = [log(0.3), log(1.2)]
+        grad_fwd = DifferentiationInterface.gradient(pipeline, AutoForwardDiff(), θ)
+        grad_fd = DifferentiationInterface.gradient(pipeline, fd_backend, θ)
+        @test all(isfinite, grad_fwd)
+        @test maximum(abs.(grad_fwd - grad_fd)) < 1.0e-3
+    end
+
     @testset "Tag-mismatch error paths" begin
         # The IFT collectors guard against partials from independent outer
         # ForwardDiff passes silently mixing. Verify the three error


### PR DESCRIPTION
Fixes #110.

## Summary
- The `WorkspaceGMRF{Float64}` + Dual-hp obs IFT dispatch didn't recognise `LinearlyTransformedLikelihood` as a wrapper that may carry inner Duals. A composite of LTL-wrapped per-channel likelihoods fell back to the primal Newton path and crashed assigning Dual Hessian entries into the Float64 workspace.
- Three traits now recurse through LTL alongside the existing `CompositeLikelihood` recursion: `_lik_carries_dual_hp` (IFT gating), `_lik_dual_tag_npartials` (Tag/N extraction), `_primal_obs_lik` (Dual stripping for the primal Newton pass).
- Plus a small unwrap in `_maybe_downcast_diagonal` so LTL's `Symmetric(A' * hess_η * A)` Hessian routes to the sparse-pattern-subset branch of `_assemble_q_post_dual` instead of the dense-error branch.

## Notes vs. the issue
- The proposed patch in #110 listed two helpers; the third — `_lik_dual_tag_npartials` — is also required, otherwise the IFT helper sees a Dual lik but can't recover its Tag/N and errors with "IFT path invoked with no Dual partials in either prior or likelihood".
- The `Symmetric` unwrap is needed because LTL's loghessian returns `Symmetric(A' * hess_η * A)`. Without it the IFT path dies in `_assemble_q_post_dual`'s dense-error branch even though the underlying matrix is sparse.
- The reproducer in #110 used `Q_prior = sparse(0.01I, 3, 3)` — that diagonal pattern would trip `_sparse_hessian_map`'s subset check before the IFT recursion ever runs. The new test uses a prior-Q whose pattern subsumes the LTL Hessian; this is a separate workspace-reuse constraint, not part of the IFT fix.

## Test plan
- [x] New testset in `test/observation_models/test_workspace_dualhp_ift.jl` mirroring the issue reproducer (composite of two LTL-wrapped Dual NormalLikelihoods, ForwardDiff vs FiniteDiff cross-check)
- [x] Full `WorkspaceGMRF dual-hp IFT` testset: 41 / 41 (40 existing + 1 new)
- [x] `runic` formatter clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)