### PR TITLE
Cache NLSQ residual sparse-AD backends once per model

### DIFF
--- a/docs/src/reference/observation_models.md
+++ b/docs/src/reference/observation_models.md
@@ -243,6 +243,7 @@ Key properties
   - `∇²ℓ(x) ≈ − J(x)' Diagonal(w) J(x)`
 - `σ`: accepts a scalar or vector (heteroskedastic), both interpreted as standard deviations.
 - Sparse autodiff: requires loading `SparseConnectivityTracer` and `SparseMatrixColorings` to activate the sparse Jacobian backend.
+- Fixed sparsity pattern: the residual's Jacobian and residual-curvature Hessian sparsity patterns are detected once (at a probe point) and reused, so they must be independent of both `x` and the hyperparameters `θ`. Data-dependent control flow that changes *which* latents an output couples to (e.g. `x[1] > 0 ? x[1] * x[2] : x[1]`) is unsupported: `SparseConnectivityTracer` follows only the branch active at the probe point, so the pattern is frozen on one branch and entries on the others are silently dropped.
 
 Example
 ```julia

--- a/ext/GaussianMarkovRandomFieldsSparseADLikelihoods.jl
+++ b/ext/GaussianMarkovRandomFieldsSparseADLikelihoods.jl
@@ -39,21 +39,29 @@ function GaussianMarkovRandomFields.known_pattern_jacobian_backend(f, x_probe::A
     )
 end
 
+# Hessian analogue of `known_pattern_jacobian_backend`. `g` must be scalar-valued.
+# Detection runs once here on the primal residual sum, so the pattern (which depends only
+# on the residual structure, not on σ/θ/x*) is reused across materializations.
+function GaussianMarkovRandomFields.known_pattern_hessian_backend(g, x_probe::AbstractVector)
+    pattern = sparse(DI.hessian_sparsity(g, x_probe, TracerSparsityDetector()))
+    return DI.AutoSparse(
+        DI.AutoForwardDiff();
+        sparsity_detector = DI.ADTypes.KnownHessianSparsityDetector(pattern),
+        coloring_algorithm = GreedyColoringAlgorithm(),
+    )
+end
+
 # Residual-curvature term C = Σ_k (W r)_k ∇²f_k(x*) = ∇²[Σ_k (W r)_k f_k(x)] at x*.
 # `W r` is held constant (evaluated at x*), so this is a plain scalar Hessian with no
-# inner Jacobian — computed once, at the primal mode, via sparse forward-mode AD.
+# inner Jacobian. Its sparsity pattern is θ- and x*-independent, so it is detected once
+# and cached on the model (`lik.hess_backend`); only the numeric Hessian is recomputed here.
 function GaussianMarkovRandomFields.residual_curvature(
         lik::GaussianMarkovRandomFields.NonlinearLeastSquaresLikelihood, x_star::AbstractVector
     )
     f = GaussianMarkovRandomFields._residual_function(lik)
     Wr = lik.inv_σ² .* (lik.y .- f(x_star))
     g = x -> sum(Wr .* f(x))
-    backend = DI.AutoSparse(
-        DI.AutoForwardDiff();
-        sparsity_detector = TracerSparsityDetector(),
-        coloring_algorithm = GreedyColoringAlgorithm(),
-    )
-    return sparse(DI.hessian(g, backend, x_star))
+    return sparse(DI.hessian(g, lik.hess_backend, x_star))
 end
 
 end # module

--- a/ext/forwarddiff/autodiff_likelihood_dual.jl
+++ b/ext/forwarddiff/autodiff_likelihood_dual.jl
@@ -106,8 +106,9 @@ _strip_offset_partials(b::AbstractVector) = b
 
 # NonlinearLeastSquaresLikelihood: strip the σ-derived numeric fields (Dual when σ
 # carried partials) and the stored residual hyperparameters (Dual when an `f(x; θ...)`
-# hyperparameter carried partials). `f` and `jac_backend` are unchanged; the backend
-# already holds a primal-detected sparsity pattern, so it is valid for the primal pass.
+# hyperparameter carried partials). `f` and the cached backends (`jac_backend`,
+# `hess_backend`) are unchanged; they already hold primal-detected sparsity patterns, so
+# they are valid for the primal pass.
 function _primal_obs_lik(lik::GMRFs.NonlinearLeastSquaresLikelihood)
     (GMRFs._hp_carries_ad_partials(lik.hyperparams) || GMRFs._carries_ad_partials(lik.inv_σ²)) || return lik
     return GMRFs.NonlinearLeastSquaresLikelihood(
@@ -116,6 +117,7 @@ function _primal_obs_lik(lik::GMRFs.NonlinearLeastSquaresLikelihood)
         ForwardDiff.value.(lik.inv_σ²),
         ForwardDiff.value(lik.log_const),
         lik.jac_backend,
+        lik.hess_backend,
         GMRFs._strip_ad_partials_hyperparams(lik.hyperparams),
     )
 end

--- a/src/observation_models/nonlinear_least_squares.jl
+++ b/src/observation_models/nonlinear_least_squares.jl
@@ -2,9 +2,23 @@ using LinearAlgebra
 using SparseArrays
 using Distributions: Normal, product_distribution
 import DifferentiationInterface as DI
-import GaussianMarkovRandomFields: known_pattern_jacobian_backend
+import GaussianMarkovRandomFields: known_pattern_jacobian_backend, known_pattern_hessian_backend
 
 export NonlinearLeastSquaresModel, NonlinearLeastSquaresLikelihood
+
+# Per-model cache for the residual's sparse-AD backends. The Jacobian and
+# residual-curvature Hessian sparsity patterns are determined solely by the residual `f`
+# and the latent dimension `n` — they do not depend on σ, the hyperparameters θ, or the
+# linearization point — so each is detected once (on the primal residual) and reused
+# across every materialization, instead of re-detecting on each `model(y; …)` call
+# (Jacobian) or each hyperparameter-gradient evaluation (residual Hessian). The model
+# stays immutable and just holds a reference to this mutable cache (cf. `_ADPrepCache`).
+mutable struct _NLSQBackendCache
+    jacobian::Any   # AutoSparse Jacobian backend, or `nothing` until first detected
+    hessian::Any    # AutoSparse residual-Hessian backend, or `nothing` until first detected
+    lock::ReentrantLock
+end
+_NLSQBackendCache() = _NLSQBackendCache(nothing, nothing, ReentrantLock())
 
 """
     NonlinearLeastSquaresModel(f, n; hyperparams=())
@@ -38,14 +52,31 @@ The declared θ are stored on the materialized likelihood and splatted into `f` 
 evaluation time (mirroring [`AutoDiffObservationModel`](@ref)); with no declared
 hyperparameters the stored `f` is called directly, so the fixed path is unchanged.
 
+!!! warning "The residual must have a fixed sparsity pattern"
+    The residual's sparse-AD backends — its Jacobian (used by `loggrad`/`loghessian`) and
+    the residual-curvature Hessian `Σₖ (W r)ₖ ∇²fₖ` (used for exact hyperparameter
+    gradients) — are detected **once**, at a probe point, and reused for every
+    materialization and linearization point `x`. Their sparsity patterns must therefore be
+    **independent of both `x` and the hyperparameters θ**.
+
+    Residuals built from ordinary arithmetic and elementwise operations satisfy this
+    automatically. The pitfall is data-dependent control flow that changes *which* latents
+    an output couples to: `SparseConnectivityTracer` follows only the branch active at the
+    probe point — a comparison such as `x[i] > 0` is evaluated to a plain `Bool`, so neither
+    `if`/`?:` nor `ifelse` unions the alternatives — so a residual like
+    `x[1] > 0 ? x[1] * x[2] : x[1]` freezes its pattern on one branch and silently drops the
+    coupling on the others. Branches whose alternatives share the same sparsity structure
+    are fine.
+
 !!! note "Differentiating the hyperparameters"
-    The residual Jacobian's sparsity pattern is detected once at materialization and
-    reused, so `loggrad`/`loghessian` compose with an outer ForwardDiff pass.
+    The residual's Jacobian and residual-curvature Hessian sparsity patterns are detected
+    once per model (on the primal residual) and reused across all materializations, so
+    `loggrad`/`loghessian` compose with an outer ForwardDiff pass.
     Forward-mode (`ForwardDiff`) hyperparameter gradients through `gaussian_approximation`
     with a `WorkspaceGMRF` prior are supported and **exact**: the implicit-function mode
     sensitivity is solved with the true Hessian — the Gauss–Newton posterior precision
     corrected by the residual-curvature term `Σₖ (W r)ₖ ∇²fₖ` — so exactness holds even
-    for residuals nonlinear in `x`. The Jacobian sparsity pattern must be θ-independent
+    for residuals nonlinear in `x`. Both sparsity patterns must be `x`- and θ-independent
     (see the warning above).
 
     Reverse-mode AD (Zygote, Mooncake, …) through `gaussian_approximation` is **not**
@@ -57,25 +88,27 @@ struct NonlinearLeastSquaresModel{F, H <: Tuple{Vararg{Symbol}}} <: ObservationM
     f::F
     n::Int
     hyperparams::H
+    backend_cache::_NLSQBackendCache
 end
 
 NonlinearLeastSquaresModel(f, n::Int; hyperparams::Tuple{Vararg{Symbol}} = ()) =
-    NonlinearLeastSquaresModel(f, n, hyperparams)
+    NonlinearLeastSquaresModel(f, n, hyperparams, _NLSQBackendCache())
 
 """
     NonlinearLeastSquaresLikelihood <: ObservationLikelihood
 
-Materialized likelihood for NonlinearLeastSquaresModel with precomputed weights and
-cached sparse-Jacobian state. Hessian uses Gauss–Newton. `hyperparams` holds the θ
-values (if any) splatted into the residual `f(x; θ...)`; it is empty for the
-non-parameterized case.
+Materialized likelihood for NonlinearLeastSquaresModel with precomputed weights and the
+model's cached fixed-pattern sparse-AD backends (Jacobian and residual-curvature Hessian).
+Hessian uses Gauss–Newton. `hyperparams` holds the θ values (if any) splatted into the
+residual `f(x; θ...)`; it is empty for the non-parameterized case.
 """
-struct NonlinearLeastSquaresLikelihood{F, T, JB, HP <: NamedTuple} <: ObservationLikelihood
+struct NonlinearLeastSquaresLikelihood{F, T, JB, HB, HP <: NamedTuple} <: ObservationLikelihood
     f::F
     y::Vector{T}
     inv_σ²::Vector{T}
     log_const::T
-    jac_backend::JB       # DI backend for sparse Jacobian
+    jac_backend::JB       # DI backend for the sparse Jacobian (fixed pattern)
+    hess_backend::HB      # DI backend for the sparse residual-curvature Hessian (fixed pattern)
     hyperparams::HP       # θ values splatted into f(x; θ...); empty NamedTuple if none
 end
 
@@ -87,6 +120,34 @@ end
 @inline _bind_residual(f, hp::NamedTuple) = x -> f(x; hp...)
 
 _residual_function(lik::NonlinearLeastSquaresLikelihood) = _bind_residual(lik.f, lik.hyperparams)
+
+# Detect-once-then-reuse accessors for the residual's sparse-AD backends. The first
+# materialization detects the pattern on the primal probe residual `f_probe`; later
+# materializations reuse the cached backend. The cache lock makes concurrent first
+# materializations of the same model safe (duplicated detection under contention is not
+# avoided beyond serializing, matching `_ADPrepCache`).
+function _cached_jacobian_backend(model::NonlinearLeastSquaresModel, f_probe)
+    c = model.backend_cache
+    return @lock c.lock begin
+        if c.jacobian === nothing
+            c.jacobian = known_pattern_jacobian_backend(f_probe, zeros(model.n))
+        end
+        c.jacobian
+    end
+end
+
+function _cached_residual_hessian_backend(model::NonlinearLeastSquaresModel, f_probe)
+    c = model.backend_cache
+    return @lock c.lock begin
+        if c.hessian === nothing
+            # Detect the pattern of ∇²[Σ_k f_k(x)]. The runtime curvature weights `W r`
+            # only scale terms, so the unweighted sum has the same structural pattern.
+            g_probe = x -> sum(f_probe(x))
+            c.hessian = known_pattern_hessian_backend(g_probe, zeros(model.n))
+        end
+        c.hessian
+    end
+end
 
 # -------------------------------------------------------------------------------------------------
 # Factory pattern: make the model callable to materialize a likelihood
@@ -109,16 +170,20 @@ function (model::NonlinearLeastSquaresModel)(y::AbstractVector; σ, kwargs...)
     # θ for the residual (empty NamedTuple when the model declares none).
     hp = _project_hyperparameters(model.hyperparams, values(kwargs))
 
-    # Detect the Jacobian sparsity pattern once, on the *primal* residual (so
-    # detection never traces AD-tagged hyperparameters), and reuse it for every
-    # evaluation. The resulting backend's AutoForwardDiff inner nests cleanly under
-    # an outer ForwardDiff pass, which is what makes hyperparameter gradients work.
+    # Detect the sparse-AD backends once, on the *primal* residual (so detection never
+    # traces AD-tagged hyperparameters), and reuse them across materializations via the
+    # model's cache. Their AutoForwardDiff inner nests cleanly under an outer ForwardDiff
+    # pass, which is what makes hyperparameter gradients work. The cache accessors call
+    # through the extension stubs, which throw a clear ArgumentError if
+    # SparseConnectivityTracer / SparseMatrixColorings aren't loaded.
     f_probe = _bind_residual(model.f, _strip_ad_partials_hyperparams(hp))
-    # The stub throws a clear ArgumentError if SparseConnectivityTracer /
-    # SparseMatrixColorings aren't loaded.
-    jac_backend = known_pattern_jacobian_backend(f_probe, zeros(model.n))
-    return NonlinearLeastSquaresLikelihood{typeof(model.f), T, typeof(jac_backend), typeof(hp)}(
-        model.f, y_vec, convert.(T, inv_σ²), convert(T, log_const), jac_backend, hp,
+    jac_backend = _cached_jacobian_backend(model, f_probe)
+    hess_backend = _cached_residual_hessian_backend(model, f_probe)
+    return NonlinearLeastSquaresLikelihood{
+        typeof(model.f), T, typeof(jac_backend), typeof(hess_backend), typeof(hp),
+    }(
+        model.f, y_vec, convert.(T, inv_σ²), convert(T, log_const),
+        jac_backend, hess_backend, hp,
     )
 end
 

--- a/src/utils/sparse_autodiff.jl
+++ b/src/utils/sparse_autodiff.jl
@@ -43,6 +43,27 @@ function known_pattern_jacobian_backend(args::Vararg{Any}; kwargs...)
 end
 
 """
+    known_pattern_hessian_backend(g, x_probe) -> AutoSparse
+
+Detect the sparsity pattern of the Hessian of the scalar function `g` at `x_probe`
+once and return a sparse `AutoSparse` backend that reuses that fixed pattern (skipping
+per-call detection). Used for the residual-curvature Hessian, whose pattern depends only
+on the residual structure — not on σ, the hyperparameters, or the linearization point —
+so it is detected once and shared across materializations.
+
+Concrete method provided by the SparseConnectivityTracer + SparseMatrixColorings extension.
+"""
+function known_pattern_hessian_backend(args::Vararg{Any}; kwargs...)
+    throw(
+        ArgumentError(
+            "Sparse Hessian backend not available. " *
+                "Load SparseConnectivityTracer and SparseMatrixColorings " *
+                "to activate the AutoSparse backend."
+        )
+    )
+end
+
+"""
     residual_curvature(lik::NonlinearLeastSquaresLikelihood, x_star) -> SparseMatrixCSC
 
 The residual-curvature term `C = Σ_k (W r)_k ∇²f_k(x*)` of a Gauss–Newton least-squares

--- a/test/observation_models/test_parameterized_obs_models_ift.jl
+++ b/test/observation_models/test_parameterized_obs_models_ift.jl
@@ -181,6 +181,57 @@ end
         wprior = AR1Model(n)(ws; τ = 1.0, ρ = 0.3)
         @test_throws ArgumentError ChainRulesCore.rrule(cfg, gaussian_approximation, wprior, lik)
     end
+
+    # The residual's sparse-AD backends (Jacobian + residual-curvature Hessian) have
+    # θ-/x-independent patterns, so they are detected once per model and reused across
+    # materializations rather than re-detected on every `model(y; …)` call / gradient pass.
+    @testset "Sparse-AD backends detected once and cached on the model" begin
+        Random.seed!(21)
+        n = 6
+        # Residual coupling neighbouring latents ⇒ genuinely non-diagonal Hessian pattern.
+        f = (x; α) -> α .* x .^ 2 .+ vcat(x[2:n], x[1]) .* x
+        model = NonlinearLeastSquaresModel(f, n; hyperparams = (:α,))
+        y = randn(n)
+
+        # First materialization populates the cache; a second (different σ and α) reuses it.
+        @test model.backend_cache.jacobian === nothing
+        @test model.backend_cache.hessian === nothing
+        lik1 = model(y; σ = 0.5, α = 1.3)
+        @test model.backend_cache.jacobian !== nothing
+        @test model.backend_cache.hessian !== nothing
+        lik2 = model(y; σ = 0.9, α = 2.1)
+        @test lik2.jac_backend === lik1.jac_backend     # identical object ⇒ no re-detection
+        @test lik2.hess_backend === lik1.hess_backend
+
+        # The cached residual-Hessian backend yields the correct curvature: compare the
+        # sparse result to a dense ForwardDiff Hessian of x -> Σ_k (W r)_k f_k(x). Checking
+        # at two structurally different linearization points (the pattern is detected once,
+        # at zeros) guards that the cached pattern is a valid superset away from the probe —
+        # which holds because this residual's sparsity is x-independent (the documented
+        # contract; data-dependent structure-changing branches are unsupported).
+        fα = x -> f(x; α = 1.3)
+        for x_star in (randn(n), abs.(randn(n)) .+ 1.0)
+            Wr = lik1.inv_σ² .* (lik1.y .- fα(x_star))
+            C_cached = GaussianMarkovRandomFields.residual_curvature(lik1, x_star)
+            C_ref = ForwardDiff.hessian(x -> sum(Wr .* fα(x)), x_star)
+            @test Matrix(C_cached) ≈ C_ref
+        end
+
+        # End-to-end: the hyperparameter gradient through gaussian_approximation still
+        # matches finite differences (caching the pattern doesn't change the numbers).
+        prior_model = AR1Model(n)
+        ws = make_workspace(prior_model; τ = 1.0, ρ = 0.3)
+        z = zeros(n)
+        function pipe(θ)
+            prior = prior_model(ws; τ = 1.0, ρ = 0.3)
+            lik = model(y; σ = 0.5, α = θ[1])
+            return logpdf(gaussian_approximation(prior, lik), z)
+        end
+        θ0 = [1.3]
+        g_fwd = DifferentiationInterface.gradient(pipe, AutoForwardDiff(), θ0)
+        g_fd = DifferentiationInterface.gradient(pipe, AutoFiniteDiff(), θ0)
+        @test maximum(abs.(g_fwd - g_fd)) < 5.0e-3
+    end
 end
 
 # Affine offset hyperparameter sensitivities. η = A·x + b is affine in x, so the

--- a/test/observation_models/test_parameterized_obs_models_ift.jl
+++ b/test/observation_models/test_parameterized_obs_models_ift.jl
@@ -188,8 +188,10 @@ end
     @testset "Sparse-AD backends detected once and cached on the model" begin
         Random.seed!(21)
         n = 6
-        # Residual coupling neighbouring latents ⇒ genuinely non-diagonal Hessian pattern.
-        f = (x; α) -> α .* x .^ 2 .+ vcat(x[2:n], x[1]) .* x
+        # Mildly nonlinear residual coupling each latent to its successor (no wrap-around):
+        # a genuinely non-diagonal but tridiagonal curvature that fits the AR1 prior's
+        # pattern, with curvature small enough that the true Hessian Q_post − C stays PD.
+        f = (x; α) -> α .* x .+ 0.1 .* x .* vcat(x[2:n], x[n])
         model = NonlinearLeastSquaresModel(f, n; hyperparams = (:α,))
         y = randn(n)
 


### PR DESCRIPTION
Follow-up to the θ-dependent observation-model work (#136/#138): the residual-curvature sparsity detection was the one remaining per-gradient-evaluation cost.

## What

`NonlinearLeastSquaresModel`’s residual has two sparse-AD backends — the Jacobian (Gauss–Newton `loggrad`/`loghessian`) and the residual-curvature Hessian `Σₖ (W r)ₖ ∇²fₖ` (used by `residual_curvature` for exact ForwardDiff hyperparameter gradients). Their sparsity patterns depend only on the residual `f` and the latent dimension `n` — not on σ, θ, or the linearization point.

Previously the Jacobian pattern was re-detected on **every materialization** and the residual-Hessian pattern on **every `residual_curvature` call** (i.e. every hyperparameter-gradient evaluation), each running a fresh `TracerSparsityDetector` pass.

This memoizes both backends on a small mutable cache held by the (still-immutable) model — detected once on the primal residual, reused across all materializations. It mirrors the existing `known_pattern_jacobian_backend` with ADTypes’ `KnownHessianSparsityDetector` for the Hessian; `residual_curvature` now reuses the cached backend (numeric Hessian only) instead of re-detecting.

## Contract (now documented)

Because both patterns are now frozen at a probe point, the residual’s sparsity must be **independent of `x` and θ**. This was already true of the Jacobian path (it has detected at `zeros(n)` since #136); this PR makes the Hessian path consistent and documents the whole-model contract. Data-dependent control flow that changes *which* latents an output couples to (e.g. `x[1] > 0 ? x[1]*x[2] : x[1]`) is unsupported — SCT follows only the probe-point branch (and `ifelse` does not help, since the comparison resolves to a plain `Bool`). The old per-call Hessian detection at `x_star` happened to tolerate such residuals; in exchange for the cache, that tolerance is dropped and the constraint is documented. Smooth/arithmetic residuals (the norm) are unaffected and exact.

## Tests

Adds a testset: cache populated + reused across materializations (object identity), `residual_curvature` matches a dense ForwardDiff Hessian at two linearization points, and the end-to-end hyperparameter gradient still matches finite differences.

Designed and reviewed with multi-agent workflows (mapping the patterns to mirror, then an adversarial cross-dimension review that surfaced the `x`-independence contract). Verified locally that the package loads and the model constructs with the new cache; full suite via CI (heavy Julia runs are avoided in my environment).