### PR TITLE
Properly deprecate condition_on_observations

### DIFF
--- a/docs/src/literate-tutorials/boundary_conditions.jl
+++ b/docs/src/literate-tutorials/boundary_conditions.jl
@@ -111,8 +111,8 @@ ys_ic = exp.(-xs_ic .^ 2 / 0.2^2)
 A_ic = evaluation_matrix(disc, [Tensors.Vec(x) for x in xs_ic])
 A_ic = spatial_to_spatiotemporal(A_ic, 1, N_t)
 
-x_adv_diff_dirichlet = condition_on_observations(x_adv_diff_dirichlet, A_ic, 1.0e8, ys_ic)
-x_adv_diff_periodic = condition_on_observations(x_adv_diff_periodic, A_ic, 1.0e8, ys_ic)
+x_adv_diff_dirichlet = linear_condition(x_adv_diff_dirichlet; A = A_ic, Q_ϵ = 1.0e8, y = ys_ic)
+x_adv_diff_periodic = linear_condition(x_adv_diff_periodic; A = A_ic, Q_ϵ = 1.0e8, y = ys_ic)
 
 # First, check the initial observations:
 plot(x_adv_diff_dirichlet, 1)

--- a/docs/src/literate-tutorials/spatiotemporal_modelling.jl
+++ b/docs/src/literate-tutorials/spatiotemporal_modelling.jl
@@ -89,7 +89,7 @@ Q_noise = sparse(I, N_obs_all, N_obs_all) * noise_precision_initial
 Q_noise[end, end] = noise_precision_later
 
 # Condition on the observations:
-x_st_kron_posterior = condition_on_observations(x_st_kron, A_all, Q_noise, ys_all)
+x_st_kron_posterior = linear_condition(x_st_kron; A = A_all, Q_ϵ = Q_noise, y = ys_all)
 
 # Let's look at the dynamics of this posterior.
 using CairoMakie
@@ -136,7 +136,7 @@ adv_diff_spde = AdvectionDiffusionSPDE{1}(
 x_adv_diff = discretize(adv_diff_spde, disc, ts)
 
 # Condition on the initial observations:
-x_adv_diff_posterior = condition_on_observations(x_adv_diff, A_all, Q_noise, ys_all)
+x_adv_diff_posterior = linear_condition(x_adv_diff; A = A_all, Q_ϵ = Q_noise, y = ys_all)
 
 # Let's look at the dynamics of this posterior.
 plot(x_adv_diff_posterior, t_initial_idx)

--- a/docs/src/reference/gmrfs.md
+++ b/docs/src/reference/gmrfs.md
@@ -19,7 +19,6 @@ GMRFMetadata
 
 ## Arithmetic
 ```@docs
-condition_on_observations
 linear_condition
 joint_gmrf
 ```

--- a/src/adv_diff_example.jl
+++ b/src/adv_diff_example.jl
@@ -29,10 +29,10 @@ E_total = [E; E₂]
 
 N_ic = length(ic_vals_total)
 Q_ϵ = sparse(1.0e10 * I, (N_ic, N_ic))
-X_cond = condition_on_observations(X, E_total, Q_ϵ, ic_vals_total)
+X_cond = linear_condition(X; A = E_total, Q_ϵ = Q_ϵ, y = ic_vals_total)
 
 # X₀ = X.ssm.x₀
-# X₀_cond = condition_on_observations(X₀, E_spatial, Q_ϵ, ic_vals)
+# X₀_cond = linear_condition(X₀; A = E_spatial, Q_ϵ = Q_ϵ, y = ic_vals)
 # pred₀ = Array(mean(X₀_cond))
 # G = G = sparse(X.ssm.G(0.005))
 # M = sparse(X.ssm.M(0.005))

--- a/src/arithmetic/condition/linear.jl
+++ b/src/arithmetic/condition/linear.jl
@@ -1,8 +1,6 @@
 using LinearMaps
 
 export linear_condition
-# DEPRECATED:
-export condition_on_observations
 
 """
     prepare_map(Q_prior, x) -> x_converted
@@ -74,52 +72,21 @@ end
 ####################
 ##   DEPRECATED   ##
 ####################
-""""
-    condition_on_observations(
-        x::GMRF,
-        A::Union{AbstractMatrix,LinearMap},
-        Q_ϵ::Union{AbstractMatrix,LinearMap,Real},
-        y::AbstractVector=zeros(size(A)[1]),
-        b::AbstractVector=zeros(size(A)[1]);
-        # solver_blueprint parameter removed - no longer needed with LinearSolve
-    )
+@deprecate condition_on_observations(
+    x::GMRF,
+    A::Union{AbstractMatrix, LinearMap},
+    Q_ϵ::Union{AbstractMatrix, LinearMap, Real},
+    y::AbstractVector = zeros(size(A, 1)),
+    b::AbstractVector = zeros(size(A, 1))
+) linear_condition(x; A = A, Q_ϵ = Q_ϵ, y = y, b = b)
 
-Condition a GMRF `x` on observations `y = A * x + b + ϵ` where `ϵ ~ N(0, Q_ϵ⁻¹)`.
-
-# Arguments
-- `x::GMRF`: The GMRF to condition on.
-- `A::Union{AbstractMatrix,LinearMap}`: The matrix `A`.
-- `Q_ϵ::Union{AbstractMatrix,LinearMap, Real}`: The precision matrix of the
-         noise term `ϵ`. In case a real number is provided, it is interpreted
-         as a scalar multiple of the identity matrix.
-- `y::AbstractVector=zeros(size(A)[1])`: The observations `y`; optional.
-- `b::AbstractVector=zeros(size(A)[1])`: Offset vector `b`; optional.
-
-# Keyword arguments
-# Note: solver_blueprint parameter removed - no longer needed with LinearSolve.jl
-
-# Returns
-A `GMRF` object representing the conditional GMRF `x | (y = A * x + b + ϵ)`.
-
-# Notes
-This function is deprecated. Use `linear_condition`.
-"""
-function condition_on_observations(
-        x::GMRF,
-        A::Union{AbstractMatrix, LinearMap},
-        Q_ϵ::Union{AbstractMatrix, LinearMap, Real},
-        y::AbstractVector = zeros(size(A, 1)),
-        b::AbstractVector = zeros(size(A, 1))
-        # solver_blueprint parameter removed - no longer needed with LinearSolve
-    )
-    # Delegate to new linear_condition function
-    return linear_condition(x; A = A, Q_ϵ = Q_ϵ, y = y, b = b)
-end
-
-function condition_on_observations(mgmrf::MetaGMRF, args...; kwargs...)
-    conditioned_gmrf = condition_on_observations(mgmrf.gmrf, args...; kwargs...)
-    return MetaGMRF(conditioned_gmrf, mgmrf.metadata)
-end
+@deprecate condition_on_observations(
+    mgmrf::MetaGMRF,
+    A::Union{AbstractMatrix, LinearMap},
+    Q_ϵ::Union{AbstractMatrix, LinearMap, Real},
+    y::AbstractVector = zeros(size(A, 1)),
+    b::AbstractVector = zeros(size(A, 1))
+) linear_condition(mgmrf; A = A, Q_ϵ = Q_ϵ, y = y, b = b)
 
 # ConstrainedGMRF linear conditioning - apply conditioning to base GMRF then re-constrain
 function linear_condition(constrained_gmrf::ConstrainedGMRF; kwargs...)

--- a/test/mesh/test_scattered.jl
+++ b/test/mesh/test_scattered.jl
@@ -63,7 +63,7 @@ end
     Λ_obs = 10.0
     A_train = evaluation_matrix(disc, [Tensors.Vec(x...) for x in X_train])
     A_test = evaluation_matrix(disc, [Tensors.Vec(x...) for x in X_test])
-    u_cond = condition_on_observations(u_matern, A_train, Λ_obs, y_train)
+    u_cond = linear_condition(u_matern; A = A_train, Q_ϵ = Λ_obs, y = y_train)
 
     rmse = (a, b) -> sqrt(mean((a .- b) .^ 2))
     @test rmse(A_test * mean(u_cond), y_test) < 0.25

--- a/test/spatiotemporal/test_advection_diffusion.jl
+++ b/test/spatiotemporal/test_advection_diffusion.jl
@@ -91,9 +91,9 @@ using SparseArrays
     get_peak_final = x_posterior -> xs[argmax(A_last * mean(x_posterior))]
 
     @testset "Advection" begin
-        x_cond_fast_right = condition_on_observations(x_prior_fast_right, A_ic, 1.0e8, ys)
-        x_cond_fast_left = condition_on_observations(x_prior_fast_left, A_ic, 1.0e8, ys)
-        x_cond_fast_static = condition_on_observations(x_prior_fast_static, A_ic, 1.0e8, ys)
+        x_cond_fast_right = linear_condition(x_prior_fast_right; A = A_ic, Q_ϵ = 1.0e8, y = ys)
+        x_cond_fast_left = linear_condition(x_prior_fast_left; A = A_ic, Q_ϵ = 1.0e8, y = ys)
+        x_cond_fast_static = linear_condition(x_prior_fast_static; A = A_ic, Q_ϵ = 1.0e8, y = ys)
 
         peak_right_initial = get_peak_initial(x_cond_fast_right)
         peak_right_final = get_peak_final(x_cond_fast_right)
@@ -110,8 +110,8 @@ using SparseArrays
     end
 
     @testset "Diffusion" begin
-        x_cond_slow_static = condition_on_observations(x_prior_slow_static, A_ic, 1.0e8, ys)
-        x_cond_fast_static = condition_on_observations(x_prior_fast_static, A_ic, 1.0e8, ys)
+        x_cond_slow_static = linear_condition(x_prior_slow_static; A = A_ic, Q_ϵ = 1.0e8, y = ys)
+        x_cond_fast_static = linear_condition(x_prior_fast_static; A = A_ic, Q_ϵ = 1.0e8, y = ys)
 
         final_vals_slow = A_last * mean(x_cond_slow_static)
         final_vals_fast = A_last * mean(x_cond_fast_static)
@@ -123,12 +123,12 @@ using SparseArrays
         x_prior_fast_right_periodic =
             GaussianMarkovRandomFields.discretize(spde_fast_right, disc_periodic, ts; streamline_diffusion = sd)
         x_cond_fast_right_periodic =
-            condition_on_observations(x_prior_fast_right_periodic, A_ic, 1.0e8, ys)
+            linear_condition(x_prior_fast_right_periodic; A = A_ic, Q_ϵ = 1.0e8, y = ys)
 
         x_prior_fast_right_dirichlet =
             GaussianMarkovRandomFields.discretize(spde_fast_right, disc_dirichlet, ts; streamline_diffusion = sd)
         x_cond_fast_right_dirichlet =
-            condition_on_observations(x_prior_fast_right_dirichlet, A_ic, 1.0e8, ys)
+            linear_condition(x_prior_fast_right_dirichlet; A = A_ic, Q_ϵ = 1.0e8, y = ys)
 
         N_samples = 3
         samples_periodic = [time_rands(x_cond_fast_right_periodic, rng) for _ in 1:N_samples]

--- a/test/spdes/test_matern.jl
+++ b/test/spdes/test_matern.jl
@@ -52,8 +52,8 @@ using LinearAlgebra
             A_eval = evaluation_matrix(disc, [Tensors.Vec(fill(0.0, d)...)])
             y = [1.0]
 
-            x_high_cond = condition_on_observations(x_high_range, A_eval, 1.0e8, y)
-            x_low_cond = condition_on_observations(x_low_range, A_eval, 1.0e8, y)
+            x_high_cond = linear_condition(x_high_range; A = A_eval, Q_ϵ = 1.0e8, y = y)
+            x_low_cond = linear_condition(x_low_range; A = A_eval, Q_ϵ = 1.0e8, y = y)
 
             A_test = evaluation_matrix(disc, [Tensors.Vec(fill(0.5, d)...)])
             @test A_test * mean(x_high_cond) > A_test * mean(x_low_cond) .+ 0.1

--- a/test/test_gmrf_arithmetic.jl
+++ b/test/test_gmrf_arithmetic.jl
@@ -1,4 +1,5 @@
 using GaussianMarkovRandomFields, Ferrite, Random, LinearAlgebra, SparseArrays
+using Test: @test_deprecated
 
 @testset "GMRF arithmetic" begin
     spde = MaternSPDE{2}(κ = 1.0, ν = 1)
@@ -42,8 +43,19 @@ using GaussianMarkovRandomFields, Ferrite, Random, LinearAlgebra, SparseArrays
         y = randn(rng, 5)
         b = randn(rng, 5)
         x1 = x
-        x2 = condition_on_observations(x1, A, Q_ϵ, y, b)
+        x2 = linear_condition(x1; A = A, Q_ϵ = Q_ϵ, y = y, b = b)
         @test A * mean(x2) ≈ y - b
         @test mean(var(x2)) < mean(var(x1))
+    end
+
+    @testset "condition_on_observations deprecation" begin
+        A = sprand(rng, 5, length(x.mean), 0.3)
+        Q_ϵ = sparse(1.0e12 * I, 5, 5)
+        y = randn(rng, 5)
+        b = randn(rng, 5)
+        expected = linear_condition(x; A = A, Q_ϵ = Q_ϵ, y = y, b = b)
+        actual = @test_deprecated condition_on_observations(x, A, Q_ϵ, y, b)
+        @test mean(actual) ≈ mean(expected)
+        @test precision_matrix(actual) ≈ precision_matrix(expected)
     end
 end

--- a/test/test_metagmrf.jl
+++ b/test/test_metagmrf.jl
@@ -1,5 +1,6 @@
 using GaussianMarkovRandomFields
 using LinearAlgebra, SparseArrays, Random, Distributions
+using Test: @test_deprecated
 
 @testset "MetaGMRF Tests" begin
     # Setup base GMRF for testing
@@ -83,19 +84,25 @@ using LinearAlgebra, SparseArrays, Random, Distributions
         @test conditioned.metadata.name == "test"
         @test conditioned.metadata.value == 42
 
-        # Test condition_on_observations preserves wrapper type
-        conditioned2 = condition_on_observations(meta_gmrf, E, Q_eps, y)
-        @test isa(conditioned2, MetaGMRF{TestMetadata})
-        @test conditioned2.metadata === metadata
-
         # Test that conditioning actually changed the mean
         @test abs(mean(conditioned)[1] - 1.0) < 0.1
         @test mean(conditioned) != mean(meta_gmrf)
 
         # Test conditioning chain preserves type
-        conditioned3 = condition_on_observations(conditioned2, E, Q_eps, [0.5])
+        conditioned3 = linear_condition(conditioned; A = E, Q_ϵ = Q_eps, y = [0.5])
         @test isa(conditioned3, MetaGMRF{TestMetadata})
         @test conditioned3.metadata === metadata
+    end
+
+    @testset "condition_on_observations deprecation" begin
+        E = sparse([1.0 0 0 zeros(1, 7)...])
+        Q_eps = 1.0e4
+        y = [1.0]
+        expected = linear_condition(meta_gmrf; A = E, Q_ϵ = Q_eps, y = y)
+        actual = @test_deprecated condition_on_observations(meta_gmrf, E, Q_eps, y)
+        @test isa(actual, MetaGMRF{TestMetadata})
+        @test actual.metadata === metadata
+        @test mean(actual) ≈ mean(expected)
     end
 
     @testset "Show Methods" begin


### PR DESCRIPTION
Closes #121 (part of the JOSS review in #114, item 8).

## Summary
- Replace the hand-written `condition_on_observations` wrapper in [src/arithmetic/condition/linear.jl](src/arithmetic/condition/linear.jl) with `@deprecate` macros for the `GMRF` and `MetaGMRF` methods, so callers now get a real runtime deprecation warning pointing at `linear_condition` instead of just a docstring note.
- Migrate every internal caller (`src/adv_diff_example.jl`, the two literate tutorials, and five test files) over to `linear_condition` so the library's own code, tests, and docs don't trigger the warning.
- Add `@test_deprecated` coverage in `test/test_gmrf_arithmetic.jl` and `test/test_metagmrf.jl` that asserts the warning fires and the deprecated path still produces the same result as `linear_condition`.
- Drop `condition_on_observations` from `docs/src/reference/gmrfs.md`, since the `@deprecate` form no longer carries a docstring for Documenter to render.

## Test plan
- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` passes locally
- [x] Docs build succeeds (no missing docstring error for `condition_on_observations`)