### PR TITLE
Clarify ConstrainedGMRF precision_map docstring (#122)

### DIFF
--- a/src/arithmetic/constrained.jl
+++ b/src/arithmetic/constrained.jl
@@ -158,11 +158,19 @@ mean(d::ConstrainedGMRF) = d.constrained_mean
 """
     precision_map(d::ConstrainedGMRF)
 
-Return the precision map of the constrained GMRF.
-Note: This is singular due to the constraints, but we return it for interface compliance.
-In practice, this should rarely be used directly due to singularity.
+Return the precision map of the *unconstrained* base GMRF.
+
+The precision of the constrained distribution `x | Ax = e` is rank-deficient
+(its null space is spanned by the columns of `A'`), so there is no canonical
+non-singular precision matrix to return. The base precision is what the
+unnormalised log-density on the constraint manifold uses,
+
+    log p(x | Ax = e) ∝ -0.5 (x - μ)' Q (x - μ)   for x with Ax = e,
+
+so generic methods like [`sqmahal`](@ref) and [`gradlogpdf`](@ref) give the
+correct values when evaluated at points that satisfy the constraint.
 """
-precision_map(d::ConstrainedGMRF) = precision_map(d.base_gmrf)  # TODO: Return constrained precision
+precision_map(d::ConstrainedGMRF) = precision_map(d.base_gmrf)
 
 """
     _rand!(rng::AbstractRNG, d::ConstrainedGMRF, x::AbstractVector)

--- a/src/arithmetic/constrained.jl
+++ b/src/arithmetic/constrained.jl
@@ -167,8 +167,8 @@ unnormalised log-density on the constraint manifold uses,
 
     log p(x | Ax = e) ∝ -0.5 (x - μ)' Q (x - μ)   for x with Ax = e,
 
-so generic methods like [`sqmahal`](@ref) and [`gradlogpdf`](@ref) give the
-correct values when evaluated at points that satisfy the constraint.
+so generic methods like `sqmahal` and `gradlogpdf` give the correct values
+when evaluated at points that satisfy the constraint.
 """
 precision_map(d::ConstrainedGMRF) = precision_map(d.base_gmrf)
 

--- a/test/test_constrained_gmrf.jl
+++ b/test/test_constrained_gmrf.jl
@@ -65,10 +65,11 @@ using Random
         end
 
         @testset "Precision map" begin
+            # The constrained precision is singular, so we deliberately return
+            # the base precision — it's what density methods need on the
+            # constraint manifold.
             Q_constrained = precision_map(constrained)
             @test size(Q_constrained) == (4, 4)
-            # For now, we return the base precision map (TODO: implement proper constrained precision)
-            # This is a placeholder implementation
             @test Q_constrained == precision_map(base_gmrf)
         end
     end


### PR DESCRIPTION
## Summary

Resolves [#122](https://github.com/timweiland/GaussianMarkovRandomFields.jl/issues/122) (JOSS review item #9 from [#114](https://github.com/timweiland/GaussianMarkovRandomFields.jl/issues/114)).

The `precision_map(::ConstrainedGMRF)` method had a `TODO: Return constrained precision` comment that suggested the wrong matrix is currently being returned. In reality, the constrained distribution's precision is rank-deficient by construction (its null space is spanned by the columns of `A'`), so there is no canonical non-singular precision matrix to return. The existing behaviour — returning the base precision — is actually the right choice: on the constraint manifold, the unnormalised log-density is `-0.5 (x - μ)' Q (x - μ)`, so generic methods like `sqmahal` and `gradlogpdf` give correct values at constraint-satisfying points.

The previous docstring also incorrectly claimed the returned matrix "is singular due to the constraints" — but the code returns the *base* precision, which is not singular. This PR replaces the misleading TODO and docstring with an accurate explanation, and updates the stale test comment to match.

No behaviour change.

## Test plan

- [x] Existing `@testset "Precision map"` still passes (no behavioural change).