### PR TITLE
Add JET static analysis and fix all reports (#115)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Manifest.toml
 .DS_Store
 
 .claude/
+tmp/

--- a/Project.toml
+++ b/Project.toml
@@ -72,6 +72,7 @@ ForwardDiff = "0.10, 1"
 GeoInterface = "1.4"
 Gmsh = "0.3"
 Graphs = "1"
+JET = "0.9, 0.10, 0.11"
 LibGEOS = "0.8, 0.9"
 LinearAlgebra = "<0.0.1, 1"
 LinearMaps = "3.11"
@@ -108,6 +109,7 @@ FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
 Gmsh = "705231aa-382f-11e9-3f0c-b7cb4346fdeb"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 LibGEOS = "a90b1aa1-3769-5649-ba7e-abc5a9d163eb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
@@ -121,4 +123,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "Distributions", "Enzyme", "Ferrite", "FerriteGmsh", "FiniteDiff", "ForwardDiff", "GeoInterface", "Gmsh", "LibGEOS", "LinearAlgebra", "Mooncake", "MooncakeSparse", "ReTest", "SparseArrays", "SparseConnectivityTracer", "SparseMatrixColorings", "StatsModels", "Test", "Zygote"]
+test = ["Aqua", "Distributions", "Enzyme", "Ferrite", "FerriteGmsh", "FiniteDiff", "ForwardDiff", "GeoInterface", "Gmsh", "JET", "LibGEOS", "LinearAlgebra", "Mooncake", "MooncakeSparse", "ReTest", "SparseArrays", "SparseConnectivityTracer", "SparseMatrixColorings", "StatsModels", "Test", "Zygote"]

--- a/src/arithmetic/condition/gaussian_approximation.jl
+++ b/src/arithmetic/condition/gaussian_approximation.jl
@@ -99,7 +99,10 @@ function _ga_make_posterior(x, Q, solver, prior::Union{GMRF, ConstrainedGMRF}, c
     return _apply_constraints(new_gmrf, constraints)
 end
 
-function _ga_make_posterior(x, Q, solver, prior::ChordalGMRF, ::Nothing)
+function _ga_make_posterior(x, Q, solver, prior::ChordalGMRF, _)
+    # ChordalGMRF priors do not carry constraints (see _extract_constraints(::ChordalGMRF) = nothing),
+    # so the second arg is always `nothing` at runtime. The relaxed signature is just so JET
+    # can see a method for the inferred Union type of the constraints argument.
     return ChordalGMRF(x, Q, solver)
 end
 

--- a/src/arithmetic/joint.jl
+++ b/src/arithmetic/joint.jl
@@ -7,7 +7,7 @@ export joint_gmrf
         x1::AbstractGMRF,
         A::AbstractMatrix,
         Q_ϵ::AbstractMatrix,
-        b::AbstractVector=spzeros(size(A)[1])
+        b::AbstractVector=spzeros(size(A, 1))
     )
 
 Return the joint GMRF of `x1` and `x2 = A * x1 + b + ϵ` where `ϵ ~ N(0, Q_ϵ⁻¹)`.
@@ -16,7 +16,7 @@ Return the joint GMRF of `x1` and `x2 = A * x1 + b + ϵ` where `ϵ ~ N(0, Q_ϵ�
 - `x1::AbstractGMRF`: The first GMRF.
 - `A::AbstractMatrix`: The matrix `A`.
 - `Q_ϵ::AbstractMatrix`: The precision matrix of the noise term `ϵ`.
-- `b::AbstractVector=spzeros(size(A)[1])`: Offset vector `b`; optional.
+- `b::AbstractVector=spzeros(size(A, 1))`: Offset vector `b`; optional.
 
 # Returns
 A `GMRF` object representing the joint GMRF of `x1` and `x2 = A * x1 + b + ϵ`.
@@ -25,7 +25,7 @@ function joint_gmrf(
         x1::AbstractGMRF,
         A::AbstractMatrix,
         Q_ϵ::AbstractMatrix,
-        b::AbstractVector = spzeros(size(A)[1]),
+        b::AbstractVector = spzeros(size(A, 1)::Int),
     )
     # TODO: Think about using LinearMap implementation here
     x1_mean, x1_precision = mean(x1), sparse(precision_map(x1))
@@ -34,10 +34,7 @@ function joint_gmrf(
         x1_precision + A' * Q_ϵ * A off_diagonal'
         off_diagonal Q_ϵ
     ]
-    x2_mean = A * x1_mean
-    if b !== nothing
-        x2_mean += b
-    end
+    x2_mean = A * x1_mean + b
     μ_joint = [x1_mean; x2_mean]
     return GMRF(μ_joint, Symmetric(Q_joint))
 end

--- a/src/linear_maps/ad_jacobian.jl
+++ b/src/linear_maps/ad_jacobian.jl
@@ -56,6 +56,19 @@ struct ADJacobianAdjointMap{T} <: LinearMaps.LinearMap{T}
     f_pullback::Function
 end
 
+# Fallback for the 3-arg `(f, x₀, N_outputs)` constructor, which is implemented in the
+# Zygote extension. Vararg{Any} keeps the fallback strictly less specific than the
+# extension's concrete signature (no method overwriting). The error tells the user
+# what to load; JET sees a matching method so no false "no matching method" report.
+function ADJacobianAdjointMap(args::Vararg{Any})
+    return throw(
+        ArgumentError(
+            "Building an ADJacobianAdjointMap from (f, x₀, N_outputs) requires the " *
+                "Zygote extension. Load Zygote to enable reverse-mode AD adjoints of ADJacobianMap."
+        )
+    )
+end
+
 function LinearMaps.size(J::ADJacobianAdjointMap)
     return (length(J.x₀), J.N_outputs)
 end

--- a/src/linear_maps/outer_product.jl
+++ b/src/linear_maps/outer_product.jl
@@ -41,11 +41,12 @@ function to_matrix(L::OuterProductMap)
     end
     A_mat = to_matrix(L.A)
 
-    if L.Q isa LinearMaps.UniformScalingMap
-        L.to_mat_cache = Symmetric(L.Q.λ * A_mat' * A_mat)
+    Q = L.Q
+    if Q isa LinearMaps.UniformScalingMap
+        L.to_mat_cache = Symmetric(Q.λ * A_mat' * A_mat)
         return L.to_mat_cache
     end
-    Q_mat = to_matrix(L.Q)
+    Q_mat = to_matrix(Q)
     L.to_mat_cache = A_mat' * Q_mat * A_mat
     if issymmetric(Q_mat)
         L.to_mat_cache = Symmetric(L.to_mat_cache)
@@ -58,8 +59,9 @@ function linmap_sqrt(OP::OuterProductMap)
         throw(ArgumentError("Map is not symmetric"))
     end
 
-    if OP.Q isa LinearMaps.UniformScalingMap
-        return sqrt(OP.Q.λ) * OP.A'
+    Q = OP.Q
+    if Q isa LinearMaps.UniformScalingMap
+        return sqrt(Q.λ) * OP.A'
     end
-    return OP.A' * linmap_sqrt(OP.Q)
+    return OP.A' * linmap_sqrt(Q)
 end

--- a/src/observation_models/nonlinear_least_squares.jl
+++ b/src/observation_models/nonlinear_least_squares.jl
@@ -59,23 +59,9 @@ function (model::NonlinearLeastSquaresModel)(y::AbstractVector; σ, kwargs...)
     y_vec = collect(Float64, y)
     T = promote_type(eltype(y_vec), eltype(inv_σ²))
 
-    # Prepare sparse Jacobian backend via extension
-    jac_backend = try
-        default_sparse_jacobian_backend()
-    catch err
-        # COV_EXCL_START
-        if err isa MethodError
-            throw(
-                ArgumentError(
-                    "Sparse Jacobian backend not available.\n" *
-                        "Install/enable SparseConnectivityTracer and SparseMatrixColorings to activate the AutoSparse backend."
-                )
-            )
-        else
-            rethrow()
-        end
-        # COV_EXCL_STOP
-    end
+    # Prepare sparse Jacobian backend via extension; the stub throws a clear
+    # ArgumentError if SparseConnectivityTracer / SparseMatrixColorings aren't loaded.
+    jac_backend = default_sparse_jacobian_backend()
     return NonlinearLeastSquaresLikelihood{typeof(model.f), T, typeof(jac_backend)}(
         model.f, y_vec, convert.(T, inv_σ²), convert(T, log_const), jac_backend,
     )

--- a/src/utils/linsolve_utils.jl
+++ b/src/utils/linsolve_utils.jl
@@ -17,7 +17,7 @@ prepare_for_linsolve(A::AbstractMatrix, ::LinearSolve.PardisoJL) = tril(sparse(A
 # SymTridiagonal only works nicely with LDLt
 prepare_for_linsolve(A::SymTridiagonal, ::LinearSolve.LDLtFactorization) = A
 prepare_for_linsolve(A::SymTridiagonal, alg) = prepare_for_linsolve(sparse(A), alg)
-prepare_for_linsolve(A::SymTridiagonal, ::LinearSolve.PardisoJL) = prepare_for_linsolve(sparse(A), alg)
+prepare_for_linsolve(A::SymTridiagonal, alg::LinearSolve.PardisoJL) = prepare_for_linsolve(sparse(A), alg)
 
 # ldlt! doesn't work with `Symmetric`, so keep it as-is
 prepare_for_linsolve(A::AbstractMatrix, ::LinearSolve.LDLtFactorization) = A

--- a/src/utils/sparse_autodiff.jl
+++ b/src/utils/sparse_autodiff.jl
@@ -4,6 +4,19 @@
 Stubs for sparse autodiff backends. Concrete methods are provided by package
 extensions when optional dependencies are loaded (e.g., SparseConnectivityTracer
 and SparseMatrixColorings) via DifferentiationInterface.AutoSparse.
+
+The fallback below uses `Vararg{Any}`/`Any` so that any extension-provided method
+with a concrete signature takes precedence by Julia dispatch — no method
+overwriting occurs. The fallback exists so callers get a clear error (and JET
+can see a method) when the relevant extension is not loaded.
 """
 
-function default_sparse_jacobian_backend end
+function default_sparse_jacobian_backend(args::Vararg{Any}; kwargs...)
+    throw(
+        ArgumentError(
+            "Sparse Jacobian backend not available. " *
+                "Load SparseConnectivityTracer and SparseMatrixColorings " *
+                "to activate the AutoSparse backend."
+        )
+    )
+end

--- a/src/workspace/latent_model_integration.jl
+++ b/src/workspace/latent_model_integration.jl
@@ -157,7 +157,7 @@ Used by the `(::LatentModel)(ws; θ...)` fast path so that workspaces
 built with the joint prior + observation-Hessian pattern can still accept
 prior-pattern precision matrices from the model.
 """
-function _pad_to_workspace_pattern(Q::SparseMatrixCSC, ws::GMRFWorkspace)
+function _pad_to_workspace_pattern(Q::SparseMatrixCSC{T}, ws::GMRFWorkspace) where {T}
     size(Q) == size(ws.Q) ||
         throw(
         DimensionMismatch(
@@ -166,11 +166,10 @@ function _pad_to_workspace_pattern(Q::SparseMatrixCSC, ws::GMRFWorkspace)
     )
     _same_pattern(Q, ws.Q) && return Q
 
-    T = eltype(Q)
     Q_padded = SparseMatrixCSC(
         ws.Q.m, ws.Q.n,
         copy(ws.Q.colptr), copy(ws.Q.rowval),
-        zeros(T, length(ws.Q.nzval))
+        zeros(T, length(ws.Q.nzval))::Vector{T}
     )
 
     Q_rows = rowvals(Q)

--- a/test/GaussianMarkovRandomFieldsTests.jl
+++ b/test/GaussianMarkovRandomFieldsTests.jl
@@ -50,4 +50,6 @@ include("workspace/runtests.jl")
     @test length(Test.detect_ambiguities(GaussianMarkovRandomFields)) == 0
 end
 
+include("test_jet.jl")
+
 end

--- a/test/test_jet.jl
+++ b/test/test_jet.jl
@@ -1,0 +1,22 @@
+using GaussianMarkovRandomFields
+using JET
+
+@testset "JET" begin
+    if VERSION >= v"1.10" && VERSION < v"1.13-"
+        @testset "typo analysis" begin
+            JET.test_package(
+                GaussianMarkovRandomFields;
+                target_defined_modules = true,
+                mode = :typo,
+                toplevel_logger = nothing,
+            )
+        end
+        @testset "error analysis" begin
+            JET.test_package(
+                GaussianMarkovRandomFields;
+                target_defined_modules = true,
+                toplevel_logger = nothing,
+            )
+        end
+    end
+end


### PR DESCRIPTION
Closes #115.

## Summary
- Wires `JET.test_package(GaussianMarkovRandomFields)` into the test suite — both `:typo` mode and default error analysis, scoped to the package's own modules via `target_defined_modules=true`, gated by `VERSION >= v"1.10" && VERSION < v"1.13-"`.
- Fixes the 8 reports surfaced by the initial run; package now passes both JET analyses with zero reports.
- No CI changes needed — JET runs as part of the existing `julia-actions/julia-runtest@v1` job.

## Fixes

| File | What JET found | Fix |
|------|---------------|-----|
| `src/utils/linsolve_utils.jl` | Unnamed `alg` parameter in the `SymTridiagonal`/`PardisoJL` method shadowed an undefined ref | Name the parameter — real bug |
| `src/linear_maps/outer_product.jl` | `L.Q.λ` after `isa` narrowing failed because each mutable-field access re-reads the abstract field type | Bind `Q = L.Q` once, narrow the local |
| `src/arithmetic/joint.jl` | `spzeros(size(A)[1])` widened to `Union{SparseVector, SparseMatrixCSC}` since `size(A)[1]` was `::Any` | `spzeros(size(A, 1)::Int)`; drop the resulting dead `b !== nothing` branch |
| `src/arithmetic/condition/gaussian_approximation.jl` | `_ga_make_posterior(::ChordalGMRF, ::Nothing)` couldn't match the inferred `Union{Nothing, NamedTuple}` for constraints | Relax to `_ga_make_posterior(..., _)` (ChordalGMRF never carries constraints at runtime — `_extract_constraints(::ChordalGMRF) = nothing`) |
| `src/workspace/latent_model_integration.jl` | `zeros(T, n)` inferred to `Union{Vector, Matrix{Float64}}` because `T` was abstract | Add `where {T}` to the method signature, `::Vector{T}` annotation on the result |
| `src/linear_maps/ad_jacobian.jl` | 3-arg `ADJacobianAdjointMap` constructor lives in the Zygote extension only | Add a `Vararg{Any}` fallback in core that throws a clear "load Zygote" error. Extension's concrete signature still wins by dispatch, so no method-overwrite warning |
| `src/utils/sparse_autodiff.jl` + `nonlinear_least_squares.jl` | `default_sparse_jacobian_backend` was an extensionless stub | Same pattern (Vararg fallback). Lets us drop the brittle `try { ... } catch err::MethodError ...` wrapper |

## Test plan
- [x] `JET.test_package(...; mode=:typo)` — 0 reports
- [x] `JET.test_package(...)` (default error analysis) — 0 reports
- [x] Focused ReTest run hitting all modified modules (`OuterProductMap`, `AD Jacobian`, `GMRF arithmetic`, `Constrained Gaussian Approximation`, `Workspace*`, `LatentModel Call Interface`, etc.) — 837/837 pass
- [x] `NonlinearLeastSquares` + `Pointwise Log-Likelihood` testsets — 24/24 pass (confirms the simplified `default_sparse_jacobian_backend` path)
- [x] `runic --check` on all modified files — clean