### PR TITLE
Hyperparameter-dependent affine offset for LinearlyTransformedObservationModel (#137)

### DIFF
--- a/docs/src/reference/observation_models.md
+++ b/docs/src/reference/observation_models.md
@@ -567,6 +567,7 @@ PointSecondDerivativeObsModel
 LinearlyTransformedObservationModel
 LinearlyTransformedLikelihood
 ParameterizedMatrix
+ParameterizedOffset
 PoissonObservations
 NegativeBinomialObservations
 counts

--- a/ext/forwarddiff/autodiff_likelihood_dual.jl
+++ b/ext/forwarddiff/autodiff_likelihood_dual.jl
@@ -91,12 +91,18 @@ function _primal_obs_lik(lik::GMRFs.LinearlyTransformedLikelihood)
     return GMRFs.LinearlyTransformedLikelihood(
         _primal_obs_lik(lik.base_likelihood),
         _strip_matrix_partials(lik.design_matrix),
+        _strip_offset_partials(lik.offset),
     )
 end
 
 # Strip Dual partials from a (possibly θ-dependent) design matrix.
 _strip_matrix_partials(A::AbstractMatrix{<:ForwardDiff.Dual}) = ForwardDiff.value.(A)
 _strip_matrix_partials(A::AbstractMatrix) = A
+
+# Strip Dual partials from a (possibly θ-dependent) affine offset.
+_strip_offset_partials(::Nothing) = nothing
+_strip_offset_partials(b::AbstractVector{<:ForwardDiff.Dual}) = ForwardDiff.value.(b)
+_strip_offset_partials(b::AbstractVector) = b
 
 # NonlinearLeastSquaresLikelihood: strip the σ-derived numeric fields (Dual when σ
 # carried partials) and the stored residual hyperparameters (Dual when an `f(x; θ...)`

--- a/ext/forwarddiff/autodiff_likelihood_ift.jl
+++ b/ext/forwarddiff/autodiff_likelihood_ift.jl
@@ -51,7 +51,9 @@ _lik_carries_dual_hp(::_DualObsLik) = true
 _lik_carries_dual_hp(lik::GMRFs.CompositeLikelihood) =
     any(_lik_carries_dual_hp, lik.components)
 _lik_carries_dual_hp(lik::GMRFs.LinearlyTransformedLikelihood) =
-    _lik_carries_dual_hp(lik.base_likelihood) || GMRFs._carries_ad_partials(lik.design_matrix)
+    _lik_carries_dual_hp(lik.base_likelihood) ||
+    GMRFs._carries_ad_partials(lik.design_matrix) ||
+    GMRFs._carries_ad_partials(lik.offset)
 _lik_carries_dual_hp(lik::GMRFs.NonlinearLeastSquaresLikelihood) =
     GMRFs._hp_carries_ad_partials(lik.hyperparams) || GMRFs._carries_ad_partials(lik.inv_σ²)
 
@@ -116,11 +118,12 @@ end
 _q_post_with_pattern(Q_prior::SparseMatrixCSC, nzval_dual) =
     SparseMatrixCSC(Q_prior.m, Q_prior.n, copy(Q_prior.colptr), copy(Q_prior.rowval), nzval_dual)
 
-# Diagonal H_dual — subtract H from a `DualT`-lifted copy of Q_prior's nzval.
-# Works for both Float64 and Dual Q_prior; native `Dual - Dual` arithmetic
-# composes the prior's existing partials with H's.
+# Diagonal H — subtract H from a `DualT`-lifted copy of Q_prior's nzval. The eltype
+# is `<:Real` (not just `<:Dual`): a Dual H composes its partials, while a Float64 H
+# (e.g. a Normal base whose Hessian is offset/hyperparameter-invariant) subtracts with
+# zero θ-partials — the precision genuinely doesn't depend on that hyperparameter.
 function _assemble_q_post_dual(
-        Q_prior::SparseMatrixCSC, H_dual::Diagonal{<:ForwardDiff.Dual},
+        Q_prior::SparseMatrixCSC, H_dual::Diagonal{<:Real},
         ::Type{DualT}, ::Val{N}
     ) where {DualT, N}
     n = size(Q_prior, 1)
@@ -143,7 +146,7 @@ end
 # isn't applicable for this likelihood/prior combination.
 function _assemble_q_post_dual(
         Q_prior::SparseMatrixCSC,
-        H_dual::SparseMatrixCSC{<:ForwardDiff.Dual},
+        H_dual::SparseMatrixCSC{<:Real},
         ::Type{DualT}, ::Val{N}
     ) where {DualT, N}
     _check_h_pattern_subset(H_dual, Q_prior)
@@ -197,7 +200,7 @@ end
 # a less actionable message, so we error explicitly with guidance.
 function _assemble_q_post_dual(
         Q_prior::SparseMatrixCSC,
-        H_dual::AbstractMatrix{<:ForwardDiff.Dual},
+        H_dual::AbstractMatrix{<:Real},
         ::Type{DualT}, ::Val{N}
     ) where {DualT, N}
     throw(
@@ -244,7 +247,9 @@ end
 function _lik_dual_tag_npartials(lik::GMRFs.LinearlyTransformedLikelihood)
     T1, N1 = _lik_dual_tag_npartials(lik.base_likelihood)
     T2, N2 = _array_tag_npartials(lik.design_matrix)
-    return _reconcile_tag_npartials(T1, N1, T2, N2)
+    T3, N3 = _array_tag_npartials(lik.offset)
+    Tm, Nm = _reconcile_tag_npartials(T1, N1, T2, N2)
+    return _reconcile_tag_npartials(Tm, Nm, T3, N3)
 end
 
 function _lik_dual_tag_npartials(lik::GMRFs.NonlinearLeastSquaresLikelihood)
@@ -254,10 +259,11 @@ function _lik_dual_tag_npartials(lik::GMRFs.NonlinearLeastSquaresLikelihood)
     return _reconcile_tag_npartials(T1, N1, T2, N2)
 end
 
-# (Tag, N) of a Dual-eltype array, or (nothing, nothing) for a plain array.
+# (Tag, N) of a Dual-eltype array, or (nothing, nothing) for a plain/absent array.
 _array_tag_npartials(A::AbstractArray{<:ForwardDiff.Dual}) =
     (ForwardDiff.tagtype(eltype(A)), ForwardDiff.npartials(eltype(A)))
 _array_tag_npartials(::AbstractArray) = (nothing, nothing)
+_array_tag_npartials(::Nothing) = (nothing, nothing)
 
 # Combine two (Tag, N) results, erroring if both are present but disagree.
 function _reconcile_tag_npartials(T1, N1, T2, N2)

--- a/src/arithmetic/condition/gaussian_approximation.jl
+++ b/src/arithmetic/condition/gaussian_approximation.jl
@@ -281,16 +281,21 @@ function gaussian_approximation(prior_gmrf::GMRF, obs_lik::NormalLikelihood{Iden
     end
 end
 
+# Affine offset of a LinearlyTransformedLikelihood as a concrete vector for the
+# conjugate path: `y ~ N(A·x + b, σ²)` ⇒ `y = A·x + b + ε`, matching linear_condition's `b`.
+_offset_or_zeros(::Nothing, n::Integer) = zeros(n)
+_offset_or_zeros(b::AbstractVector, ::Integer) = b
+
 # Specialized dispatch for linearly transformed Normal observation likelihoods (also conjugate)
 function gaussian_approximation(prior_gmrf::GMRF, obs_lik::LinearlyTransformedLikelihood{<:NormalLikelihood{IdentityLink}})
-    # Linearly transformed Normal with identity link: y ~ N(A*x, σ²I) - still conjugate!
-    # This is exactly the linear conditioning setup: y = A*x + 0 + ε, where ε ~ N(0, σ²I)
+    # Linearly transformed Normal with identity link: y ~ N(A*x + b, σ²I) - still conjugate!
+    # This is exactly the linear conditioning setup: y = A*x + b + ε, where ε ~ N(0, σ²I)
 
     base_lik = obs_lik.base_likelihood
     A = obs_lik.design_matrix
     Q_ϵ = base_lik.inv_σ²  # 1/σ² (scalar gets converted to scaled identity automatically)
     y = base_lik.y
-    b = zeros(length(y))  # No offset
+    b = _offset_or_zeros(obs_lik.offset, length(y))
 
     return linear_condition(prior_gmrf; A = A, Q_ϵ = Q_ϵ, y = y, b = b)
 end
@@ -332,7 +337,7 @@ function gaussian_approximation(prior_constrained::ConstrainedGMRF, obs_lik::Lin
         A = obs_lik.design_matrix,
         Q_ϵ = base_lik.inv_σ²,
         y = base_lik.y,
-        b = zeros(length(base_lik.y))
+        b = _offset_or_zeros(obs_lik.offset, length(base_lik.y))
     )
 end
 

--- a/src/observation_models/linearly_transformed.jl
+++ b/src/observation_models/linearly_transformed.jl
@@ -1,7 +1,7 @@
 using LinearAlgebra
 using SparseArrays
 
-export LinearlyTransformedObservationModel, LinearlyTransformedLikelihood, ParameterizedMatrix
+export LinearlyTransformedObservationModel, LinearlyTransformedLikelihood, ParameterizedMatrix, ParameterizedOffset
 
 """
     ParameterizedMatrix(builder; hyperparameters::Tuple{Vararg{Symbol}}, n_latent=nothing)
@@ -61,6 +61,66 @@ _design_matrix_latent_dim(A::AbstractMatrix) = size(A, 2)
 _design_matrix_latent_dim(spec::ParameterizedMatrix) = spec.n_latent
 
 """
+    ParameterizedOffset(builder; hyperparameters::Tuple{Vararg{Symbol}})
+
+A hyperparameter-dependent additive offset `b` for [`LinearlyTransformedObservationModel`](@ref),
+making the linear predictor affine: `η = A·x + b`.
+
+`builder` is a keyword-callable returning the concrete offset vector when invoked with the
+hyperparameters it declares: `builder(; θ...) -> AbstractVector`. `hyperparameters` lists the
+θ-names `builder` consumes; they are merged into the model's `hyperparameters` and routed to
+`builder` when the model is materialized.
+
+The offset is resolved once, inside `model(y; θ...)`, so the materialized
+[`LinearlyTransformedLikelihood`](@ref) and all downstream conditioning see only a concrete
+vector — there is no per-evaluation overhead beyond the single `builder` call.
+
+# Example
+```julia
+# Observing a PDE residual ℒu − S(θ) at collocation points: affine in u, with a
+# hyperparameter-dependent forcing offset b = −S(θ).
+build_b(; s) = -source_term(s)            # length fixed; only values depend on s
+ltom = LinearlyTransformedObservationModel(
+    ExponentialFamily(Normal), ℒ_matrix;
+    offset = ParameterizedOffset(build_b; hyperparameters = (:s,)),
+)
+ltlik = ltom(y; σ = 1.0, s = 0.3)         # σ → base model, s → build_b
+```
+
+!!! warning "θ-independent length"
+    The offset's *values* may depend on the hyperparameters, but its *length* may not — it
+    must match the number of observations so the workspace symbolic factorization stays valid.
+
+See also: [`LinearlyTransformedObservationModel`](@ref), [`ParameterizedMatrix`](@ref).
+"""
+struct ParameterizedOffset{B, H <: Tuple{Vararg{Symbol}}}
+    builder::B
+    hp_names::H
+end
+
+ParameterizedOffset(builder; hyperparameters::Tuple{Vararg{Symbol}}) =
+    ParameterizedOffset(builder, hyperparameters)
+
+# Resolve a (possibly parameterized) offset at materialization time. `nothing` (no offset)
+# and a fixed vector resolve to themselves (identity, selected by dispatch → no runtime
+# branch); a ParameterizedOffset is built once.
+@inline _resolve_offset(::Nothing, ::NamedTuple) = nothing
+@inline _resolve_offset(b::AbstractVector, ::NamedTuple) = b
+function _resolve_offset(spec::ParameterizedOffset, θ::NamedTuple)
+    return spec.builder(; _project_hyperparameters(spec.hp_names, θ)...)
+end
+
+# Hyperparameter names contributed by the offset.
+_offset_hp_names(::Nothing) = ()
+_offset_hp_names(::AbstractVector) = ()
+_offset_hp_names(spec::ParameterizedOffset) = spec.hp_names
+
+# Affine linear predictor η = A·x (+ b). The `Nothing` method is the pure-linear path,
+# byte-for-byte the pre-offset behaviour with no allocation for an absent offset.
+@inline _linear_predictor(A, x, ::Nothing) = A * x
+@inline _linear_predictor(A, x, b::AbstractVector) = A * x .+ b
+
+"""
     LinearlyTransformedObservationModel{M, A} <: ObservationModel
 
 Observation model that applies a linear transformation to the latent field before 
@@ -78,11 +138,13 @@ design matrix A:
 
 # Type Parameters
 - `M <: ObservationModel`: Type of the base observation model
-- `A`: Type of the design matrix (typically AbstractMatrix)
+- `A`: Type of the design matrix (`AbstractMatrix` or [`ParameterizedMatrix`](@ref))
+- `B`: Type of the offset (`Nothing`, `AbstractVector`, or [`ParameterizedOffset`](@ref))
 
 # Fields
 - `base_model::M`: The underlying observation model that operates on linear predictors
 - `design_matrix::A`: Matrix mapping full latent field to observation-specific linear predictors
+- `offset::B`: Optional additive offset `b` making the predictor affine (`η = A·x + b`); `nothing` for no offset
 
 # Usage Pattern
 ```julia
@@ -109,21 +171,40 @@ obs_lik = obs_model(y; σ=1.2)  # Creates LinearlyTransformedLikelihood
 ll = loglik(x_full, obs_lik)
 ```
 
+# Affine offset
+The predictor may be made affine, `η = A·x + b`, via the `offset` keyword: a fixed
+vector or a [`ParameterizedOffset`](@ref) builder. The offset is resolved at
+materialization; `nothing` (the default) is the pure-linear path with no overhead.
+
 # Hyperparameters
 By default all hyperparameters come from the base observation model and the design
 matrix introduces none — it's a fixed linear transformation. To let the design matrix
-depend on hyperparameters, pass a [`ParameterizedMatrix`](@ref) instead of a plain
-matrix; its declared hyperparameters are merged into `hyperparameters(model)` and the
-concrete matrix is built once at materialization.
+or the offset depend on hyperparameters, pass a [`ParameterizedMatrix`](@ref) and/or a
+[`ParameterizedOffset`](@ref); their declared hyperparameters are merged into
+`hyperparameters(model)` and resolved once at materialization.
 
-See also: [`LinearlyTransformedLikelihood`](@ref), [`ParameterizedMatrix`](@ref), [`ExponentialFamily`](@ref), [`ObservationModel`](@ref)
+See also: [`LinearlyTransformedLikelihood`](@ref), [`ParameterizedMatrix`](@ref), [`ParameterizedOffset`](@ref), [`ExponentialFamily`](@ref), [`ObservationModel`](@ref)
 """
-struct LinearlyTransformedObservationModel{M <: ObservationModel, A} <: ObservationModel
+struct LinearlyTransformedObservationModel{M <: ObservationModel, A, B} <: ObservationModel
     base_model::M
     design_matrix::A
+    offset::B
 end
 
-function LinearlyTransformedObservationModel(base_model::ObservationModel, design_matrix::AbstractMatrix)
+# Validate the offset spec at construction: must be nothing, a fixed vector, or a
+# ParameterizedOffset. (Length is checked at materialization against the design matrix.)
+_validate_offset(::Nothing) = nothing
+_validate_offset(::AbstractVector) = nothing
+_validate_offset(::ParameterizedOffset) = nothing
+# COV_EXCL_START
+_validate_offset(offset) = throw(
+    ArgumentError(
+        "offset must be `nothing`, an `AbstractVector`, or a `ParameterizedOffset`; got $(typeof(offset))."
+    )
+)
+# COV_EXCL_STOP
+
+function LinearlyTransformedObservationModel(base_model::ObservationModel, design_matrix::AbstractMatrix; offset = nothing)
     # Validate that design matrix is appropriate
     # COV_EXCL_START
     if size(design_matrix, 1) == 0
@@ -136,13 +217,16 @@ function LinearlyTransformedObservationModel(base_model::ObservationModel, desig
     if design_matrix isa Matrix
         @warn "Received a dense design matrix. This can lead to major performance bottlenecks!"
     end
-    return LinearlyTransformedObservationModel{typeof(base_model), typeof(design_matrix)}(base_model, design_matrix)
+    _validate_offset(offset)
+    return LinearlyTransformedObservationModel{typeof(base_model), typeof(design_matrix), typeof(offset)}(base_model, design_matrix, offset)
 end
 
 # Parameterized design matrix: no shape validation possible until the matrix is
 # built (deferred to materialization); just store the spec.
-LinearlyTransformedObservationModel(base_model::ObservationModel, design_matrix::ParameterizedMatrix) =
-    LinearlyTransformedObservationModel{typeof(base_model), typeof(design_matrix)}(base_model, design_matrix)
+function LinearlyTransformedObservationModel(base_model::ObservationModel, design_matrix::ParameterizedMatrix; offset = nothing)
+    _validate_offset(offset)
+    return LinearlyTransformedObservationModel{typeof(base_model), typeof(design_matrix), typeof(offset)}(base_model, design_matrix, offset)
+end
 
 """
     LinearlyTransformedLikelihood{L, A} <: ObservationLikelihood
@@ -155,11 +239,13 @@ data and hyperparameters, following the factory pattern used throughout the pack
 
 # Type Parameters
 - `L <: ObservationLikelihood`: Type of the materialized base likelihood
-- `A`: Type of the design matrix
+- `A`: Type of the (resolved, concrete) design matrix
+- `B`: Type of the (resolved) offset — `Nothing` or a concrete `AbstractVector`
 
 # Fields
 - `base_likelihood::L`: Materialized base observation likelihood (contains y and θ)
 - `design_matrix::A`: Design matrix mapping full latent field to linear predictors
+- `offset::B`: Additive offset `b` (`η = A·x + b`), or `nothing` for the pure-linear `η = A·x`
 
 # Usage
 This type is typically created automatically:
@@ -169,10 +255,15 @@ ltlik = ltom(y; σ=1.2)  # Creates LinearlyTransformedLikelihood
 ll = loglik(x_full, ltlik)  # Fast evaluation
 ```
 """
-struct LinearlyTransformedLikelihood{L <: ObservationLikelihood, A} <: ObservationLikelihood
+struct LinearlyTransformedLikelihood{L <: ObservationLikelihood, A, B} <: ObservationLikelihood
     base_likelihood::L
     design_matrix::A
+    offset::B
 end
+
+# Backward-compatible constructor: no offset (η = A·x).
+LinearlyTransformedLikelihood(base_likelihood::ObservationLikelihood, design_matrix) =
+    LinearlyTransformedLikelihood(base_likelihood, design_matrix, nothing)
 
 # =======================================================================================
 # FACTORY PATTERN: Make LinearlyTransformedObservationModel callable
@@ -182,18 +273,37 @@ function (ltom::LinearlyTransformedObservationModel)(y; kwargs...)
     # Create materialized base likelihood (base model picks the kwargs it needs).
     base_likelihood = ltom.base_model(y; kwargs...)
 
-    # Resolve the design matrix at θ (identity for a plain matrix; one builder
-    # call for a ParameterizedMatrix) and wrap.
-    A = _resolve_design_matrix(ltom.design_matrix, values(kwargs))
-    return LinearlyTransformedLikelihood(base_likelihood, A)
+    # Resolve the design matrix and offset at θ (identity for fixed objects; one
+    # builder call for a ParameterizedMatrix / ParameterizedOffset) and wrap.
+    θ_nt = values(kwargs)
+    A = _resolve_design_matrix(ltom.design_matrix, θ_nt)
+    b = _resolve_offset(ltom.offset, θ_nt)
+    _check_offset_length(b, A)
+    return LinearlyTransformedLikelihood(base_likelihood, A, b)
 end
+
+# The offset length must match the number of observations (rows of A); this is the
+# `θ-independent length` contract surfaced at materialization with a clear message.
+_check_offset_length(::Nothing, _) = nothing
+function _check_offset_length(b::AbstractVector, A::AbstractMatrix)
+    length(b) == size(A, 1) || throw(
+        DimensionMismatch(
+            "offset has length $(length(b)) but the design matrix has $(size(A, 1)) rows (observations)."
+        )
+    )
+    return nothing
+end
+_check_offset_length(::AbstractVector, _) = nothing  # non-matrix A (e.g. UniformScaling): skip
 
 # =======================================================================================
 # HYPERPARAMETER INTERFACE DELEGATION
 # =======================================================================================
 
 hyperparameters(ltom::LinearlyTransformedObservationModel) =
-    _merge_hyperparameter_names(hyperparameters(ltom.base_model), _design_matrix_hp_names(ltom.design_matrix))
+    _merge_hyperparameter_names(
+    _merge_hyperparameter_names(hyperparameters(ltom.base_model), _design_matrix_hp_names(ltom.design_matrix)),
+    _offset_hp_names(ltom.offset),
+)
 latent_dimension(ltom::LinearlyTransformedObservationModel, y::AbstractVector) = _design_matrix_latent_dim(ltom.design_matrix)
 
 # =======================================================================================
@@ -201,23 +311,24 @@ latent_dimension(ltom::LinearlyTransformedObservationModel, y::AbstractVector) =
 # =======================================================================================
 
 function loglik(x_full, ltlik::LinearlyTransformedLikelihood)
-    η = ltlik.design_matrix * x_full
+    η = _linear_predictor(ltlik.design_matrix, x_full, ltlik.offset)
     return loglik(η, ltlik.base_likelihood)
 end
 
 function loggrad(x_full, ltlik::LinearlyTransformedLikelihood)
-    η = ltlik.design_matrix * x_full
+    η = _linear_predictor(ltlik.design_matrix, x_full, ltlik.offset)
     grad_η = loggrad(η, ltlik.base_likelihood)
-    return ltlik.design_matrix' * grad_η  # Chain rule: A^T * grad_η
+    return ltlik.design_matrix' * grad_η  # Chain rule: A^T * grad_η (offset is x-independent)
 end
 
 function loghessian(x_full, ltlik::LinearlyTransformedLikelihood)
-    η = ltlik.design_matrix * x_full
+    η = _linear_predictor(ltlik.design_matrix, x_full, ltlik.offset)
     hess_η = loghessian(η, ltlik.base_likelihood)
     A = ltlik.design_matrix
 
-    # Chain rule: A^T * hess_η * A
-    # This preserves sparsity patterns efficiently
+    # Chain rule: A^T * hess_η * A. η = A·x + b is affine in x, so the additive
+    # offset leaves ∂η/∂x = A and the Hessian structure unchanged (it only shifts the
+    # point η at which the base Hessian is evaluated).
     return Symmetric(A' * hess_η * A)
 end
 
@@ -230,7 +341,7 @@ The design matrix A maps the full latent field to observation-specific linear pr
 η = A * x_full, then pointwise log-likelihoods are computed from the base likelihood.
 """
 function _pointwise_loglik(::ConditionallyIndependent, x_full, ltlik::LinearlyTransformedLikelihood)
-    η = ltlik.design_matrix * x_full
+    η = _linear_predictor(ltlik.design_matrix, x_full, ltlik.offset)
     return pointwise_loglik(η, ltlik.base_likelihood)
 end
 
@@ -243,7 +354,7 @@ Computes η = A * x_full and delegates to the base likelihood's in-place method.
 Note: Allocates temporary storage for η (cannot avoid this allocation).
 """
 function _pointwise_loglik!(::ConditionallyIndependent, result, x_full, ltlik::LinearlyTransformedLikelihood)
-    η = ltlik.design_matrix * x_full  # Allocates - unavoidable
+    η = _linear_predictor(ltlik.design_matrix, x_full, ltlik.offset)  # Allocates - unavoidable
     return pointwise_loglik!(result, η, ltlik.base_likelihood)
 end
 
@@ -252,20 +363,26 @@ end
 # =======================================================================================
 
 function conditional_distribution(ltom::LinearlyTransformedObservationModel, x_full; kwargs...)
-    A = _resolve_design_matrix(ltom.design_matrix, values(kwargs))
-    η = A * x_full
+    θ_nt = values(kwargs)
+    A = _resolve_design_matrix(ltom.design_matrix, θ_nt)
+    b = _resolve_offset(ltom.offset, θ_nt)
+    η = _linear_predictor(A, x_full, b)
     return conditional_distribution(ltom.base_model, η; kwargs...)
 end
 
 # COV_EXCL_START
+_offset_descr(::Nothing) = "none"
+_offset_descr(b::AbstractVector) = "fixed($(length(b)))"
+_offset_descr(spec::ParameterizedOffset) = "parameterized($(isempty(spec.hp_names) ? "none" : join(spec.hp_names, ", ")))"
+
 function Base.show(io::IO, model::LinearlyTransformedObservationModel)
     A = model.design_matrix
-    if A isa ParameterizedMatrix
-        names = isempty(A.hp_names) ? "none" : join(A.hp_names, ", ")
-        return print(io, "LinearlyTransformedObservationModel(base=$(typeof(model.base_model)), A=parameterized($(names)))")
+    A_str = if A isa ParameterizedMatrix
+        "parameterized($(isempty(A.hp_names) ? "none" : join(A.hp_names, ", ")))"
+    else
+        m, n = size(A)
+        "$(m)×$(n) $(A isa SparseArrays.AbstractSparseMatrix ? "sparse" : "dense")"
     end
-    m, n = size(A)
-    A_kind = A isa SparseArrays.AbstractSparseMatrix ? "sparse" : "dense"
-    return print(io, "LinearlyTransformedObservationModel(base=$(typeof(model.base_model)), A=$(m)×$(n) $(A_kind))")
+    return print(io, "LinearlyTransformedObservationModel(base=$(typeof(model.base_model)), A=$(A_str), offset=$(_offset_descr(model.offset)))")
 end
 # COV_EXCL_STOP

--- a/test/observation_models/test_linearly_transformed.jl
+++ b/test/observation_models/test_linearly_transformed.jl
@@ -154,4 +154,73 @@ using Distributions
         end
     end
 
+    @testset "Affine offset (η = A·x + b)" begin
+        base = ExponentialFamily(Normal)
+        A = sparse([1.0 0.5; 0.0 1.0])
+        y = [1.0, 2.0]
+        x = [0.5, 1.0]
+
+        @testset "No offset is backward-compatible" begin
+            ltom = LinearlyTransformedObservationModel(base, A)
+            ltlik = ltom(y; σ = 1.0)
+            @test ltlik.offset === nothing
+            @test loglik(x, ltlik) ≈ loglik(A * x, base(y; σ = 1.0))   # η = A·x
+            @test hyperparameters(ltom) == (:σ,)
+        end
+
+        @testset "Fixed offset" begin
+            b = [0.3, -0.2]
+            ltom = LinearlyTransformedObservationModel(base, A; offset = b)
+            ltlik = ltom(y; σ = 1.0)
+            @test ltlik.offset == b
+            η = A * x .+ b
+            @test loglik(x, ltlik) ≈ loglik(η, base(y; σ = 1.0))
+            @test loggrad(x, ltlik) ≈ A' * loggrad(η, base(y; σ = 1.0))
+            @test loghessian(x, ltlik) ≈ A' * loghessian(η, base(y; σ = 1.0)) * A
+            @test loggrad(x, ltlik) ≈ ForwardDiff.gradient(z -> loglik(z, ltlik), x)
+            @test hyperparameters(ltom) == (:σ,)            # fixed offset adds no names
+        end
+
+        @testset "ParameterizedOffset materialization + merging" begin
+            build_b(; s) = [s, 2s]
+            spec = ParameterizedOffset(build_b; hyperparameters = (:s,))
+            ltom = LinearlyTransformedObservationModel(base, A; offset = spec)
+            @test hyperparameters(ltom) == (:σ, :s)         # base, then offset
+            ltlik = ltom(y; σ = 1.0, s = 0.5)
+            @test ltlik.offset == build_b(; s = 0.5)
+            @test loglik(x, ltlik) ≈ loglik(A * x .+ build_b(; s = 0.5), base(y; σ = 1.0))
+        end
+
+        @testset "Parameterized offset == fixed at same θ" begin
+            build_b(; s) = [s, 2s]
+            s0 = 0.4
+            lf = LinearlyTransformedObservationModel(base, A; offset = build_b(; s = s0))(y; σ = 1.0)
+            lp = LinearlyTransformedObservationModel(
+                base, A; offset = ParameterizedOffset(build_b; hyperparameters = (:s,))
+            )(y; σ = 1.0, s = s0)
+            @test loglik(x, lp) ≈ loglik(x, lf)
+            @test loggrad(x, lp) ≈ loggrad(x, lf)
+            @test loghessian(x, lp) ≈ loghessian(x, lf)
+        end
+
+        @testset "Conjugate Normal path shifts mean by offset" begin
+            b = [0.5, -0.3]
+            prior = GMRF(zeros(2), sparse(2.0 * I, 2, 2))
+            post = gaussian_approximation(prior, LinearlyTransformedObservationModel(base, A; offset = b)(y; σ = 1.0))
+            # Equivalent: no offset, conditioning on shifted data y − b.
+            post0 = gaussian_approximation(prior, LinearlyTransformedObservationModel(base, A)(y .- b; σ = 1.0))
+            @test mean(post) ≈ mean(post0)
+        end
+
+        @testset "Errors" begin
+            build_b(; s) = [s, 2s]
+            ltom = LinearlyTransformedObservationModel(
+                base, A; offset = ParameterizedOffset(build_b; hyperparameters = (:s,))
+            )
+            @test_throws ArgumentError ltom(y; σ = 1.0)               # s missing
+            # offset length must match the number of observations
+            @test_throws DimensionMismatch LinearlyTransformedObservationModel(base, A; offset = [1.0, 2.0, 3.0])(y; σ = 1.0)
+        end
+    end
+
 end

--- a/test/observation_models/test_parameterized_obs_models_ift.jl
+++ b/test/observation_models/test_parameterized_obs_models_ift.jl
@@ -182,3 +182,107 @@ end
         @test_throws ArgumentError ChainRulesCore.rrule(cfg, gaussian_approximation, wprior, lik)
     end
 end
+
+# Affine offset hyperparameter sensitivities. η = A·x + b is affine in x, so the
+# offset enters the IFT through the (cheap) offset builder only: it shifts the mode and,
+# for non-Gaussian bases, the point at which the base Hessian is evaluated. Exactness is
+# cross-checked against finite differences for Gaussian (offset-invariant Hessian) and
+# Poisson (offset-shifted Hessian) bases.
+@testset "Parameterized offset — ForwardDiff IFT" begin
+    fd = AutoFiniteDiff()
+
+    @testset "Normal base, Dual offset (workspace IFT)" begin
+        Random.seed!(21)
+        n = 5
+        model = AR1Model(n)
+        A = sparse(1.0 * I, n, n)
+        build_b(; s) = fill(s, n)
+        ltom = LinearlyTransformedObservationModel(
+            ExponentialFamily(Normal), A;
+            offset = ParameterizedOffset(build_b; hyperparameters = (:s,))
+        )
+        y = randn(n)
+        z = zeros(n)
+        ws = make_workspace(model; τ = 1.0, ρ = 0.3)
+        function pipe(θ)
+            prior = model(ws; τ = 1.0, ρ = 0.3)
+            lik = ltom(y; σ = 1.0, s = θ[1])
+            return logpdf(gaussian_approximation(prior, lik), z)
+        end
+        gF = DifferentiationInterface.gradient(pipe, AutoForwardDiff(), [0.4])
+        gD = DifferentiationInterface.gradient(pipe, fd, [0.4])
+        @test maximum(abs.(gF - gD)) < 1.0e-3
+    end
+
+    @testset "Poisson base, Dual offset shifts the Hessian (workspace IFT)" begin
+        Random.seed!(22)
+        n = 5
+        model = AR1Model(n)
+        A = sparse(1.0 * I, n, n)
+        build_b(; s) = fill(s, n)
+        ltom = LinearlyTransformedObservationModel(
+            ExponentialFamily(Poisson), A;
+            offset = ParameterizedOffset(build_b; hyperparameters = (:s,))
+        )
+        y = PoissonObservations([2, 1, 3, 0, 4])
+        z = zeros(n)
+        ws = make_workspace(model; τ = 1.0, ρ = 0.3)
+        function pipe(θ)
+            prior = model(ws; τ = 1.0, ρ = 0.3)
+            lik = ltom(y; s = θ[1])
+            return logpdf(gaussian_approximation(prior, lik), z)
+        end
+        gF = DifferentiationInterface.gradient(pipe, AutoForwardDiff(), [0.2])
+        gD = DifferentiationInterface.gradient(pipe, fd, [0.2])
+        @test maximum(abs.(gF - gD)) < 1.0e-3
+    end
+
+    @testset "Joint Dual offset + Dual design matrix" begin
+        Random.seed!(23)
+        n = 5
+        model = AR1Model(n)
+        build_A(; κ) = sparse(Diagonal(fill(κ, n)))
+        build_b(; s) = fill(s, n)
+        ltom = LinearlyTransformedObservationModel(
+            ExponentialFamily(Normal),
+            ParameterizedMatrix(build_A; hyperparameters = (:κ,), n_latent = n);
+            offset = ParameterizedOffset(build_b; hyperparameters = (:s,))
+        )
+        @test hyperparameters(ltom) == (:σ, :κ, :s)
+        y = randn(n)
+        z = zeros(n)
+        ws = make_workspace(model; τ = 1.0, ρ = 0.3)
+        function pipe(θ)
+            prior = model(ws; τ = 1.0, ρ = 0.3)
+            lik = ltom(y; σ = 1.0, κ = θ[1], s = θ[2])
+            return logpdf(gaussian_approximation(prior, lik), z)
+        end
+        gF = DifferentiationInterface.gradient(pipe, AutoForwardDiff(), [0.8, 0.4])
+        gD = DifferentiationInterface.gradient(pipe, fd, [0.8, 0.4])
+        @test maximum(abs.(gF - gD)) < 1.0e-3
+    end
+
+    @testset "Dual offset + Dual prior (GMRF{Dual} plain path)" begin
+        Random.seed!(24)
+        n = 5
+        model = AR1Model(n)
+        A = sparse(1.0 * I, n, n)
+        build_b(; s) = fill(s, n)
+        ltom = LinearlyTransformedObservationModel(
+            ExponentialFamily(Normal), A;
+            offset = ParameterizedOffset(build_b; hyperparameters = (:s,))
+        )
+        y = randn(n)
+        z = zeros(n)
+        function pipe(θ)
+            μ = mean(model; τ = exp(θ[1]), ρ = 0.3)
+            Q = sparse(precision_matrix(model; τ = exp(θ[1]), ρ = 0.3))
+            prior = GMRF(μ, Q)
+            lik = ltom(y; σ = 1.0, s = θ[2])
+            return logpdf(gaussian_approximation(prior, lik), z)
+        end
+        gF = DifferentiationInterface.gradient(pipe, AutoForwardDiff(), [0.1, 0.4])
+        gD = DifferentiationInterface.gradient(pipe, fd, [0.1, 0.4])
+        @test maximum(abs.(gF - gD)) < 1.0e-3
+    end
+end


### PR DESCRIPTION
Closes #137. Completes the affine trio — design matrix, residual, **offset** — for hyperparameter-dependent observation structure.

**Stacked on #136** (`ParameterizedMatrix` / NLSQ residual / the forward-mode IFT machinery this reuses). Base branch is `theta-dependent-obs-models`; GitHub will retarget to `main` once #136 merges.

## Summary

`LinearlyTransformedObservationModel`'s linear predictor is now affine, `η = A·x + b`, where `b` is an optional fixed vector or a hyperparameter-dependent `ParameterizedOffset`, resolved once at materialization. The no-offset path dispatches to an identity (`offset = nothing`, the default), so it is zero-overhead and fully backward-compatible.

This keeps affine-in-latent Gaussian observations with hyperparameter-dependent structure on the fast conjugate / Gauss–Newton path with exact gradients, instead of falling back to a dense-AD-Hessian `AutoDiffObservationModel`. Motivating case (from the issue): observing a PDE residual `ℒu − S(θ)` at collocation points, where the forcing `S(θ)` is parameterized by hyperparameters being inferred.

## API

```julia
# Fixed offset
ltom = LinearlyTransformedObservationModel(base, A; offset = b)

# Hyperparameter-dependent offset
build_b(; s) = -source_term(s)           # length fixed; only values depend on s
ltom = LinearlyTransformedObservationModel(
    base, ℒ; offset = ParameterizedOffset(build_b; hyperparameters = (:s,)))
ltlik = ltom(y; σ = 1.0, s = 0.3)        # σ → base, s → build_b
```

## How it works

- `η = A·x + b` via an identity-vs-vector dispatch (`_linear_predictor`); loglik/loggrad/loghessian fold in the offset, with the absent-offset path byte-for-byte the previous `η = A·x`.
- `hyperparameters(model)` reports the ordered union of base, design-matrix, and offset names.
- **Conjugate Normal path**: the offset maps directly to `linear_condition`'s `b` (`y ~ N(A·x + b, σ²) ⇔ y = A·x + b + ε`).
- **Exact forward-mode hyperparameter gradients** via #136's IFT: a `Dual` offset threads `db/dθ` through `loggrad`/`loghessian`. Because `η = A·x + b` is affine in `x`, `A'·H(η)·A` is already the *exact* Hessian — no curvature correction is needed (that was NLSQ-specific, for its nonlinear residual). For a Normal base the Hessian is offset-invariant; for non-Gaussian bases the offset just shifts where `H(η)` is evaluated. `_assemble_q_post_dual` was relaxed to accept a real (θ-invariant) Hessian so the offset-only-Normal case assembles correctly.

## Contract

The offset's *values* may depend on θ, but its *length* may not (checked at materialization) — keeping the workspace symbolic factorization valid. Same shape as `ParameterizedMatrix`.

## Tests

- **Offset core**: no-offset backward compat, fixed offset (loglik/grad/hess vs manual + ForwardDiff chain rule), `ParameterizedOffset` materialization + hyperparameter merging, parameterized==fixed-at-same-θ, conjugate-path mean shift (vs conditioning on `y − b`), and missing-hyperparameter / length-mismatch errors.
- **Offset IFT** (forward-mode vs finite differences): Normal (offset-invariant Hessian) and Poisson (offset-shifted Hessian) bases via workspace IFT, joint offset + design matrix, and the `GMRF{Dual}` plain path.
- Full suite passes (incl. JET, Aqua — no new ambiguities).