### PR TITLE
Fix benchmark workflow baseline-checkout bug

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -67,11 +67,13 @@ jobs:
 
       - name: Restore PR worktree for comparison script
         run: |
-          # Remove the bench scripts we copied in so they don't block the
-          # switch back to the PR branch (where they're tracked).
-          rm -f benchmarks/benchmarks.jl benchmarks/run_regression.jl \
-                benchmarks/compare_results.jl benchmarks/Project.toml
-          git checkout -
+          # Force-switch back to the PR worktree. The baseline checkout
+          # overwrote the tracked benchmark scripts (cp from /tmp); a plain
+          # `git checkout -` PRESERVES those local edits/deletions whenever the
+          # file is byte-identical across branches, which left compare_results.jl
+          # missing at the compare step. `-f` discards the local changes and
+          # restores the PR's tracked files (scripts + Project.toml).
+          git checkout -f "@{-1}"
 
       - name: Compare PR vs baseline
         id: compare


### PR DESCRIPTION
The `Performance regression benchmarks` job has failed on every PR to `main`.

**Cause.** The *Restore PR worktree* step deletes the benchmark scripts it had copied onto the baseline branch and then runs `git checkout -`. When a script is byte-identical between the PR and baseline branches, that plain checkout *preserves* the working-tree deletion rather than restoring the file. `benchmarks/compare_results.jl` therefore stays missing, and the *Compare PR vs baseline* step dies with `No such file or directory`.

**Fix.** Force the switch back with `git checkout -f "@{-1}"`, which discards the local edits/deletions and unconditionally restores the PR's tracked files (scripts + `Project.toml`). No manual `rm` needed.

Verified the git behavior in a throwaway repo: with identical files across branches, plain `git checkout -` leaves the file deleted, while `git checkout -f @{-1}` restores it.