### PR TITLE
Merge ForwardDiff extensions, split Zygote into its own

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -45,7 +45,6 @@ StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [extensions]
-GaussianMarkovRandomFieldsAutoDiff = ["ForwardDiff", "Zygote"]
 GaussianMarkovRandomFieldsEnzyme = "Enzyme"
 GaussianMarkovRandomFieldsFormula = "StatsModels"
 GaussianMarkovRandomFieldsForwardDiff = "ForwardDiff"
@@ -55,6 +54,7 @@ GaussianMarkovRandomFieldsPardiso = "Pardiso"
 GaussianMarkovRandomFieldsShapefile = "Shapefile"
 GaussianMarkovRandomFieldsSparseADLikelihoods = ["SparseConnectivityTracer", "SparseMatrixColorings"]
 GaussianMarkovRandomFieldsSparseJacobian = ["Symbolics", "SparseDiffTools"]
+GaussianMarkovRandomFieldsZygote = "Zygote"
 
 [compat]
 AMD = "0.5"

--- a/ext/GaussianMarkovRandomFieldsForwardDiff.jl
+++ b/ext/GaussianMarkovRandomFieldsForwardDiff.jl
@@ -5,14 +5,20 @@
 module GaussianMarkovRandomFieldsForwardDiff
 
 import GaussianMarkovRandomFields as GMRFs
-import GaussianMarkovRandomFields: GMRF
+import GaussianMarkovRandomFields: GMRF, ADJacobianMap
 import Distributions: logdetcov
 
 using ForwardDiff
 using LinearAlgebra
 using LinearMaps
+import LinearMaps: _unsafe_mul!
 using LinearSolve
 using SparseArrays
+
+function LinearMaps._unsafe_mul!(y, J::ADJacobianMap, x::AbstractVector)
+    g(t) = J.f(J.x₀ + t * x)
+    return y .= ForwardDiff.derivative(g, 0.0)
+end
 
 include("forwarddiff/common.jl")
 include("forwarddiff/gmrf_constructors.jl")

--- a/ext/GaussianMarkovRandomFieldsZygote.jl
+++ b/ext/GaussianMarkovRandomFieldsZygote.jl
@@ -1,13 +1,8 @@
-module GaussianMarkovRandomFieldsAutoDiff
+module GaussianMarkovRandomFieldsZygote
 
 using GaussianMarkovRandomFields
-using ForwardDiff, Zygote, LinearAlgebra, LinearMaps
+using LinearAlgebra, LinearMaps, Zygote
 import LinearMaps: _unsafe_mul!
-
-function LinearMaps._unsafe_mul!(y, J::ADJacobianMap, x::AbstractVector)
-    g(t) = J.f(J.x₀ + t * x)
-    return y .= ForwardDiff.derivative(g, 0.0)
-end
 
 function GaussianMarkovRandomFields.ADJacobianAdjointMap(
         f::Function,


### PR DESCRIPTION
Closes #118.

The old `GaussianMarkovRandomFieldsAutoDiff` extension required both ForwardDiff and Zygote despite its name, and overlapped with `GaussianMarkovRandomFieldsForwardDiff`. This PR cleans that up:

- The ForwardDiff-only piece — the `ADJacobianMap` JVP — moves into `GaussianMarkovRandomFieldsForwardDiff`.
- The Zygote-only pieces — the `ADJacobianAdjointMap` constructor and its VJP — move into a new `GaussianMarkovRandomFieldsZygote` extension, mirroring how Enzyme and Mooncake are handled.

Users who only want forward-mode JVPs no longer pull Zygote, and vice versa. No public API changes; the existing AD-Jacobian test already loads both packages so both methods remain available.