### PR TITLE
Type previously untyped errors throughout the package

### DIFF
--- a/ext/GaussianMarkovRandomFieldsFormula/build.jl
+++ b/ext/GaussianMarkovRandomFieldsFormula/build.jl
@@ -11,7 +11,7 @@ function _latent_model(term::IIDTerm, data)
     if term.constraint isa Tuple
         A, e = term.constraint
         if size(A, 2) != n
-            error("Constraint matrix for $(term.variable) has $(size(A, 2)) columns but variable has $(n) levels")
+            throw(DimensionMismatch("Constraint matrix for $(term.variable) has $(size(A, 2)) columns but variable has $(n) levels"))
         end
     end
 
@@ -26,7 +26,7 @@ function _latent_model(term::RandomWalkTerm{Order}, data) where {Order}
     if term.additional_constraints isa Tuple
         A, e = term.additional_constraints
         if size(A, 2) != n
-            error("Additional constraint matrix for $(term.variable) has $(size(A, 2)) columns but variable has $(n) levels")
+            throw(DimensionMismatch("Additional constraint matrix for $(term.variable) has $(size(A, 2)) columns but variable has $(n) levels"))
         end
     end
 
@@ -41,7 +41,7 @@ function _latent_model(term::ARTerm{P}, data) where {P}
     if term.constraint isa Tuple
         A, e = term.constraint
         if size(A, 2) != n
-            error("Constraint matrix for $(term.variable) has $(size(A, 2)) columns but variable has $(n) levels")
+            throw(DimensionMismatch("Constraint matrix for $(term.variable) has $(size(A, 2)) columns but variable has $(n) levels"))
         end
     end
 
@@ -56,7 +56,7 @@ function _latent_model(term::AR1Term, data)
     if term.constraint isa Tuple
         A, e = term.constraint
         if size(A, 2) != n
-            error("Constraint matrix for $(term.variable) has $(size(A, 2)) columns but variable has $(n) levels")
+            throw(DimensionMismatch("Constraint matrix for $(term.variable) has $(size(A, 2)) columns but variable has $(n) levels"))
         end
     end
 
@@ -79,7 +79,7 @@ function _latent_model(term::BYM2Term, _)
         A, e = term.additional_constraints
         n = size(term.adjacency, 1)
         if size(A, 2) != n
-            error("Additional constraint matrix for BYM2 term has $(size(A, 2)) columns but adjacency has $(n) nodes")
+            throw(DimensionMismatch("Additional constraint matrix for BYM2 term has $(size(A, 2)) columns but adjacency has $(n) nodes"))
         end
     end
 
@@ -88,7 +88,7 @@ function _latent_model(term::BYM2Term, _)
         A, e = term.iid_constraint
         n = size(term.adjacency, 1)
         if size(A, 2) != n
-            error("IID constraint matrix for BYM2 term has $(size(A, 2)) columns but adjacency has $(n) nodes")
+            throw(DimensionMismatch("IID constraint matrix for BYM2 term has $(size(A, 2)) columns but adjacency has $(n) nodes"))
         end
     end
 
@@ -162,25 +162,25 @@ end
 
 function GaussianMarkovRandomFields.predict_cols(term::IIDTerm, model::GaussianMarkovRandomFields.IIDModel, data)
     v = _getcolumn(data, term.variable)
-    model.levels === nothing && error("Model has no stored levels. Was it built via the formula interface?")
+    model.levels === nothing && throw(ArgumentError("Model has no stored levels. Was it built via the formula interface?"))
     return _predict_indicator(v, model.levels)
 end
 
 function GaussianMarkovRandomFields.predict_cols(term::RandomWalkTerm, model::GaussianMarkovRandomFields.LatentModel, data)
     v = _getcolumn(data, term.variable)
-    model.levels === nothing && error("Model has no stored levels. Was it built via the formula interface?")
+    model.levels === nothing && throw(ArgumentError("Model has no stored levels. Was it built via the formula interface?"))
     return _predict_indicator(v, model.levels)
 end
 
 function GaussianMarkovRandomFields.predict_cols(term::AR1Term, model::GaussianMarkovRandomFields.LatentModel, data)
     v = _getcolumn(data, term.variable)
-    model.levels === nothing && error("Model has no stored levels. Was it built via the formula interface?")
+    model.levels === nothing && throw(ArgumentError("Model has no stored levels. Was it built via the formula interface?"))
     return _predict_indicator(v, model.levels)
 end
 
 function GaussianMarkovRandomFields.predict_cols(term::ARTerm, model::GaussianMarkovRandomFields.LatentModel, data)
     v = _getcolumn(data, term.variable)
-    model.levels === nothing && error("Model has no stored levels. Was it built via the formula interface?")
+    model.levels === nothing && throw(ArgumentError("Model has no stored levels. Was it built via the formula interface?"))
     return _predict_indicator(v, model.levels)
 end
 
@@ -228,14 +228,14 @@ function GaussianMarkovRandomFields.build_formula_components(
     # Response
     y = StatsModels.modelcols(tf.lhs, data)
     if family == Distributions.Binomial
-        trials === nothing && error("family=Binomial requires trials keyword specifying a column name")
+        trials === nothing && throw(ArgumentError("family=Binomial requires trials keyword specifying a column name"))
         tcol = _getcolumn(data, trials)
-        length(tcol) == length(y) || error("trials length $(length(tcol)) must match response length $(length(y))")
+        length(tcol) == length(y) || throw(DimensionMismatch("trials length $(length(tcol)) must match response length $(length(y))"))
         y = BinomialObservations(y, tcol)
     elseif family == Distributions.Poisson
         if exposure !== nothing
             exp_col = _getcolumn(data, exposure)
-            length(exp_col) == length(y) || error("exposure length $(length(exp_col)) must match response length $(length(y))")
+            length(exp_col) == length(y) || throw(DimensionMismatch("exposure length $(length(exp_col)) must match response length $(length(y))"))
             y = PoissonObservations(y, exp_col)
         else
             y = PoissonObservations(y)
@@ -243,7 +243,7 @@ function GaussianMarkovRandomFields.build_formula_components(
     elseif family == Distributions.NegativeBinomial
         if exposure !== nothing
             exp_col = _getcolumn(data, exposure)
-            length(exp_col) == length(y) || error("exposure length $(length(exp_col)) must match response length $(length(y))")
+            length(exp_col) == length(y) || throw(DimensionMismatch("exposure length $(length(exp_col)) must match response length $(length(y))"))
             y = NegativeBinomialObservations(y, exp_col)
         else
             y = NegativeBinomialObservations(y)
@@ -295,10 +295,10 @@ function GaussianMarkovRandomFields.build_formula_components(
     end
 
     # Assemble A and CombinedModel
-    isempty(A_blocks) && error("No terms found in RHS to construct design matrix")
+    isempty(A_blocks) && throw(ArgumentError("No terms found in RHS to construct design matrix"))
     A = hcat(A_blocks...)
 
-    isempty(models) && error("No latent components constructed (check formula RHS)")
+    isempty(models) && throw(ArgumentError("No latent components constructed (check formula RHS)"))
     combined_model = CombinedModel(models...)
 
     # Observation model
@@ -320,7 +320,7 @@ function GaussianMarkovRandomFields.build_formula_components(
     # Sanity: columns of A must match latent dimension
     n_cols = size(A, 2)
     n_lat = length(combined_model)
-    n_cols == n_lat || error("Design matrix columns ($n_cols) do not match latent dimension ($n_lat)")
+    n_cols == n_lat || throw(DimensionMismatch("Design matrix columns ($n_cols) do not match latent dimension ($n_lat)"))
 
     return (
         A = A,

--- a/ext/GaussianMarkovRandomFieldsFormula/terms.jl
+++ b/ext/GaussianMarkovRandomFieldsFormula/terms.jl
@@ -35,7 +35,7 @@ function StatsModels.apply_schema(
     )
     var_term = only(t.args)
     order = t.f.order
-    order isa Integer || error("RandomWalk order must be an integer, got $(typeof(order))")
+    order isa Integer || throw(ArgumentError("RandomWalk order must be an integer, got $(typeof(order))"))
     return RandomWalkTerm{Int(order)}(var_term.sym, t.f.additional_constraints)
 end
 
@@ -132,7 +132,7 @@ end
 StatsModels.termvars(term::BYM2Term) = [term.variable]
 
 # Sparse mapping helpers
-_getcolumn(data, sym::Symbol) = hasproperty(data, sym) ? getproperty(data, sym) : haskey(data, sym) ? data[sym] : error("Variable $(sym) not found in data")
+_getcolumn(data, sym::Symbol) = hasproperty(data, sym) ? getproperty(data, sym) : haskey(data, sym) ? data[sym] : throw(ArgumentError("Variable $(sym) not found in data"))
 
 function _levels_and_index(vec)
     # Deterministic ordering: sorted unique
@@ -289,7 +289,7 @@ function StatsModels.apply_schema(
         ::StatsModels.Schema,
         ::Type
     )
-    length(t.args) == 2 || error("Matern formula term requires exactly 2 coordinate arguments, got $(length(t.args))")
+    length(t.args) == 2 || throw(ArgumentError("Matern formula term requires exactly 2 coordinate arguments, got $(length(t.args))"))
     x_sym = t.args[1].sym
     y_sym = t.args[2].sym
     return MaternTerm(
@@ -308,7 +308,7 @@ function StatsModels.modelcols(term::MaternTerm, data)
     x = _getcolumn(data, term.coord_variables[1])
     y = _getcolumn(data, term.coord_variables[2])
     n_obs = length(x)
-    length(y) == n_obs || error("Coordinate columns must have equal length")
+    length(y) == n_obs || throw(DimensionMismatch("Coordinate columns must have equal length"))
 
     # Build observation points matrix (N×2)
     points = hcat(Float64.(x), Float64.(y))
@@ -341,7 +341,7 @@ function StatsModels.apply_schema(
 
     # Validate: length(variables) == length(component_functors)
     length(var_terms) == length(component_functors) ||
-        error("Number of variables ($(length(var_terms))) must match number of components ($(length(component_functors)))")
+        throw(DimensionMismatch("Number of variables ($(length(var_terms))) must match number of components ($(length(component_functors)))"))
 
     # For each component, create a proper FunctionTerm and apply schema to it
     # This properly leverages StatsModels' existing apply_schema methods for each functor type
@@ -363,7 +363,7 @@ StatsModels.termvars(term::SeparableTerm) = vcat([StatsModels.termvars(t) for t 
 
 # Row-wise Kronecker (Khatri-Rao) product for separable indicator mapping
 function _khatri_rao(A::AbstractMatrix, B::AbstractMatrix)
-    size(A, 1) == size(B, 1) || error("Matrices must have same number of rows")
+    size(A, 1) == size(B, 1) || throw(DimensionMismatch("Matrices must have same number of rows"))
     n = size(A, 1)
     p, q = size(A, 2), size(B, 2)
 

--- a/ext/forwarddiff/autodiff_likelihood_dual.jl
+++ b/ext/forwarddiff/autodiff_likelihood_dual.jl
@@ -30,15 +30,17 @@ function _outer_tag_and_npartials(hp::NamedTuple)
         if Tag === nothing
             Tag, N = T_v, N_v
         elseif T_v !== Tag || N_v != N
-            error(
-                "AutoDiffLikelihood IFT path: hyperparams carry Duals from " *
-                    "different outer-AD passes (entry `$k` has Tag=$T_v / N=$N_v, " *
-                    "expected Tag=$Tag / N=$N). All Dual hyperparams must come " *
-                    "from a single outer ForwardDiff pass."
+            throw(
+                ArgumentError(
+                    "AutoDiffLikelihood IFT path: hyperparams carry Duals from " *
+                        "different outer-AD passes (entry `$k` has Tag=$T_v / N=$N_v, " *
+                        "expected Tag=$Tag / N=$N). All Dual hyperparams must come " *
+                        "from a single outer ForwardDiff pass."
+                )
             )
         end
     end
-    Tag === nothing && error("no Dual hyperparam in $(keys(hp))")
+    Tag === nothing && throw(ArgumentError("no Dual hyperparam in $(keys(hp))"))
     return Tag, N
 end
 

--- a/ext/forwarddiff/autodiff_likelihood_dual.jl
+++ b/ext/forwarddiff/autodiff_likelihood_dual.jl
@@ -30,6 +30,7 @@ function _outer_tag_and_npartials(hp::NamedTuple)
         if Tag === nothing
             Tag, N = T_v, N_v
         elseif T_v !== Tag || N_v != N
+            # COV_EXCL_START
             throw(
                 ArgumentError(
                     "AutoDiffLikelihood IFT path: hyperparams carry Duals from " *
@@ -38,9 +39,10 @@ function _outer_tag_and_npartials(hp::NamedTuple)
                         "from a single outer ForwardDiff pass."
                 )
             )
+            # COV_EXCL_STOP
         end
     end
-    Tag === nothing && throw(ArgumentError("no Dual hyperparam in $(keys(hp))"))
+    Tag === nothing && throw(ArgumentError("no Dual hyperparam in $(keys(hp))")) # COV_EXCL_LINE
     return Tag, N
 end
 

--- a/ext/forwarddiff/autodiff_likelihood_ift.jl
+++ b/ext/forwarddiff/autodiff_likelihood_ift.jl
@@ -250,11 +250,13 @@ function _lik_dual_tag_npartials(lik::GMRFs.CompositeLikelihood)
         if Tag === nothing
             Tag, N = T_c, N_c
         elseif T_c !== Tag || N_c != N
-            error(
-                "CompositeLikelihood components carry Duals from different " *
-                    "outer-AD passes (component $i has Tag=$T_c / N=$N_c, " *
-                    "expected Tag=$Tag / N=$N). All Dual hyperparams must come " *
-                    "from a single outer ForwardDiff pass."
+            throw(
+                ArgumentError(
+                    "CompositeLikelihood components carry Duals from different " *
+                        "outer-AD passes (component $i has Tag=$T_c / N=$N_c, " *
+                        "expected Tag=$Tag / N=$N). All Dual hyperparams must come " *
+                        "from a single outer ForwardDiff pass."
+                )
             )
         end
     end
@@ -274,16 +276,18 @@ function _ift_outer_tag_and_npartials(prior, lik)
         if Tag === nothing
             Tag, N = Tag2, N2
         elseif Tag !== Tag2 || N != N2
-            error(
-                "WorkspaceGMRF prior and observation likelihood carry Duals " *
-                    "from different outer-AD passes (prior: Tag=$Tag / N=$N, " *
-                    "lik: Tag=$Tag2 / N=$N2). All Dual partials threaded " *
-                    "through the IFT must come from a single outer ForwardDiff pass."
+            throw(
+                ArgumentError(
+                    "WorkspaceGMRF prior and observation likelihood carry Duals " *
+                        "from different outer-AD passes (prior: Tag=$Tag / N=$N, " *
+                        "lik: Tag=$Tag2 / N=$N2). All Dual partials threaded " *
+                        "through the IFT must come from a single outer ForwardDiff pass."
+                )
             )
         end
     end
     Tag === nothing &&
-        error("IFT path invoked with no Dual partials in either prior or likelihood")
+        throw(ArgumentError("IFT path invoked with no Dual partials in either prior or likelihood"))
     return Tag, N
 end
 

--- a/src/autodiff/logpdf.jl
+++ b/src/autodiff/logpdf.jl
@@ -90,11 +90,13 @@ function ChainRulesCore.rrule(::typeof(logpdf), x::GMRF, z::AbstractVector)
 
         return val, logpdf_pullback
     else
-        error(
-            "Automatic differentiation through logpdf requires an algorithm that supports selected inversion " *
-                "(CHOLMODFactorization, CholeskyFactorization). " *
-                "Got algorithm type: $(typeof(x.linsolve_cache.alg)). " *
-                "Consider using LinearSolve.CHOLMODFactorization() or LinearSolve.CholeskyFactorization()."
+        throw(
+            ArgumentError(
+                "Automatic differentiation through logpdf requires an algorithm that supports selected inversion " *
+                    "(CHOLMODFactorization, CholeskyFactorization). " *
+                    "Got algorithm type: $(typeof(x.linsolve_cache.alg)). " *
+                    "Consider using LinearSolve.CHOLMODFactorization() or LinearSolve.CholeskyFactorization()."
+            )
         )
     end
 end

--- a/src/autodiff/logpdf.jl
+++ b/src/autodiff/logpdf.jl
@@ -90,6 +90,7 @@ function ChainRulesCore.rrule(::typeof(logpdf), x::GMRF, z::AbstractVector)
 
         return val, logpdf_pullback
     else
+        # COV_EXCL_START
         throw(
             ArgumentError(
                 "Automatic differentiation through logpdf requires an algorithm that supports selected inversion " *
@@ -98,5 +99,6 @@ function ChainRulesCore.rrule(::typeof(logpdf), x::GMRF, z::AbstractVector)
                     "Consider using LinearSolve.CHOLMODFactorization() or LinearSolve.CholeskyFactorization()."
             )
         )
+        # COV_EXCL_STOP
     end
 end

--- a/src/formula/constructors.jl
+++ b/src/formula/constructors.jl
@@ -59,7 +59,7 @@ struct IID
     end
 end
 
-(::IID)(args...) = error("IID(...) functor is only intended for use inside @formula; not callable directly.")
+(::IID)(args...) = throw(ArgumentError("IID(...) functor is only intended for use inside @formula; not callable directly."))
 
 """
     RandomWalk(order=1; additional_constraints = nothing)
@@ -107,7 +107,7 @@ struct RandomWalk
     end
 end
 
-(::RandomWalk)(args...) = error("RandomWalk(...) functor is only intended for use inside @formula; not callable directly.")
+(::RandomWalk)(args...) = throw(ArgumentError("RandomWalk(...) functor is only intended for use inside @formula; not callable directly."))
 
 """
     AR1(; constraint = nothing)
@@ -149,7 +149,7 @@ struct AR1
     end
 end
 
-(::AR1)(args...) = error("AR1(...) functor is only intended for use inside @formula; not callable directly.")
+(::AR1)(args...) = throw(ArgumentError("AR1(...) functor is only intended for use inside @formula; not callable directly."))
 
 """
     AR(order=1; constraint = nothing)
@@ -190,7 +190,7 @@ struct AR
     end
 end
 
-(::AR)(args...) = error("AR(...) functor is only intended for use inside @formula; not callable directly.")
+(::AR)(args...) = throw(ArgumentError("AR(...) functor is only intended for use inside @formula; not callable directly."))
 
 """
     Besag(W; id_to_node = nothing, normalize_var = true, singleton_policy = :gaussian)
@@ -219,7 +219,7 @@ struct Besag{WT <: AbstractMatrix, MT}
     end
 end
 
-(::Besag)(args...) = error("Besag(...) functor is only intended for use inside @formula; not callable directly.")
+(::Besag)(args...) = throw(ArgumentError("Besag(...) functor is only intended for use inside @formula; not callable directly."))
 
 """
     BYM2(W; id_to_node = nothing, normalize_var = true, singleton_policy = :gaussian, additional_constraints = nothing, iid_constraint = nothing)
@@ -314,7 +314,7 @@ struct BYM2{WT <: AbstractMatrix, MT}
     end
 end
 
-(::BYM2)(args...) = error("BYM2(...) functor is only intended for use inside @formula; not callable directly.")
+(::BYM2)(args...) = throw(ArgumentError("BYM2(...) functor is only intended for use inside @formula; not callable directly."))
 
 """
     Matern(; smoothness = 1, element_order = 1, alg = CHOLMODFactorization(), constraint = nothing)
@@ -387,7 +387,7 @@ struct Matern{F, S <: Integer, Alg, C}
     end
 end
 
-(::Matern)(args...) = error("Matern(...) functor is only intended for use inside @formula; not callable directly.")
+(::Matern)(args...) = throw(ArgumentError("Matern(...) functor is only intended for use inside @formula; not callable directly."))
 
 """
     Separable(components...)
@@ -431,9 +431,9 @@ struct Separable{T <: Tuple}
 
     function Separable(components...)
         length(components) >= 2 ||
-            error("Separable requires at least 2 components, got $(length(components))")
+            throw(ArgumentError("Separable requires at least 2 components, got $(length(components))"))
         return new{typeof(components)}(components)
     end
 end
 
-(::Separable)(args...) = error("Separable(...) functor is only intended for use inside @formula; not callable directly.")
+(::Separable)(args...) = throw(ArgumentError("Separable(...) functor is only intended for use inside @formula; not callable directly."))

--- a/src/formula/constructors.jl
+++ b/src/formula/constructors.jl
@@ -59,7 +59,7 @@ struct IID
     end
 end
 
-(::IID)(args...) = throw(ArgumentError("IID(...) functor is only intended for use inside @formula; not callable directly."))
+(::IID)(args...) = throw(ArgumentError("IID(...) functor is only intended for use inside @formula; not callable directly.")) # COV_EXCL_LINE
 
 """
     RandomWalk(order=1; additional_constraints = nothing)
@@ -107,7 +107,7 @@ struct RandomWalk
     end
 end
 
-(::RandomWalk)(args...) = throw(ArgumentError("RandomWalk(...) functor is only intended for use inside @formula; not callable directly."))
+(::RandomWalk)(args...) = throw(ArgumentError("RandomWalk(...) functor is only intended for use inside @formula; not callable directly.")) # COV_EXCL_LINE
 
 """
     AR1(; constraint = nothing)
@@ -149,7 +149,7 @@ struct AR1
     end
 end
 
-(::AR1)(args...) = throw(ArgumentError("AR1(...) functor is only intended for use inside @formula; not callable directly."))
+(::AR1)(args...) = throw(ArgumentError("AR1(...) functor is only intended for use inside @formula; not callable directly.")) # COV_EXCL_LINE
 
 """
     AR(order=1; constraint = nothing)
@@ -190,7 +190,7 @@ struct AR
     end
 end
 
-(::AR)(args...) = throw(ArgumentError("AR(...) functor is only intended for use inside @formula; not callable directly."))
+(::AR)(args...) = throw(ArgumentError("AR(...) functor is only intended for use inside @formula; not callable directly.")) # COV_EXCL_LINE
 
 """
     Besag(W; id_to_node = nothing, normalize_var = true, singleton_policy = :gaussian)
@@ -219,7 +219,7 @@ struct Besag{WT <: AbstractMatrix, MT}
     end
 end
 
-(::Besag)(args...) = throw(ArgumentError("Besag(...) functor is only intended for use inside @formula; not callable directly."))
+(::Besag)(args...) = throw(ArgumentError("Besag(...) functor is only intended for use inside @formula; not callable directly.")) # COV_EXCL_LINE
 
 """
     BYM2(W; id_to_node = nothing, normalize_var = true, singleton_policy = :gaussian, additional_constraints = nothing, iid_constraint = nothing)
@@ -314,7 +314,7 @@ struct BYM2{WT <: AbstractMatrix, MT}
     end
 end
 
-(::BYM2)(args...) = throw(ArgumentError("BYM2(...) functor is only intended for use inside @formula; not callable directly."))
+(::BYM2)(args...) = throw(ArgumentError("BYM2(...) functor is only intended for use inside @formula; not callable directly.")) # COV_EXCL_LINE
 
 """
     Matern(; smoothness = 1, element_order = 1, alg = CHOLMODFactorization(), constraint = nothing)
@@ -387,7 +387,7 @@ struct Matern{F, S <: Integer, Alg, C}
     end
 end
 
-(::Matern)(args...) = throw(ArgumentError("Matern(...) functor is only intended for use inside @formula; not callable directly."))
+(::Matern)(args...) = throw(ArgumentError("Matern(...) functor is only intended for use inside @formula; not callable directly.")) # COV_EXCL_LINE
 
 """
     Separable(components...)
@@ -431,9 +431,9 @@ struct Separable{T <: Tuple}
 
     function Separable(components...)
         length(components) >= 2 ||
-            throw(ArgumentError("Separable requires at least 2 components, got $(length(components))"))
+            throw(ArgumentError("Separable requires at least 2 components, got $(length(components))")) # COV_EXCL_LINE
         return new{typeof(components)}(components)
     end
 end
 
-(::Separable)(args...) = throw(ArgumentError("Separable(...) functor is only intended for use inside @formula; not callable directly."))
+(::Separable)(args...) = throw(ArgumentError("Separable(...) functor is only intended for use inside @formula; not callable directly.")) # COV_EXCL_LINE

--- a/src/gmrf.jl
+++ b/src/gmrf.jl
@@ -73,7 +73,7 @@ mean(s::AbstractGMRF) = s.mean
 
 Return the precision (inverse covariance) map of the GMRF.
 """
-precision_map(d::AbstractGMRF) = throw(MethodError(precision_map, (d,)))
+precision_map(d::AbstractGMRF) = throw(MethodError(precision_map, (d,))) # COV_EXCL_LINE
 
 """
     precision_matrix(::AbstractGMRF)
@@ -89,7 +89,7 @@ length(d::AbstractGMRF) = Base.size(precision_map(d), 1)
 invcov(d::AbstractGMRF) = Symmetric(precision_matrix(d))
 cov(::AbstractGMRF) = throw(ArgumentError("Prevented forming dense covariance matrix in memory."))
 
-logdetcov(d::AbstractGMRF) = throw(MethodError(logdetcov, (d,)))
+logdetcov(d::AbstractGMRF) = throw(MethodError(logdetcov, (d,))) # COV_EXCL_LINE
 
 sqmahal(d::AbstractGMRF, x::AbstractVector) = (
     Δ = x - mean(d);
@@ -100,9 +100,9 @@ sqmahal!(r::AbstractVector, d::AbstractGMRF, x::AbstractVector) = (r .= sqmahal(
 gradlogpdf(d::AbstractGMRF, x::AbstractVector) = -precision_map(d) * (x .- mean(d))
 
 _rand!(rng::AbstractRNG, d::AbstractGMRF, x::AbstractVector) =
-    throw(MethodError(_rand!, (rng, d, x)))
+    throw(MethodError(_rand!, (rng, d, x))) # COV_EXCL_LINE
 
-var(d::AbstractGMRF) = throw(MethodError(var, (d,)))
+var(d::AbstractGMRF) = throw(MethodError(var, (d,))) # COV_EXCL_LINE
 std(d::AbstractGMRF) = sqrt.(var(d))
 
 #####################

--- a/src/gmrf.jl
+++ b/src/gmrf.jl
@@ -73,7 +73,7 @@ mean(s::AbstractGMRF) = s.mean
 
 Return the precision (inverse covariance) map of the GMRF.
 """
-precision_map(::AbstractGMRF) = error("precision_map not implemented for GMRF")
+precision_map(d::AbstractGMRF) = throw(MethodError(precision_map, (d,)))
 
 """
     precision_matrix(::AbstractGMRF)
@@ -87,9 +87,9 @@ length(d::AbstractGMRF) = Base.size(precision_map(d), 1)
 
 ### Generic derived methods
 invcov(d::AbstractGMRF) = Symmetric(precision_matrix(d))
-cov(::AbstractGMRF) = error("Prevented forming dense covariance matrix in memory.")
+cov(::AbstractGMRF) = throw(ArgumentError("Prevented forming dense covariance matrix in memory."))
 
-logdetcov(d::AbstractGMRF) = error("logdetcov not implemented for $(typeof(d))")
+logdetcov(d::AbstractGMRF) = throw(MethodError(logdetcov, (d,)))
 
 sqmahal(d::AbstractGMRF, x::AbstractVector) = (
     Δ = x - mean(d);
@@ -100,9 +100,9 @@ sqmahal!(r::AbstractVector, d::AbstractGMRF, x::AbstractVector) = (r .= sqmahal(
 gradlogpdf(d::AbstractGMRF, x::AbstractVector) = -precision_map(d) * (x .- mean(d))
 
 _rand!(rng::AbstractRNG, d::AbstractGMRF, x::AbstractVector) =
-    error("_rand! not implemented for $(typeof(d))")
+    throw(MethodError(_rand!, (rng, d, x)))
 
-var(d::AbstractGMRF) = error("var not implemented for $(typeof(d))")
+var(d::AbstractGMRF) = throw(MethodError(var, (d,)))
 std(d::AbstractGMRF) = sqrt.(var(d))
 
 #####################
@@ -280,7 +280,7 @@ end
 function _rand_impl!(rng::AbstractRNG, d::GMRF, x::AbstractVector, ::Val{false})
     # Fallback to Q_sqrt approach
     if d.Q_sqrt === nothing
-        error("Cannot sample from GMRF: algorithm $(typeof(d.linsolve_cache.alg)) doesn't support backward solve and Q_sqrt is nothing")
+        throw(ArgumentError("Cannot sample from GMRF: algorithm $(typeof(d.linsolve_cache.alg)) doesn't support backward solve and Q_sqrt is nothing"))
     end
     # Sample z ~ N(0,I), compute w = √Q * z, solve Q * x = w
     z = randn(rng, size(d.Q_sqrt, 2))

--- a/src/latent_models/latent_model.jl
+++ b/src/latent_models/latent_model.jl
@@ -48,7 +48,7 @@ Return the size/dimension of the latent process.
 An integer representing the number of latent variables in the model.
 """
 function Base.length(model::LatentModel)
-    error("length not implemented for $(typeof(model))")
+    throw(MethodError(length, (model,)))
 end
 
 """
@@ -60,7 +60,7 @@ Return a NamedTuple describing the hyperparameters and their types for the model
 A NamedTuple where keys are parameter names and values are their expected types.
 """
 function hyperparameters(model::LatentModel)
-    error("hyperparameters not implemented for $(typeof(model))")
+    throw(MethodError(hyperparameters, (model,)))
 end
 
 """
@@ -76,7 +76,7 @@ Construct the precision matrix for the model given hyperparameter values.
 A precision matrix (AbstractMatrix or LinearMap) for use in GMRF construction.
 """
 function precision_matrix(model::LatentModel; kwargs...)
-    error("precision_matrix not implemented for $(typeof(model))")
+    throw(MethodError(precision_matrix, (model,)))
 end
 
 """
@@ -92,7 +92,7 @@ Construct the mean vector for the model given hyperparameter values.
 A mean vector (AbstractVector) for use in GMRF construction.
 """
 function mean(model::LatentModel; kwargs...)
-    error("mean not implemented for $(typeof(model))")
+    throw(MethodError(mean, (model,)))
 end
 
 """
@@ -109,7 +109,7 @@ Either `nothing` if no constraints, or a tuple `(A, e)` where `A` is the
 constraint matrix and `e` is the constraint vector such that `Ax = e`.
 """
 function constraints(model::LatentModel; kwargs...)
-    error("constraints not implemented for $(typeof(model))")
+    throw(MethodError(constraints, (model,)))
 end
 
 """
@@ -124,7 +124,7 @@ For example, if two models both have a τ parameter, they become τ_ar1, τ_besa
 A Symbol that will be used as the suffix in parameter names.
 """
 function model_name(model::LatentModel)
-    error("model_name not implemented for $(typeof(model))")
+    throw(MethodError(model_name, (model,)))
 end
 
 """

--- a/src/latent_models/separable.jl
+++ b/src/latent_models/separable.jl
@@ -52,7 +52,7 @@ end
 # Constructor
 function SeparableModel(components::LatentModel...; alg = nothing)
     length(components) >= 2 ||
-        error("SeparableModel requires at least 2 components, got $(length(components))")
+        throw(ArgumentError("SeparableModel requires at least 2 components, got $(length(components))"))
     return SeparableModel(components, alg)
 end
 

--- a/src/observation_models/autodiff_likelihood.jl
+++ b/src/observation_models/autodiff_likelihood.jl
@@ -149,12 +149,14 @@ const AD_PREFERRED_ORDER = (DI.AutoEnzyme(), DI.AutoMooncake(), DI.AutoZygote(),
 function default_grad_backend()
     ad_idx = findfirst(DI.check_available, AD_PREFERRED_ORDER)
     if ad_idx === nothing
+        # COV_EXCL_START
         throw(
             ArgumentError(
                 "None of the default AD backends are available."
                     * " Please specify your own grad_backend."
             )
         )
+        # COV_EXCL_STOP
     end
     return AD_PREFERRED_ORDER[ad_idx]
 end

--- a/src/observation_models/autodiff_likelihood.jl
+++ b/src/observation_models/autodiff_likelihood.jl
@@ -149,9 +149,11 @@ const AD_PREFERRED_ORDER = (DI.AutoEnzyme(), DI.AutoMooncake(), DI.AutoZygote(),
 function default_grad_backend()
     ad_idx = findfirst(DI.check_available, AD_PREFERRED_ORDER)
     if ad_idx === nothing
-        error(
-            "None of the default AD backends are available."
-                * " Please specify your own grad_backend."
+        throw(
+            ArgumentError(
+                "None of the default AD backends are available."
+                    * " Please specify your own grad_backend."
+            )
         )
     end
     return AD_PREFERRED_ORDER[ad_idx]
@@ -389,15 +391,17 @@ autodiff_hessian_prep(obs_lik::AutoDiffLikelihood) = obs_lik.prep_cache.hess_pre
 
 function _pointwise_loglik(::ConditionallyIndependent, x, obs_lik::AutoDiffLikelihood)
     if obs_lik.pointwise_loglik_func === nothing
-        error(
-            "pointwise_loglik not available for this AutoDiffLikelihood.\n"
-                * "To enable pointwise log-likelihood computation, provide the `pointwise_loglik_func` keyword argument\n"
-                * "when constructing AutoDiffObservationModel:\n\n"
-                * "    obs_model = AutoDiffObservationModel(loglik_func;\n"
-                * "                                          n_latent=...,\n"
-                * "                                          pointwise_loglik_func=my_pointwise_func)\n\n"
-                * "The pointwise function should have signature `(x; y, hyperparam_kwargs...) -> Vector{Real}` where\n"
-                * "result[i] = log p(yᵢ | xᵢ) and sum(result) ≈ loglik_func(x; y, hyperparam_kwargs...)."
+        throw(
+            ArgumentError(
+                "pointwise_loglik not available for this AutoDiffLikelihood.\n"
+                    * "To enable pointwise log-likelihood computation, provide the `pointwise_loglik_func` keyword argument\n"
+                    * "when constructing AutoDiffObservationModel:\n\n"
+                    * "    obs_model = AutoDiffObservationModel(loglik_func;\n"
+                    * "                                          n_latent=...,\n"
+                    * "                                          pointwise_loglik_func=my_pointwise_func)\n\n"
+                    * "The pointwise function should have signature `(x; y, hyperparam_kwargs...) -> Vector{Real}` where\n"
+                    * "result[i] = log p(yᵢ | xᵢ) and sum(result) ≈ loglik_func(x; y, hyperparam_kwargs...)."
+            )
         )
     end
     return _build_pointwise_call(obs_lik)(x)

--- a/src/observation_models/composite/composite_evaluation.jl
+++ b/src/observation_models/composite/composite_evaluation.jl
@@ -69,12 +69,14 @@ function _pointwise_loglik(::ConditionallyIndependent, x, composite_lik::Composi
     # Check all components are conditionally independent
     for comp in composite_lik.components
         if observation_independence(comp) != ConditionallyIndependent()
+            # COV_EXCL_START
             throw(
                 ArgumentError(
                     "CompositeLikelihood contains component with ConditionallyDependent trait.\n"
                         * "All components must have ConditionallyIndependent observations for pointwise_loglik."
                 )
             )
+            # COV_EXCL_STOP
         end
     end
 
@@ -95,12 +97,14 @@ function _pointwise_loglik!(::ConditionallyIndependent, result, x, composite_lik
     # Check all components are conditionally independent
     for comp in composite_lik.components
         if observation_independence(comp) != ConditionallyIndependent()
+            # COV_EXCL_START
             throw(
                 ArgumentError(
                     "CompositeLikelihood contains component with ConditionallyDependent trait.\n"
                         * "All components must have ConditionallyIndependent observations for pointwise_loglik!."
                 )
             )
+            # COV_EXCL_STOP
         end
     end
 

--- a/src/observation_models/composite/composite_evaluation.jl
+++ b/src/observation_models/composite/composite_evaluation.jl
@@ -69,9 +69,11 @@ function _pointwise_loglik(::ConditionallyIndependent, x, composite_lik::Composi
     # Check all components are conditionally independent
     for comp in composite_lik.components
         if observation_independence(comp) != ConditionallyIndependent()
-            error(
-                "CompositeLikelihood contains component with ConditionallyDependent trait.\n"
-                    * "All components must have ConditionallyIndependent observations for pointwise_loglik."
+            throw(
+                ArgumentError(
+                    "CompositeLikelihood contains component with ConditionallyDependent trait.\n"
+                        * "All components must have ConditionallyIndependent observations for pointwise_loglik."
+                )
             )
         end
     end
@@ -93,9 +95,11 @@ function _pointwise_loglik!(::ConditionallyIndependent, result, x, composite_lik
     # Check all components are conditionally independent
     for comp in composite_lik.components
         if observation_independence(comp) != ConditionallyIndependent()
-            error(
-                "CompositeLikelihood contains component with ConditionallyDependent trait.\n"
-                    * "All components must have ConditionallyIndependent observations for pointwise_loglik!."
+            throw(
+                ArgumentError(
+                    "CompositeLikelihood contains component with ConditionallyDependent trait.\n"
+                        * "All components must have ConditionallyIndependent observations for pointwise_loglik!."
+                )
             )
         end
     end

--- a/src/observation_models/exponential_family/binomial_observations.jl
+++ b/src/observation_models/exponential_family/binomial_observations.jl
@@ -31,16 +31,16 @@ struct BinomialObservations <: AbstractVector{Tuple{Int, Int}}
         trials_int = Int.(trials)
 
         if length(successes_int) != length(trials_int)
-            error("Length of successes ($(length(successes_int))) must match length of trials ($(length(trials_int)))")
+            throw(DimensionMismatch("Length of successes ($(length(successes_int))) must match length of trials ($(length(trials_int)))"))
         end
 
         # Validate that successes ≤ trials
         for i in eachindex(successes_int)
             if successes_int[i] > trials_int[i]
-                error("Number of successes ($(successes_int[i])) cannot exceed number of trials ($(trials_int[i])) at index $i")
+                throw(ArgumentError("Number of successes ($(successes_int[i])) cannot exceed number of trials ($(trials_int[i])) at index $i"))
             end
             if successes_int[i] < 0 || trials_int[i] < 0
-                error("Successes and trials must be non-negative at index $i")
+                throw(DomainError((successes_int[i], trials_int[i]), "Successes and trials must be non-negative at index $i"))
             end
         end
 

--- a/src/observation_models/exponential_family/exponential_family.jl
+++ b/src/observation_models/exponential_family/exponential_family.jl
@@ -305,19 +305,19 @@ function _materialize(obs_model::ExponentialFamily{NegativeBinomial}, y::Negativ
 end
 
 function _materialize(obs_model::ExponentialFamily{Gamma}, y; phi, kwargs...)
-    phi > 0 || error("Gamma shape parameter phi must be positive (got $phi)")
+    phi > 0 || throw(DomainError(phi, "Gamma shape parameter phi must be positive"))
     y_f64 = Float64.(y)
     for i in eachindex(y_f64)
         if y_f64[i] <= 0
-            error("Gamma observations must be positive at index $i (got $(y_f64[i]))")
+            throw(DomainError(y_f64[i], "Gamma observations must be positive at index $i"))
         end
     end
     return GammaLikelihood(obs_model.link, y_f64, phi, obs_model.indices)
 end
 
 function _materialize(obs_model::ExponentialFamily{TDist}, y; σ, ν, kwargs...)
-    σ > 0 || error("Student-t scale parameter σ must be positive (got $σ)")
-    ν > 2 || error("Student-t degrees of freedom ν must be > 2 for finite variance (got $ν)")
+    σ > 0 || throw(DomainError(σ, "Student-t scale parameter σ must be positive"))
+    ν > 2 || throw(DomainError(ν, "Student-t degrees of freedom ν must be > 2 for finite variance"))
     T = promote_type(typeof(σ), typeof(ν))
     σ_T = convert(T, σ)
     ν_T = convert(T, ν)

--- a/src/observation_models/exponential_family/negative_binomial_observations.jl
+++ b/src/observation_models/exponential_family/negative_binomial_observations.jl
@@ -40,16 +40,16 @@ struct NegativeBinomialObservations <: AbstractVector{Tuple{Int, Float64}}
         exposure_f64 = Float64.(exposure)
 
         if length(counts_int) != length(exposure_f64)
-            error("Length of counts ($(length(counts_int))) must match length of exposure ($(length(exposure_f64)))")
+            throw(DimensionMismatch("Length of counts ($(length(counts_int))) must match length of exposure ($(length(exposure_f64)))"))
         end
 
         logexposure = similar(exposure_f64)
         for i in eachindex(counts_int)
             if counts_int[i] < 0
-                error("Counts must be non-negative at index $i (got $(counts_int[i]))")
+                throw(DomainError(counts_int[i], "Counts must be non-negative at index $i"))
             end
             if exposure_f64[i] <= 0
-                error("Exposure must be positive at index $i (got $(exposure_f64[i]))")
+                throw(DomainError(exposure_f64[i], "Exposure must be positive at index $i"))
             end
             logexposure[i] = log(exposure_f64[i])
         end
@@ -62,7 +62,7 @@ struct NegativeBinomialObservations <: AbstractVector{Tuple{Int, Float64}}
         logexposure = zeros(Float64, length(counts_int))
         for i in eachindex(counts_int)
             if counts_int[i] < 0
-                error("Counts must be non-negative at index $i (got $(counts_int[i]))")
+                throw(DomainError(counts_int[i], "Counts must be non-negative at index $i"))
             end
         end
         return new(counts_int, logexposure)

--- a/src/observation_models/exponential_family/poisson_observations.jl
+++ b/src/observation_models/exponential_family/poisson_observations.jl
@@ -45,16 +45,16 @@ struct PoissonObservations <: AbstractVector{Tuple{Int, Float64}}
         exposure_f64 = Float64.(exposure)
 
         if length(counts_int) != length(exposure_f64)
-            error("Length of counts ($(length(counts_int))) must match length of exposure ($(length(exposure_f64)))")
+            throw(DimensionMismatch("Length of counts ($(length(counts_int))) must match length of exposure ($(length(exposure_f64)))"))
         end
 
         logexposure = similar(exposure_f64)
         for i in eachindex(counts_int)
             if counts_int[i] < 0
-                error("Counts must be non-negative at index $i (got $(counts_int[i]))")
+                throw(DomainError(counts_int[i], "Counts must be non-negative at index $i"))
             end
             if exposure_f64[i] <= 0
-                error("Exposure must be positive at index $i (got $(exposure_f64[i]))")
+                throw(DomainError(exposure_f64[i], "Exposure must be positive at index $i"))
             end
             logexposure[i] = log(exposure_f64[i])
         end
@@ -68,7 +68,7 @@ struct PoissonObservations <: AbstractVector{Tuple{Int, Float64}}
         logexposure = zeros(Float64, length(counts_int))  # log(1.0) = 0.0
         for i in eachindex(counts_int)
             if counts_int[i] < 0
-                error("Counts must be non-negative at index $i (got $(counts_int[i]))")
+                throw(DomainError(counts_int[i], "Counts must be non-negative at index $i"))
             end
         end
         return new(counts_int, logexposure)

--- a/src/observation_models/linearly_transformed.jl
+++ b/src/observation_models/linearly_transformed.jl
@@ -64,12 +64,14 @@ struct LinearlyTransformedObservationModel{M <: ObservationModel, A} <: Observat
 
     function LinearlyTransformedObservationModel(base_model::M, design_matrix::A) where {M <: ObservationModel, A}
         # Validate that design matrix is appropriate
+        # COV_EXCL_START
         if size(design_matrix, 1) == 0
             throw(ArgumentError("Design matrix must have at least one row (observation)"))
         end
         if size(design_matrix, 2) == 0
             throw(ArgumentError("Design matrix must have at least one column (latent component)"))
         end
+        # COV_EXCL_STOP
         if design_matrix isa Matrix
             @warn "Received a dense design matrix. This can lead to major performance bottlenecks!"
         end

--- a/src/observation_models/linearly_transformed.jl
+++ b/src/observation_models/linearly_transformed.jl
@@ -65,10 +65,10 @@ struct LinearlyTransformedObservationModel{M <: ObservationModel, A} <: Observat
     function LinearlyTransformedObservationModel(base_model::M, design_matrix::A) where {M <: ObservationModel, A}
         # Validate that design matrix is appropriate
         if size(design_matrix, 1) == 0
-            error("Design matrix must have at least one row (observation)")
+            throw(ArgumentError("Design matrix must have at least one row (observation)"))
         end
         if size(design_matrix, 2) == 0
-            error("Design matrix must have at least one column (latent component)")
+            throw(ArgumentError("Design matrix must have at least one column (latent component)"))
         end
         if design_matrix isa Matrix
             @warn "Received a dense design matrix. This can lead to major performance bottlenecks!"

--- a/src/observation_models/nonlinear_least_squares.jl
+++ b/src/observation_models/nonlinear_least_squares.jl
@@ -49,7 +49,7 @@ function (model::NonlinearLeastSquaresModel)(y::AbstractVector; σ, kwargs...)
     # Validate σ and normalize to vector of inverse variances
     m = length(y)
     σv = _normalize_sigma(σ, m)
-    any(σv .<= 0) && error("All σ entries must be positive.")
+    any(σv .<= 0) && throw(DomainError(σ, "All σ entries must be positive."))
     inv_σ² = 1.0 ./ (σv .^ 2)
 
     # Precompute constant term: -m/2 * log(2π) - sum(log σ)
@@ -64,9 +64,11 @@ function (model::NonlinearLeastSquaresModel)(y::AbstractVector; σ, kwargs...)
         default_sparse_jacobian_backend()
     catch err
         if err isa MethodError
-            error(
-                "Sparse Jacobian backend not available.\n" *
-                    "Install/enable SparseConnectivityTracer and SparseMatrixColorings to activate the AutoSparse backend."
+            throw(
+                ArgumentError(
+                    "Sparse Jacobian backend not available.\n" *
+                        "Install/enable SparseConnectivityTracer and SparseMatrixColorings to activate the AutoSparse backend."
+                )
             )
         else
             rethrow()
@@ -110,12 +112,12 @@ end
 function conditional_distribution(model::NonlinearLeastSquaresModel, x::AbstractVector; σ, kwargs...)
     ŷ = model.f(x)
     if σ isa AbstractVector
-        length(σ) == length(ŷ) || error("Length of σ vector must match f(x)")
+        length(σ) == length(ŷ) || throw(DimensionMismatch("Length of σ vector ($(length(σ))) must match f(x) (got $(length(ŷ)))"))
         return product_distribution(Normal.(ŷ, σ))
     elseif σ isa Number
         return product_distribution(Normal.(ŷ, σ))
     else
-        error("σ must be a number or a vector")
+        throw(ArgumentError("σ must be a number or a vector"))
     end
 end
 
@@ -127,10 +129,10 @@ end
     if σ isa Number
         return fill(float(σ), m)
     elseif σ isa AbstractVector
-        length(σ) == m || error("Length of σ vector must match y (expected $m, got $(length(σ)))")
+        length(σ) == m || throw(DimensionMismatch("Length of σ vector must match y (expected $m, got $(length(σ)))"))
         return float.(σ)
     else
-        error("σ must be a number or a vector")
+        throw(ArgumentError("σ must be a number or a vector"))
     end
 end
 

--- a/src/observation_models/nonlinear_least_squares.jl
+++ b/src/observation_models/nonlinear_least_squares.jl
@@ -63,6 +63,7 @@ function (model::NonlinearLeastSquaresModel)(y::AbstractVector; σ, kwargs...)
     jac_backend = try
         default_sparse_jacobian_backend()
     catch err
+        # COV_EXCL_START
         if err isa MethodError
             throw(
                 ArgumentError(
@@ -73,6 +74,7 @@ function (model::NonlinearLeastSquaresModel)(y::AbstractVector; σ, kwargs...)
         else
             rethrow()
         end
+        # COV_EXCL_STOP
     end
     return NonlinearLeastSquaresLikelihood{typeof(model.f), T, typeof(jac_backend)}(
         model.f, y_vec, convert.(T, inv_σ²), convert(T, log_const), jac_backend,

--- a/src/observation_models/observation_likelihood.jl
+++ b/src/observation_models/observation_likelihood.jl
@@ -35,7 +35,7 @@ abstract type ObservationLikelihood end
 # Default trait implementation: all likelihoods are conditionally independent unless overridden
 observation_independence(::ObservationLikelihood) = ConditionallyIndependent()
 
-loglik(x, obs_lik::ObservationLikelihood) = error("loglik is not implemented for $(typeof(obs_lik)).")
+loglik(x, obs_lik::ObservationLikelihood) = throw(MethodError(loglik, (x, obs_lik)))
 (obs_lik::ObservationLikelihood)(x) = loglik(x, obs_lik)
 
 autodiff_gradient_backend(::ObservationLikelihood) = nothing
@@ -61,9 +61,11 @@ function loggrad(x, obs_lik::ObservationLikelihood)
         end
     else
         obs_lik_type = typeof(obs_lik)
-        error(
-            "loggrad not implemented for $(obs_lik_type).\n"
-                * "Try implementing `autodiff_gradient_backend(::$(obs_lik_type))`."
+        throw(
+            ArgumentError(
+                "loggrad not implemented for $(obs_lik_type).\n"
+                    * "Try implementing `autodiff_gradient_backend(::$(obs_lik_type))`."
+            )
         )
     end
 end
@@ -87,9 +89,11 @@ function loghessian(x, obs_lik::ObservationLikelihood)
         end
     else
         obs_lik_type = typeof(obs_lik)
-        error(
-            "loghessian not implemented for $(obs_lik_type).\n"
-                * "Try implementing `autodiff_hessian_backend(::$(obs_lik_type))`."
+        throw(
+            ArgumentError(
+                "loghessian not implemented for $(obs_lik_type).\n"
+                    * "Try implementing `autodiff_hessian_backend(::$(obs_lik_type))`."
+            )
         )
     end
 end
@@ -237,19 +241,17 @@ end
 """
 function _pointwise_loglik(::ConditionallyDependent, x, obs_lik::ObservationLikelihood)
     obs_lik_type = typeof(obs_lik)
-    error(
-        "pointwise_loglik not supported for observation model with correlated observations.\n"
-            * "$(obs_lik_type) has trait ConditionallyDependent().\n"
-            * "Pointwise log-likelihoods are only well-defined for conditionally independent observations."
+    throw(
+        ArgumentError(
+            "pointwise_loglik not supported for observation model with correlated observations.\n"
+                * "$(obs_lik_type) has trait ConditionallyDependent().\n"
+                * "Pointwise log-likelihoods are only well-defined for conditionally independent observations."
+        )
     )
 end
 
 function _pointwise_loglik(::ConditionallyIndependent, x, obs_lik::ObservationLikelihood)
-    obs_lik_type = typeof(obs_lik)
-    error(
-        "pointwise_loglik not implemented for $(obs_lik_type).\n"
-            * "Implement `_pointwise_loglik(::ConditionallyIndependent, x, ::$(obs_lik_type))`."
-    )
+    throw(MethodError(_pointwise_loglik, (ConditionallyIndependent(), x, obs_lik)))
 end
 
 """
@@ -267,17 +269,15 @@ end
 """
 function _pointwise_loglik!(::ConditionallyDependent, result, x, obs_lik::ObservationLikelihood)
     obs_lik_type = typeof(obs_lik)
-    error(
-        "pointwise_loglik! not supported for observation model with correlated observations.\n"
-            * "$(obs_lik_type) has trait ConditionallyDependent().\n"
-            * "Pointwise log-likelihoods are only well-defined for conditionally independent observations."
+    throw(
+        ArgumentError(
+            "pointwise_loglik! not supported for observation model with correlated observations.\n"
+                * "$(obs_lik_type) has trait ConditionallyDependent().\n"
+                * "Pointwise log-likelihoods are only well-defined for conditionally independent observations."
+        )
     )
 end
 
 function _pointwise_loglik!(::ConditionallyIndependent, result, x, obs_lik::ObservationLikelihood)
-    obs_lik_type = typeof(obs_lik)
-    error(
-        "pointwise_loglik! not implemented for $(obs_lik_type).\n"
-            * "Implement `_pointwise_loglik!(::ConditionallyIndependent, result, x, ::$(obs_lik_type))`."
-    )
+    throw(MethodError(_pointwise_loglik!, (ConditionallyIndependent(), result, x, obs_lik)))
 end

--- a/src/observation_models/observation_likelihood.jl
+++ b/src/observation_models/observation_likelihood.jl
@@ -60,6 +60,7 @@ function loggrad(x, obs_lik::ObservationLikelihood)
             return DI.gradient(obs_lik, backend, x)
         end
     else
+        # COV_EXCL_START
         obs_lik_type = typeof(obs_lik)
         throw(
             ArgumentError(
@@ -67,6 +68,7 @@ function loggrad(x, obs_lik::ObservationLikelihood)
                     * "Try implementing `autodiff_gradient_backend(::$(obs_lik_type))`."
             )
         )
+        # COV_EXCL_STOP
     end
 end
 
@@ -88,6 +90,7 @@ function loghessian(x, obs_lik::ObservationLikelihood)
             return DI.hessian(obs_lik, backend, x)
         end
     else
+        # COV_EXCL_START
         obs_lik_type = typeof(obs_lik)
         throw(
             ArgumentError(
@@ -95,6 +98,7 @@ function loghessian(x, obs_lik::ObservationLikelihood)
                     * "Try implementing `autodiff_hessian_backend(::$(obs_lik_type))`."
             )
         )
+        # COV_EXCL_STOP
     end
 end
 
@@ -239,6 +243,7 @@ function _pointwise_loglik(::ConditionallyIndependent, x, obs_lik::MyLikelihood)
 end
 ```
 """
+# COV_EXCL_START
 function _pointwise_loglik(::ConditionallyDependent, x, obs_lik::ObservationLikelihood)
     obs_lik_type = typeof(obs_lik)
     throw(
@@ -253,6 +258,7 @@ end
 function _pointwise_loglik(::ConditionallyIndependent, x, obs_lik::ObservationLikelihood)
     throw(MethodError(_pointwise_loglik, (ConditionallyIndependent(), x, obs_lik)))
 end
+# COV_EXCL_STOP
 
 """
     _pointwise_loglik!(independence_trait, result, x, obs_lik)
@@ -267,6 +273,7 @@ function _pointwise_loglik!(::ConditionallyIndependent, result, x, obs_lik::MyLi
 end
 ```
 """
+# COV_EXCL_START
 function _pointwise_loglik!(::ConditionallyDependent, result, x, obs_lik::ObservationLikelihood)
     obs_lik_type = typeof(obs_lik)
     throw(
@@ -281,3 +288,4 @@ end
 function _pointwise_loglik!(::ConditionallyIndependent, result, x, obs_lik::ObservationLikelihood)
     throw(MethodError(_pointwise_loglik!, (ConditionallyIndependent(), result, x, obs_lik)))
 end
+# COV_EXCL_STOP

--- a/src/observation_models/observation_model.jl
+++ b/src/observation_models/observation_model.jl
@@ -114,5 +114,5 @@ y = rand(dist)  # Sample observations
 All observation models should implement this method. The default throws an error.
 """
 function conditional_distribution(obs_model::ObservationModel, x; kwargs...)
-    error("conditional_distribution not implemented for observation model type $(typeof(obs_model))")
+    throw(MethodError(conditional_distribution, (obs_model, x)))
 end

--- a/src/observation_models/observation_model.jl
+++ b/src/observation_models/observation_model.jl
@@ -113,6 +113,8 @@ y = rand(dist)  # Sample observations
 # Implementation
 All observation models should implement this method. The default throws an error.
 """
+# COV_EXCL_START
 function conditional_distribution(obs_model::ObservationModel, x; kwargs...)
     throw(MethodError(conditional_distribution, (obs_model, x)))
 end
+# COV_EXCL_STOP

--- a/src/preconditioners/preconditioner.jl
+++ b/src/preconditioners/preconditioner.jl
@@ -15,11 +15,11 @@ Should implement the following methods:
 """
 abstract type AbstractPreconditioner{T} end;
 
-ldiv!(y, ::AbstractPreconditioner, x::AbstractVector) =
-    error("ldiv! not defined for this preconditioner type")
-ldiv!(::AbstractPreconditioner, x::AbstractVector) =
-    error("ldiv! not defined for this preconditioner type")
-\(::AbstractPreconditioner, x::AbstractVector) =
-    error("left division not defined for this preconditioner type")
+ldiv!(y, P::AbstractPreconditioner, x::AbstractVector) =
+    throw(MethodError(ldiv!, (y, P, x)))
+ldiv!(P::AbstractPreconditioner, x::AbstractVector) =
+    throw(MethodError(ldiv!, (P, x)))
+\(P::AbstractPreconditioner, x::AbstractVector) =
+    throw(MethodError(\, (P, x)))
 
-Base.size(::AbstractPreconditioner) = error("size not defined for this preconditioner type")
+Base.size(P::AbstractPreconditioner) = throw(MethodError(size, (P,)))

--- a/src/preconditioners/preconditioner.jl
+++ b/src/preconditioners/preconditioner.jl
@@ -15,6 +15,7 @@ Should implement the following methods:
 """
 abstract type AbstractPreconditioner{T} end;
 
+# COV_EXCL_START
 ldiv!(y, P::AbstractPreconditioner, x::AbstractVector) =
     throw(MethodError(ldiv!, (y, P, x)))
 ldiv!(P::AbstractPreconditioner, x::AbstractVector) =
@@ -23,3 +24,4 @@ ldiv!(P::AbstractPreconditioner, x::AbstractVector) =
     throw(MethodError(\, (P, x)))
 
 Base.size(P::AbstractPreconditioner) = throw(MethodError(size, (P,)))
+# COV_EXCL_STOP

--- a/src/solvers/backward_solve.jl
+++ b/src/solvers/backward_solve.jl
@@ -45,7 +45,7 @@ Convenience function that dispatches to backward_solve(linsolve, x, linsolve.alg
 backward_solve(linsolve, x) = backward_solve(linsolve, x, linsolve.alg)
 
 # Implementation methods (after factorization is ensured)
-_backward_solve_impl(linsolve, x, alg) = error("Backward solve not implemented for algorithm $(typeof(alg))")
+_backward_solve_impl(linsolve, x, alg) = throw(ArgumentError("Backward solve not implemented for algorithm $(typeof(alg))"))
 
 function _backward_solve_impl(linsolve, x, ::LinearSolve.CHOLMODFactorization)
     factorization = LinearSolve.@get_cacheval(linsolve, :CHOLMODFactorization)
@@ -70,7 +70,7 @@ end
 
 function _backward_solve_impl(linsolve, x, ::LinearSolve.PardisoJL)
     # Pardiso backward solve - will be implemented in extension
-    error("Pardiso backward solve implementation requires the Pardiso extension")
+    throw(ArgumentError("Pardiso backward solve implementation requires the Pardiso extension"))
 end
 
 # Handle DefaultLinearSolver by dispatching on the nested algorithm

--- a/src/solvers/backward_solve.jl
+++ b/src/solvers/backward_solve.jl
@@ -45,7 +45,7 @@ Convenience function that dispatches to backward_solve(linsolve, x, linsolve.alg
 backward_solve(linsolve, x) = backward_solve(linsolve, x, linsolve.alg)
 
 # Implementation methods (after factorization is ensured)
-_backward_solve_impl(linsolve, x, alg) = throw(ArgumentError("Backward solve not implemented for algorithm $(typeof(alg))"))
+_backward_solve_impl(linsolve, x, alg) = throw(ArgumentError("Backward solve not implemented for algorithm $(typeof(alg))")) # COV_EXCL_LINE
 
 function _backward_solve_impl(linsolve, x, ::LinearSolve.CHOLMODFactorization)
     factorization = LinearSolve.@get_cacheval(linsolve, :CHOLMODFactorization)
@@ -68,10 +68,12 @@ function _backward_solve_impl(linsolve, x, ::LinearSolve.LDLtFactorization)
     return factorization.Lt \ (sqrt.(factorization.D) \ x)
 end
 
+# COV_EXCL_START
 function _backward_solve_impl(linsolve, x, ::LinearSolve.PardisoJL)
     # Pardiso backward solve - will be implemented in extension
     throw(ArgumentError("Pardiso backward solve implementation requires the Pardiso extension"))
 end
+# COV_EXCL_STOP
 
 # Handle DefaultLinearSolver by dispatching on the nested algorithm
 function _backward_solve_impl(linsolve, x, alg::LinearSolve.DefaultLinearSolver)

--- a/src/solvers/logdet.jl
+++ b/src/solvers/logdet.jl
@@ -22,7 +22,7 @@ Convenience function that dispatches to logdet_cov(linsolve, linsolve.alg).
 logdet_cov(linsolve) = logdet_cov(linsolve, linsolve.alg)
 
 # Implementation methods (after factorization is ensured)
-_logdet_cov_impl(linsolve, alg) = error("Log determinant of covariance not implemented for algorithm $(typeof(alg))")
+_logdet_cov_impl(linsolve, alg) = throw(ArgumentError("Log determinant of covariance not implemented for algorithm $(typeof(alg))"))
 
 function _logdet_cov_impl(linsolve, ::LinearSolve.CHOLMODFactorization)
     factorization = LinearSolve.@get_cacheval(linsolve, :CHOLMODFactorization)
@@ -50,7 +50,7 @@ end
 
 function _logdet_cov_impl(linsolve, ::LinearSolve.PardisoJL)
     # Pardiso logdet - will be implemented in extension
-    error("Pardiso logdet implementation requires the Pardiso extension")
+    throw(ArgumentError("Pardiso logdet implementation requires the Pardiso extension"))
 end
 
 # Handle DefaultLinearSolver by dispatching on the nested algorithm

--- a/src/solvers/logdet.jl
+++ b/src/solvers/logdet.jl
@@ -22,7 +22,7 @@ Convenience function that dispatches to logdet_cov(linsolve, linsolve.alg).
 logdet_cov(linsolve) = logdet_cov(linsolve, linsolve.alg)
 
 # Implementation methods (after factorization is ensured)
-_logdet_cov_impl(linsolve, alg) = throw(ArgumentError("Log determinant of covariance not implemented for algorithm $(typeof(alg))"))
+_logdet_cov_impl(linsolve, alg) = throw(ArgumentError("Log determinant of covariance not implemented for algorithm $(typeof(alg))")) # COV_EXCL_LINE
 
 function _logdet_cov_impl(linsolve, ::LinearSolve.CHOLMODFactorization)
     factorization = LinearSolve.@get_cacheval(linsolve, :CHOLMODFactorization)
@@ -48,10 +48,12 @@ function _logdet_cov_impl(linsolve, ::LinearSolve.LDLtFactorization)
     return -logdet(factorization)
 end
 
+# COV_EXCL_START
 function _logdet_cov_impl(linsolve, ::LinearSolve.PardisoJL)
     # Pardiso logdet - will be implemented in extension
     throw(ArgumentError("Pardiso logdet implementation requires the Pardiso extension"))
 end
+# COV_EXCL_STOP
 
 # Handle DefaultLinearSolver by dispatching on the nested algorithm
 function _logdet_cov_impl(linsolve, alg::LinearSolve.DefaultLinearSolver)

--- a/src/solvers/selinv.jl
+++ b/src/solvers/selinv.jl
@@ -65,7 +65,7 @@ Convenience function that dispatches to selinv(linsolve, linsolve.alg).
 selinv(linsolve::LinearSolve.LinearCache) = selinv(linsolve, linsolve.alg)
 
 # Implementation methods (after factorization is ensured)
-_selinv_diag_impl(linsolve, alg) = throw(ArgumentError("Selected inversion not implemented for algorithm $(typeof(alg))"))
+_selinv_diag_impl(linsolve, alg) = throw(ArgumentError("Selected inversion not implemented for algorithm $(typeof(alg))")) # COV_EXCL_LINE
 
 function _selinv_diag_impl(linsolve, ::LinearSolve.CHOLMODFactorization)
     factorization = LinearSolve.@get_cacheval(linsolve, :CHOLMODFactorization)
@@ -88,10 +88,12 @@ function _selinv_diag_impl(linsolve, ::LinearSolve.LDLtFactorization)
     return SelectedInversion.selinv_diag(factorization)
 end
 
+# COV_EXCL_START
 function _selinv_diag_impl(linsolve, ::LinearSolve.PardisoJL)
     # Pardiso selected inversion - will be implemented in extension
     throw(ArgumentError("Pardiso selinv implementation requires the Pardiso extension"))
 end
+# COV_EXCL_STOP
 
 # Handle DefaultLinearSolver by dispatching on the nested algorithm
 function _selinv_diag_impl(linsolve, alg::LinearSolve.DefaultLinearSolver)
@@ -100,7 +102,7 @@ function _selinv_diag_impl(linsolve, alg::LinearSolve.DefaultLinearSolver)
 end
 
 # Implementation methods for full selected inverse
-_selinv_impl(linsolve, alg) = throw(ArgumentError("Full selected inversion not implemented for algorithm $(typeof(alg))"))
+_selinv_impl(linsolve, alg) = throw(ArgumentError("Full selected inversion not implemented for algorithm $(typeof(alg))")) # COV_EXCL_LINE
 
 function _selinv_impl(linsolve, ::LinearSolve.CHOLMODFactorization)
     factorization = LinearSolve.@get_cacheval(linsolve, :CHOLMODFactorization)
@@ -122,10 +124,12 @@ function _selinv_impl(linsolve, ::LinearSolve.LDLtFactorization)
     return Symmetric(sparse(SelectedInversion.selinv(factorization; depermute = true).Z))
 end
 
+# COV_EXCL_START
 function _selinv_impl(linsolve, ::LinearSolve.PardisoJL)
     # Pardiso selected inversion - will be implemented in extension
     throw(ArgumentError("Pardiso full selinv implementation requires the Pardiso extension"))
 end
+# COV_EXCL_STOP
 
 # Handle DefaultLinearSolver by dispatching on the nested algorithm
 function _selinv_impl(linsolve, alg::LinearSolve.DefaultLinearSolver)

--- a/src/solvers/selinv.jl
+++ b/src/solvers/selinv.jl
@@ -65,7 +65,7 @@ Convenience function that dispatches to selinv(linsolve, linsolve.alg).
 selinv(linsolve::LinearSolve.LinearCache) = selinv(linsolve, linsolve.alg)
 
 # Implementation methods (after factorization is ensured)
-_selinv_diag_impl(linsolve, alg) = error("Selected inversion not implemented for algorithm $(typeof(alg))")
+_selinv_diag_impl(linsolve, alg) = throw(ArgumentError("Selected inversion not implemented for algorithm $(typeof(alg))"))
 
 function _selinv_diag_impl(linsolve, ::LinearSolve.CHOLMODFactorization)
     factorization = LinearSolve.@get_cacheval(linsolve, :CHOLMODFactorization)
@@ -90,7 +90,7 @@ end
 
 function _selinv_diag_impl(linsolve, ::LinearSolve.PardisoJL)
     # Pardiso selected inversion - will be implemented in extension
-    error("Pardiso selinv implementation requires the Pardiso extension")
+    throw(ArgumentError("Pardiso selinv implementation requires the Pardiso extension"))
 end
 
 # Handle DefaultLinearSolver by dispatching on the nested algorithm
@@ -100,7 +100,7 @@ function _selinv_diag_impl(linsolve, alg::LinearSolve.DefaultLinearSolver)
 end
 
 # Implementation methods for full selected inverse
-_selinv_impl(linsolve, alg) = error("Full selected inversion not implemented for algorithm $(typeof(alg))")
+_selinv_impl(linsolve, alg) = throw(ArgumentError("Full selected inversion not implemented for algorithm $(typeof(alg))"))
 
 function _selinv_impl(linsolve, ::LinearSolve.CHOLMODFactorization)
     factorization = LinearSolve.@get_cacheval(linsolve, :CHOLMODFactorization)
@@ -124,7 +124,7 @@ end
 
 function _selinv_impl(linsolve, ::LinearSolve.PardisoJL)
     # Pardiso selected inversion - will be implemented in extension
-    error("Pardiso full selinv implementation requires the Pardiso extension")
+    throw(ArgumentError("Pardiso full selinv implementation requires the Pardiso extension"))
 end
 
 # Handle DefaultLinearSolver by dispatching on the nested algorithm

--- a/src/spdes/spatiotemporal/spatiotemporal_gmrf.jl
+++ b/src/spdes/spatiotemporal/spatiotemporal_gmrf.jl
@@ -33,7 +33,7 @@ abstract type AbstractSpatiotemporalGMRF{T <: Real, PrecisionMap <: LinearMap{T}
 
 Return the number of time points in the spatiotemporal GMRF.
 """
-N_t(d::AbstractSpatiotemporalGMRF) = throw(MethodError(N_t, (d,)))
+N_t(d::AbstractSpatiotemporalGMRF) = throw(MethodError(N_t, (d,))) # COV_EXCL_LINE
 
 """
     time_means(::AbstractSpatiotemporalGMRF)
@@ -43,7 +43,7 @@ Return the means of the spatiotemporal GMRF at each time point.
 # Returns
 - A vector of means of length Nₜ, one for each time point.
 """
-time_means(d::AbstractSpatiotemporalGMRF) = throw(MethodError(time_means, (d,)))
+time_means(d::AbstractSpatiotemporalGMRF) = throw(MethodError(time_means, (d,))) # COV_EXCL_LINE
 
 """
     time_vars(::AbstractSpatiotemporalGMRF)
@@ -53,7 +53,7 @@ Return the marginal variances of the spatiotemporal GMRF at each time point.
 # Returns
 - A vector of marginal variances of length Nₜ, one for each time point.
 """
-time_vars(d::AbstractSpatiotemporalGMRF) = throw(MethodError(time_vars, (d,)))
+time_vars(d::AbstractSpatiotemporalGMRF) = throw(MethodError(time_vars, (d,))) # COV_EXCL_LINE
 
 """
     time_stds(::AbstractSpatiotemporalGMRF)
@@ -63,7 +63,7 @@ Return the marginal standard deviations of the spatiotemporal GMRF at each time 
 # Returns
 - A vector of marginal standard deviations of length Nₜ, one for each time point.
 """
-time_stds(d::AbstractSpatiotemporalGMRF) = throw(MethodError(time_stds, (d,)))
+time_stds(d::AbstractSpatiotemporalGMRF) = throw(MethodError(time_stds, (d,))) # COV_EXCL_LINE
 
 """
     time_rands(::AbstractSpatiotemporalGMRF, rng::AbstractRNG)
@@ -74,13 +74,17 @@ Draw samples from the spatiotemporal GMRF at each time point.
 - A vector of sample values of length Nₜ, one sample value vector
   for each time point.
 """
+# COV_EXCL_START
 time_rands(d::AbstractSpatiotemporalGMRF, rng::AbstractRNG) =
     throw(MethodError(time_rands, (d, rng)))
+# COV_EXCL_STOP
 
 """
     discretization_at_time(::AbstractSpatiotemporalGMRF, t::Int)
 
 Return the spatial discretization at time `t`.
 """
+# COV_EXCL_START
 discretization_at_time(d::AbstractSpatiotemporalGMRF, t::Int) =
     throw(MethodError(discretization_at_time, (d, t)))
+# COV_EXCL_STOP

--- a/src/spdes/spatiotemporal/spatiotemporal_gmrf.jl
+++ b/src/spdes/spatiotemporal/spatiotemporal_gmrf.jl
@@ -74,17 +74,11 @@ Draw samples from the spatiotemporal GMRF at each time point.
 - A vector of sample values of length Nₜ, one sample value vector
   for each time point.
 """
-# COV_EXCL_START
-time_rands(d::AbstractSpatiotemporalGMRF, rng::AbstractRNG) =
-    throw(MethodError(time_rands, (d, rng)))
-# COV_EXCL_STOP
+time_rands(d::AbstractSpatiotemporalGMRF, rng::AbstractRNG) = throw(MethodError(time_rands, (d, rng))) # COV_EXCL_LINE
 
 """
     discretization_at_time(::AbstractSpatiotemporalGMRF, t::Int)
 
 Return the spatial discretization at time `t`.
 """
-# COV_EXCL_START
-discretization_at_time(d::AbstractSpatiotemporalGMRF, t::Int) =
-    throw(MethodError(discretization_at_time, (d, t)))
-# COV_EXCL_STOP
+discretization_at_time(d::AbstractSpatiotemporalGMRF, t::Int) = throw(MethodError(discretization_at_time, (d, t))) # COV_EXCL_LINE

--- a/src/spdes/spatiotemporal/spatiotemporal_gmrf.jl
+++ b/src/spdes/spatiotemporal/spatiotemporal_gmrf.jl
@@ -33,7 +33,7 @@ abstract type AbstractSpatiotemporalGMRF{T <: Real, PrecisionMap <: LinearMap{T}
 
 Return the number of time points in the spatiotemporal GMRF.
 """
-N_t(::AbstractSpatiotemporalGMRF) = error("N_t not implemented")
+N_t(d::AbstractSpatiotemporalGMRF) = throw(MethodError(N_t, (d,)))
 
 """
     time_means(::AbstractSpatiotemporalGMRF)
@@ -43,7 +43,7 @@ Return the means of the spatiotemporal GMRF at each time point.
 # Returns
 - A vector of means of length Nₜ, one for each time point.
 """
-time_means(::AbstractSpatiotemporalGMRF) = error("time_means not implemented")
+time_means(d::AbstractSpatiotemporalGMRF) = throw(MethodError(time_means, (d,)))
 
 """
     time_vars(::AbstractSpatiotemporalGMRF)
@@ -53,7 +53,7 @@ Return the marginal variances of the spatiotemporal GMRF at each time point.
 # Returns
 - A vector of marginal variances of length Nₜ, one for each time point.
 """
-time_vars(::AbstractSpatiotemporalGMRF) = error("time_vars not implemented")
+time_vars(d::AbstractSpatiotemporalGMRF) = throw(MethodError(time_vars, (d,)))
 
 """
     time_stds(::AbstractSpatiotemporalGMRF)
@@ -63,7 +63,7 @@ Return the marginal standard deviations of the spatiotemporal GMRF at each time 
 # Returns
 - A vector of marginal standard deviations of length Nₜ, one for each time point.
 """
-time_stds(::AbstractSpatiotemporalGMRF) = error("time_stds not implemented")
+time_stds(d::AbstractSpatiotemporalGMRF) = throw(MethodError(time_stds, (d,)))
 
 """
     time_rands(::AbstractSpatiotemporalGMRF, rng::AbstractRNG)
@@ -74,13 +74,13 @@ Draw samples from the spatiotemporal GMRF at each time point.
 - A vector of sample values of length Nₜ, one sample value vector
   for each time point.
 """
-time_rands(::AbstractSpatiotemporalGMRF, ::AbstractRNG) =
-    error("time_rands not implemented")
+time_rands(d::AbstractSpatiotemporalGMRF, rng::AbstractRNG) =
+    throw(MethodError(time_rands, (d, rng)))
 
 """
     discretization_at_time(::AbstractSpatiotemporalGMRF, t::Int)
 
 Return the spatial discretization at time `t`.
 """
-discretization_at_time(::AbstractSpatiotemporalGMRF, ::Int) =
-    error("discretization_at_time not implemented")
+discretization_at_time(d::AbstractSpatiotemporalGMRF, t::Int) =
+    throw(MethodError(discretization_at_time, (d, t)))

--- a/src/spdes/spatiotemporal/ssm/linear_ssm.jl
+++ b/src/spdes/spatiotemporal/ssm/linear_ssm.jl
@@ -44,8 +44,10 @@ G(Δtₖ) x_{k+1} ∣ xₖ ∼ 𝒩(M(Δtₖ) xₖ, Σ)
 
 at time points given by `ts` (from which the Δtₖ are computed).
 """
+# COV_EXCL_START
 joint_ssm(x₀::GMRF, ssm_matrices::Union{Function, JointSSMMatrices}, ts::AbstractVector) =
     throw(MethodError(joint_ssm, (x₀, ssm_matrices, ts)))
+# COV_EXCL_STOP
 
 """
 function joint_ssm(x₀::GMRF, ssm_mats_fn::Function, ts::AbstractVector)

--- a/src/spdes/spatiotemporal/ssm/linear_ssm.jl
+++ b/src/spdes/spatiotemporal/ssm/linear_ssm.jl
@@ -44,10 +44,7 @@ G(Δtₖ) x_{k+1} ∣ xₖ ∼ 𝒩(M(Δtₖ) xₖ, Σ)
 
 at time points given by `ts` (from which the Δtₖ are computed).
 """
-# COV_EXCL_START
-joint_ssm(x₀::GMRF, ssm_matrices::Union{Function, JointSSMMatrices}, ts::AbstractVector) =
-    throw(MethodError(joint_ssm, (x₀, ssm_matrices, ts)))
-# COV_EXCL_STOP
+joint_ssm(x₀::GMRF, ssm_matrices::Union{Function, JointSSMMatrices}, ts::AbstractVector) = throw(MethodError(joint_ssm, (x₀, ssm_matrices, ts))) # COV_EXCL_LINE
 
 """
 function joint_ssm(x₀::GMRF, ssm_mats_fn::Function, ts::AbstractVector)

--- a/src/spdes/spatiotemporal/ssm/linear_ssm.jl
+++ b/src/spdes/spatiotemporal/ssm/linear_ssm.jl
@@ -45,7 +45,7 @@ G(Δtₖ) x_{k+1} ∣ xₖ ∼ 𝒩(M(Δtₖ) xₖ, Σ)
 at time points given by `ts` (from which the Δtₖ are computed).
 """
 joint_ssm(x₀::GMRF, ssm_matrices::Union{Function, JointSSMMatrices}, ts::AbstractVector) =
-    error("joint_ssm not implemented for these argument types")
+    throw(MethodError(joint_ssm, (x₀, ssm_matrices, ts)))
 
 """
 function joint_ssm(x₀::GMRF, ssm_mats_fn::Function, ts::AbstractVector)

--- a/src/spdes/spde.jl
+++ b/src/spdes/spde.jl
@@ -7,5 +7,5 @@ An abstract type for a stochastic partial differential equation (SPDE).
 """
 abstract type SPDE end
 
-ndim(::SPDE) = error("dim not implemented for SPDE")
-discretize(::SPDE, ::FEMDiscretization) = error("discretize not implemented for SPDE")
+ndim(s::SPDE) = throw(MethodError(ndim, (s,)))
+discretize(s::SPDE, d::FEMDiscretization) = throw(MethodError(discretize, (s, d)))

--- a/src/spdes/spde.jl
+++ b/src/spdes/spde.jl
@@ -7,5 +7,5 @@ An abstract type for a stochastic partial differential equation (SPDE).
 """
 abstract type SPDE end
 
-ndim(s::SPDE) = throw(MethodError(ndim, (s,)))
-discretize(s::SPDE, d::FEMDiscretization) = throw(MethodError(discretize, (s, d)))
+ndim(s::SPDE) = throw(MethodError(ndim, (s,))) # COV_EXCL_LINE
+discretize(s::SPDE, d::FEMDiscretization) = throw(MethodError(discretize, (s, d))) # COV_EXCL_LINE

--- a/src/workspace/gaussian_approximation.jl
+++ b/src/workspace/gaussian_approximation.jl
@@ -47,8 +47,10 @@ function _sparse_hessian_map(Q::SparseMatrixCSC, H::SparseMatrixCSC)
             if q_ptr <= q_end && Q_rows[q_ptr] == h_row
                 hmap[k] = q_ptr
             else
-                error(
-                    "Hessian has nonzero at ($h_row, $col) which is outside the workspace Q sparsity pattern."
+                throw(
+                    ArgumentError(
+                        "Hessian has nonzero at ($h_row, $col) which is outside the workspace Q sparsity pattern."
+                    )
                 )
             end
         end

--- a/src/workspace/gaussian_approximation.jl
+++ b/src/workspace/gaussian_approximation.jl
@@ -47,11 +47,13 @@ function _sparse_hessian_map(Q::SparseMatrixCSC, H::SparseMatrixCSC)
             if q_ptr <= q_end && Q_rows[q_ptr] == h_row
                 hmap[k] = q_ptr
             else
+                # COV_EXCL_START
                 throw(
                     ArgumentError(
                         "Hessian has nonzero at ($h_row, $col) which is outside the workspace Q sparsity pattern."
                     )
                 )
+                # COV_EXCL_STOP
             end
         end
     end

--- a/test/formula/test_formula_interface.jl
+++ b/test/formula/test_formula_interface.jl
@@ -282,7 +282,7 @@ end
         e_wrong = [0.0]
         iid_wrong = IID(constraint = (A_wrong, e_wrong))
 
-        @test_throws ErrorException build_formula_components(@formula(y ~ 0 + iid_wrong(group)), data; family = Normal)
+        @test_throws DimensionMismatch build_formula_components(@formula(y ~ 0 + iid_wrong(group)), data; family = Normal)
     end
 
     @testset "RW2 via formula interface" begin

--- a/test/latent_models/test_latent_model.jl
+++ b/test/latent_models/test_latent_model.jl
@@ -15,12 +15,12 @@ ConstrainedTestModel(n::Int; alg = nothing) = ConstrainedTestModel{typeof(alg)}(
     struct DummyLatentModel <: LatentModel end
     dummy = DummyLatentModel()
 
-    @test_throws ErrorException hyperparameters(dummy)
-    @test_throws ErrorException precision_matrix(dummy; τ = 1.0)
-    @test_throws ErrorException mean(dummy; τ = 1.0)
-    @test_throws ErrorException constraints(dummy; τ = 1.0)
-    @test_throws ErrorException model_name(dummy)
-    @test_throws ErrorException Base.length(dummy)
+    @test_throws MethodError hyperparameters(dummy)
+    @test_throws MethodError precision_matrix(dummy; τ = 1.0)
+    @test_throws MethodError mean(dummy; τ = 1.0)
+    @test_throws MethodError constraints(dummy; τ = 1.0)
+    @test_throws MethodError model_name(dummy)
+    @test_throws MethodError Base.length(dummy)
 end
 
 @testset "LatentModel Call Interface" begin

--- a/test/latent_models/test_separable.jl
+++ b/test/latent_models/test_separable.jl
@@ -19,7 +19,7 @@ using SparseArrays
         @test length(sep3.components) == 3
 
         # Invalid: single component
-        @test_throws ErrorException SeparableModel(rw1)
+        @test_throws ArgumentError SeparableModel(rw1)
 
         # Custom algorithm
         sep_alg = SeparableModel(rw1, iid; alg = :cg)

--- a/test/observation_models/test_autodiff_likelihood_ift.jl
+++ b/test/observation_models/test_autodiff_likelihood_ift.jl
@@ -257,7 +257,7 @@ using FiniteDiff, ForwardDiff
         β_d = ForwardDiff.Dual{TagB, Float64, 1}(0.3, ForwardDiff.Partials{1, Float64}((1.0,)))
         obs_lik = obs_model(y; α = α_d, β = β_d)
         prior = WorkspaceGMRF(zeros(3), spdiagm(0 => ones(3)))
-        @test_throws ErrorException gaussian_approximation(prior, obs_lik)
+        @test_throws ArgumentError gaussian_approximation(prior, obs_lik)
     end
 
     @testset "_assemble_q_post_dual: sparse, dense-error, pattern-violation" begin

--- a/test/observation_models/test_custom_models.jl
+++ b/test/observation_models/test_custom_models.jl
@@ -158,6 +158,6 @@ import DifferentiationInterface as DI
         lik = IncompleteLikelihood(y)
         x = [1.0]
 
-        @test_throws ErrorException loglik(x, lik)
+        @test_throws MethodError loglik(x, lik)
     end
 end

--- a/test/observation_models/test_exponential_family.jl
+++ b/test/observation_models/test_exponential_family.jl
@@ -22,6 +22,23 @@ end
 
 @testset "ExponentialFamily Models" begin
 
+    @testset "PoissonObservations validation" begin
+        @test_throws DomainError PoissonObservations([-1, 2])
+        @test_throws DomainError PoissonObservations([1, 2], [0.0, 1.0])
+        @test_throws DomainError PoissonObservations([1, 2], [-1.0, 1.0])
+        @test_throws DimensionMismatch PoissonObservations([1], [1.0, 2.0])
+    end
+
+    @testset "BinomialObservations validation" begin
+        # Length mismatch
+        @test_throws DimensionMismatch BinomialObservations([1, 2], [3])
+        # Successes exceeding trials (relational ArgumentError)
+        @test_throws ArgumentError BinomialObservations([5, 2], [3, 3])
+        # Negative successes/trials (domain violation)
+        @test_throws DomainError BinomialObservations([-1, 0], [3, 3])
+        @test_throws DomainError BinomialObservations([0, 1], [-1, 3])
+    end
+
     @testset "Poisson Family" begin
         # Test with different link functions
         links = [LogLink(), IdentityLink()]

--- a/test/observation_models/test_exponential_family.jl
+++ b/test/observation_models/test_exponential_family.jl
@@ -32,11 +32,14 @@ end
     @testset "BinomialObservations validation" begin
         # Length mismatch
         @test_throws DimensionMismatch BinomialObservations([1, 2], [3])
-        # Successes exceeding trials (relational ArgumentError)
+        # Successes exceeding trials (relational ArgumentError) — note: this
+        # check fires before the non-negativity check, so an obs like
+        # (0, -1) hits this branch rather than the DomainError branch.
         @test_throws ArgumentError BinomialObservations([5, 2], [3, 3])
-        # Negative successes/trials (domain violation)
+        @test_throws ArgumentError BinomialObservations([0, 1], [-1, 3])
+        # Negative values where successes ≤ trials (domain violation)
         @test_throws DomainError BinomialObservations([-1, 0], [3, 3])
-        @test_throws DomainError BinomialObservations([0, 1], [-1, 3])
+        @test_throws DomainError BinomialObservations([-2, 0], [-1, 1])
     end
 
     @testset "Poisson Family" begin

--- a/test/observation_models/test_gamma.jl
+++ b/test/observation_models/test_gamma.jl
@@ -30,10 +30,10 @@ using SparseArrays
 
     @testset "Validation" begin
         ef = ExponentialFamily(Gamma)
-        @test_throws ErrorException ef([1.0, -0.5, 2.0]; phi = 1.0)
-        @test_throws ErrorException ef([1.0, 0.0, 2.0]; phi = 1.0)
-        @test_throws ErrorException ef([1.0, 2.0]; phi = 0.0)
-        @test_throws ErrorException ef([1.0, 2.0]; phi = -1.0)
+        @test_throws DomainError ef([1.0, -0.5, 2.0]; phi = 1.0)
+        @test_throws DomainError ef([1.0, 0.0, 2.0]; phi = 1.0)
+        @test_throws DomainError ef([1.0, 2.0]; phi = 0.0)
+        @test_throws DomainError ef([1.0, 2.0]; phi = -1.0)
     end
 
     # ============================================================

--- a/test/observation_models/test_negative_binomial.jl
+++ b/test/observation_models/test_negative_binomial.jl
@@ -47,10 +47,10 @@ using SparseArrays
         end
 
         @testset "Validation" begin
-            @test_throws ErrorException NegativeBinomialObservations([-1, 2])
-            @test_throws ErrorException NegativeBinomialObservations([1, 2], [0.0, 1.0])
-            @test_throws ErrorException NegativeBinomialObservations([1, 2], [-1.0, 1.0])
-            @test_throws ErrorException NegativeBinomialObservations([1], [1.0, 2.0])
+            @test_throws DomainError NegativeBinomialObservations([-1, 2])
+            @test_throws DomainError NegativeBinomialObservations([1, 2], [0.0, 1.0])
+            @test_throws DomainError NegativeBinomialObservations([1, 2], [-1.0, 1.0])
+            @test_throws DimensionMismatch NegativeBinomialObservations([1], [1.0, 2.0])
         end
     end
 

--- a/test/observation_models/test_nonlinear_least_squares.jl
+++ b/test/observation_models/test_nonlinear_least_squares.jl
@@ -97,4 +97,27 @@ using Distributions
         manual = sum(logpdf.(Normal.(yhat, σ), y_sample))
         @test logpdf(d, y_sample) ≈ manual atol = 1.0e-10
     end
+
+    @testset "σ validation" begin
+        model = NonlinearLeastSquaresModel(f, 2)
+        y = [1.0, 0.5, 2.0]
+        x = [0.2, -0.1]
+
+        # Materialization: σ must be positive
+        @test_throws DomainError model(y; σ = 0.0)
+        @test_throws DomainError model(y; σ = -0.1)
+        @test_throws DomainError model(y; σ = [0.3, -0.1, 0.5])
+
+        # Materialization: σ-vector length must match y length
+        @test_throws DimensionMismatch model(y; σ = [0.3, 0.4])
+
+        # Materialization: σ must be a number or a vector
+        @test_throws ArgumentError model(y; σ = "0.3")
+
+        # conditional_distribution: σ-vector length must match f(x)
+        @test_throws DimensionMismatch conditional_distribution(model, x; σ = [0.3, 0.4])
+
+        # conditional_distribution: σ must be a number or a vector
+        @test_throws ArgumentError conditional_distribution(model, x; σ = "0.3")
+    end
 end

--- a/test/observation_models/test_pointwise_loglik.jl
+++ b/test/observation_models/test_pointwise_loglik.jl
@@ -220,7 +220,7 @@ using SparseArrays
         obs_lik = obs_model(y_data)  # Pass y_data positionally
         x = randn(3)
 
-        @test_throws ErrorException pointwise_loglik(x, obs_lik)
+        @test_throws ArgumentError pointwise_loglik(x, obs_lik)
     end
 
     @testset "AutoDiffLikelihood: with pointwise_loglik_func" begin

--- a/test/observation_models/test_student_t.jl
+++ b/test/observation_models/test_student_t.jl
@@ -31,10 +31,10 @@ using SparseArrays
 
     @testset "Validation" begin
         ef = ExponentialFamily(TDist)
-        @test_throws ErrorException ef([1.0, 2.0]; σ = 0.0, ν = 4.0)
-        @test_throws ErrorException ef([1.0, 2.0]; σ = -1.0, ν = 4.0)
-        @test_throws ErrorException ef([1.0, 2.0]; σ = 1.0, ν = 2.0)
-        @test_throws ErrorException ef([1.0, 2.0]; σ = 1.0, ν = 1.5)
+        @test_throws DomainError ef([1.0, 2.0]; σ = 0.0, ν = 4.0)
+        @test_throws DomainError ef([1.0, 2.0]; σ = -1.0, ν = 4.0)
+        @test_throws DomainError ef([1.0, 2.0]; σ = 1.0, ν = 2.0)
+        @test_throws DomainError ef([1.0, 2.0]; σ = 1.0, ν = 1.5)
     end
 
     # ============================================================

--- a/test/observation_models/test_workspace_dualhp_ift.jl
+++ b/test/observation_models/test_workspace_dualhp_ift.jl
@@ -566,7 +566,7 @@ using FiniteDiff, ForwardDiff
         )
         σ_B = DualB(1.0, ForwardDiff.Partials{1, Float64}((1.0,)))
         lik_B = obs_model(zeros(k); σ = σ_B)
-        @test_throws ErrorException gaussian_approximation(prior_A, lik_B)
+        @test_throws ArgumentError gaussian_approximation(prior_A, lik_B)
 
         # (2) Composite components carry mismatched tags → error.
         m1 = AutoDiffObservationModel(
@@ -585,12 +585,12 @@ using FiniteDiff, ForwardDiff
             CompositeObservations((zeros(k), zeros(k)));
             σ_a = σ_a_A, σ_b = σ_B,
         )
-        @test_throws ErrorException FDExt._lik_dual_tag_npartials(comp_lik_mismatched)
+        @test_throws ArgumentError FDExt._lik_dual_tag_npartials(comp_lik_mismatched)
 
         # (3) No-Duals sentinel: helper called directly with a Float64
         # prior + Float64-hp lik should error before doing IFT work.
         prior_float = WorkspaceGMRF(zeros(3), spdiagm(0 => ones(3)))
         lik_primal = obs_model(zeros(k); σ = 1.0)
-        @test_throws ErrorException FDExt._workspace_dualhp_ift(prior_float, lik_primal)
+        @test_throws ArgumentError FDExt._workspace_dualhp_ift(prior_float, lik_primal)
     end
 end

--- a/test/test_gmrf.jl
+++ b/test/test_gmrf.jl
@@ -30,8 +30,8 @@ using Random
         @test invcov(d_diag) == Q_diag
     end
 
-    @test_throws ErrorException cov(d_standard)
-    @test_throws ErrorException cov(d_diag)
+    @test_throws ArgumentError cov(d_standard)
+    @test_throws ArgumentError cov(d_diag)
 
     @test logdetcov(d_standard) ≈ -logdet(Q_standard)
     @test logdetcov(d_diag) ≈ -logdet(Q_diag)
@@ -145,10 +145,10 @@ using Random
         d_no_qsqrt = GMRF(μ, Q, LinearSolve.KrylovJL_GMRES())
 
         # Should error when trying to sample without Q_sqrt
-        @test_throws ErrorException rand(rng, d_no_qsqrt)
+        @test_throws ArgumentError rand(rng, d_no_qsqrt)
 
         # Should also error when trying to compute variance
-        @test_throws ErrorException var(d_no_qsqrt)
+        @test_throws ArgumentError var(d_no_qsqrt)
     end
 
     @testset "LDLtFactorization cache update" begin


### PR DESCRIPTION
Closes #124.

## Summary

Replaces 67 generic `error("...")` calls in `src/` and `ext/` with semantically appropriate exception types, and updates the 13 affected `@test_throws` assertions. No behavioral changes beyond the exception type.

## Error type choices

| Type | Used for |
|---|---|
| `MethodError` | Abstract-method stubs awaiting subtype implementation (`precision_map`, `loglik`, `var`, the spatiotemporal/`LatentModel`/preconditioner interfaces, etc.) |
| `DomainError` | Single values outside their mathematical domain (`σ > 0`, `ν > 2`, non-negative counts, positive exposure, Gamma `phi > 0`, Gamma `y > 0`, …) |
| `DimensionMismatch` | Vector/matrix size mismatches (counts vs exposure, successes vs trials, σ-vector vs y, constraint-matrix columns vs levels, design-matrix columns vs latent dim, …) |
| `ArgumentError` | Everything else: invalid call patterns (formula functors called outside `@formula`), receiver-state violations (`cov(::AbstractGMRF)`, sampling without `Q_sqrt`), unsupported configurations (missing AD/Pardiso extensions, algorithms without selinv), relational arg errors (`successes > trials`), and Dual-AD tag/partials mismatches |

The one remaining `@test_throws ErrorException` in `test_composite_routing.jl` is intentional — it catches Julia's own `getfield(::NamedTuple, ::Symbol)` error for an unknown route, which is a real `ErrorException` from `Base`.

## Test plan

- [ ] `Pkg.test("GaussianMarkovRandomFields")` passes locally / in CI