### PR TITLE
Prepare AutoDiffLikelihood AD operator at the compute eltype (#142)

### DIFF
--- a/src/observation_models/autodiff_likelihood.jl
+++ b/src/observation_models/autodiff_likelihood.jl
@@ -351,19 +351,26 @@ end
 # an outer AD pass those arrive as `Dual`s while `x` stays primal, so we widen `eltype(x)`
 # by their value eltypes; preparing (and calling) at this type gives buffers that can hold
 # the result. On the common primal path this is just `eltype(x)`, so nothing changes.
-_ad_compute_eltype(x, obs_lik::AutoDiffLikelihood) = promote_type(
-    eltype(x), _value_eltype(obs_lik.y), map(_value_eltype, values(obs_lik.hyperparams))...
-)
+function _ad_compute_eltype(x, obs_lik::AutoDiffLikelihood)
+    S = promote_type(
+        eltype(x), _value_eltype(obs_lik.y), map(_value_eltype, values(obs_lik.hyperparams))...,
+    )
+    # Widening can land on a non-concrete type (an abstractly-typed numeric payload, e.g.
+    # `y::Vector{Real}`); we can't `zeros(S, …)` then. Fall back to `eltype(x)` — the right
+    # compute type whenever such a payload actually holds primals (the common case).
+    return isconcretetype(S) ? S : eltype(x)
+end
 
 # Value (scalar) eltype contributed by a stored payload/hyperparameter. `Union{}` is the
-# identity of `promote_type`, so `nothing` and non-numeric payloads don't widen. AD data
-# must reach the likelihood as a scalar or array of `Number`s through `x`, `y`, or a
-# `hyperparams` value to be seen here. `Dual`s hidden inside an opaque `y` (a `Tuple`,
-# `NamedTuple`, or array of structs) are NOT detected — the prep stays primal-typed and an
-# outer AD pass through such a `y` would still hit the issue-#142 buffer mismatch.
+# identity of `promote_type`, so `nothing` and non-numeric payloads (incl. arrays whose
+# eltype isn't a `Number`, like `Vector{Any}`) don't widen. AD data must reach the
+# likelihood as a `Number` or array of `Number`s through `x`, `y`, or a `hyperparams` value
+# to be seen here. `Dual`s hidden inside an opaque `y` (a `Tuple`/`NamedTuple`/struct, or an
+# abstractly-typed array) are NOT detected — the prep stays primal-typed and an outer AD
+# pass through such a `y` would still hit the issue-#142 buffer mismatch.
 _value_eltype(::Nothing) = Union{}
 _value_eltype(v::Number) = typeof(v)
-_value_eltype(v::AbstractArray) = eltype(v)
+_value_eltype(v::AbstractArray{<:Number}) = eltype(v)
 _value_eltype(::Any) = Union{}
 
 # Promote `x` to element type `S` for the AD call. Identity (no allocation) on the common

--- a/src/observation_models/autodiff_likelihood.jl
+++ b/src/observation_models/autodiff_likelihood.jl
@@ -8,9 +8,11 @@ export AutoDiffLikelihood, AutoDiffObservationModel
 
 Mutable, eltype-keyed cache of `DI.prepare_gradient` / `DI.prepare_hessian`
 results. A single `AutoDiffLikelihood` holds one of these so repeated calls
-with the same input eltype reuse the prep (the common case), while
-unexpected eltypes (e.g. AD-tagged scalars from a nested-AD caller) trigger
-a one-time prep on first miss instead of failing.
+with the same *compute* eltype (`eltype(x)` widened by any AD-tagged scalars
+the likelihood carries through `y`/`hyperparams`; see `_ad_compute_eltype`)
+reuse the prep (the common case), while a new eltype — e.g. `Dual`s from an
+outer AD pass arriving through `x`, `y`, or a hyperparameter — triggers a
+one-time prep on first miss instead of failing.
 
 `get!` on the underlying `Dict`s isn't safe under concurrent mutation, so
 the cache holds a `ReentrantLock`. The prep itself can be expensive; we
@@ -168,6 +170,16 @@ Construct an `AutoDiffObservationModel`.
 
 `loglik_func` should have signature `(x; y, hyperparam_kwargs...) -> Real`.
 `hyperparams` is a tuple of hyperparameter names (`Symbol`s) the model expects.
+
+## Differentiating through `y` or the hyperparameters
+
+`loggrad`/`loghessian` compose with an outer AD pass even when a `Dual` enters through `x`,
+the `y` payload, or a hyperparameter — the AD operator is prepared at the resulting compute
+eltype. The AD-carrying value must reach the likelihood as a `Number` or array of `Number`s;
+`Dual`s buried inside an opaque `y` (a `Tuple`/`NamedTuple`/struct) are not detected. For an
+outer pass that enters through `y`, use a dense or fixed-pattern
+(`KnownHessianSparsityDetector`) Hessian backend — the default `TracerSparsityDetector`
+sparse backend cannot trace a `Dual` captured through `y`.
 
 ## `diagonal_hessian_safe`
 
@@ -333,10 +345,38 @@ function loglik(x, obs_lik::AutoDiffLikelihood)
     return _build_call(obs_lik)(x)
 end
 
+# Element type at which to prepare (and run) the gradient/Hessian operator. The DI prep's
+# result buffers are sized from the *input* eltype, but the output also depends on any
+# AD-tagged scalars the likelihood carries through its `y` payload or `hyperparams`. Under
+# an outer AD pass those arrive as `Dual`s while `x` stays primal, so we widen `eltype(x)`
+# by their value eltypes; preparing (and calling) at this type gives buffers that can hold
+# the result. On the common primal path this is just `eltype(x)`, so nothing changes.
+_ad_compute_eltype(x, obs_lik::AutoDiffLikelihood) = promote_type(
+    eltype(x), _value_eltype(obs_lik.y), map(_value_eltype, values(obs_lik.hyperparams))...
+)
+
+# Value (scalar) eltype contributed by a stored payload/hyperparameter. `Union{}` is the
+# identity of `promote_type`, so `nothing` and non-numeric payloads don't widen. AD data
+# must reach the likelihood as a scalar or array of `Number`s through `x`, `y`, or a
+# `hyperparams` value to be seen here. `Dual`s hidden inside an opaque `y` (a `Tuple`,
+# `NamedTuple`, or array of structs) are NOT detected — the prep stays primal-typed and an
+# outer AD pass through such a `y` would still hit the issue-#142 buffer mismatch.
+_value_eltype(::Nothing) = Union{}
+_value_eltype(v::Number) = typeof(v)
+_value_eltype(v::AbstractArray) = eltype(v)
+_value_eltype(::Any) = Union{}
+
+# Promote `x` to element type `S` for the AD call. Identity (no allocation) on the common
+# primal path, where `x` already has eltype `S`; otherwise widen (e.g. a primal `x` lifted
+# to `Dual` so it matches an outer pass that entered through `y`/a hyperparameter).
+_as_eltype(::Type{S}, x::AbstractArray{S}) where {S} = x
+_as_eltype(::Type{S}, x::AbstractArray) where {S} = convert.(S, x)
+
 function loggrad(x, obs_lik::AutoDiffLikelihood)
     f = _build_call(obs_lik)
-    prep = _get_or_prepare_grad!(obs_lik.prep_cache, f, obs_lik.grad_backend, eltype(x))
-    return DI.gradient(f, prep, obs_lik.grad_backend, x)
+    S = _ad_compute_eltype(x, obs_lik)
+    prep = _get_or_prepare_grad!(obs_lik.prep_cache, f, obs_lik.grad_backend, S)
+    return DI.gradient(f, prep, obs_lik.grad_backend, _as_eltype(S, x))
 end
 
 function loghessian(x, obs_lik::AutoDiffLikelihood)
@@ -344,8 +384,9 @@ function loghessian(x, obs_lik::AutoDiffLikelihood)
         return _diagonal_hessian_via_pointwise(x, obs_lik)
     end
     f = _build_call(obs_lik)
-    prep = _get_or_prepare_hess!(obs_lik.prep_cache, f, obs_lik.hess_backend, eltype(x))
-    return DI.hessian(f, prep, obs_lik.hess_backend, x)
+    S = _ad_compute_eltype(x, obs_lik)
+    prep = _get_or_prepare_hess!(obs_lik.prep_cache, f, obs_lik.hess_backend, S)
+    return DI.hessian(f, prep, obs_lik.hess_backend, _as_eltype(S, x))
 end
 
 # Pointwise structured-Hessian fast path. Gated on the user's

--- a/test/observation_models/test_autodiff_likelihood.jl
+++ b/test/observation_models/test_autodiff_likelihood.jl
@@ -150,6 +150,24 @@ using ForwardDiff
         @test sum(loghessian(x, model(y0))) ≈ -3 - 0.6 * sum(y0 .* x)
     end
 
+    @testset "Abstractly-typed y payload stays concrete" begin
+        # The compute-eltype widening must not produce a non-concrete eltype: an
+        # abstractly-typed numeric payload (e.g. Vector{Any}/Vector{Real}) holding primals
+        # must fall back to eltype(x), not attempt `zeros(Any, …)` (issue #142 follow-up).
+        x = [0.1, 0.2, 0.3]
+        loglik_func = (x; y) -> -0.5 * sum((y .- x) .^ 2)   # ∇ = y .- x
+        @testset "eltype $(eltype(yp)) payload" for yp in (Any[1.0, 2.0, 3.0], Real[1.0, 2.0, 3.0])
+            model = AutoDiffObservationModel(
+                loglik_func; n_latent = 3,
+                grad_backend = DI.AutoForwardDiff(), hessian_backend = DI.AutoForwardDiff(),
+            )
+            lik = model(yp)
+            @test eltype(loggrad(x, lik)) == Float64
+            @test eltype(loghessian(x, lik)) == Float64
+            @test loggrad(x, lik) ≈ Float64.(yp) .- x
+        end
+    end
+
     @testset "Pointwise Hessian fast path returns Diagonal" begin
         # With both `pointwise_loglik_func` set and `diagonal_hessian_safe = true`,
         # loghessian returns a `Diagonal` via per-element 1D second derivatives.

--- a/test/observation_models/test_autodiff_likelihood.jl
+++ b/test/observation_models/test_autodiff_likelihood.jl
@@ -116,6 +116,40 @@ using ForwardDiff
         @test loggrad(x0, obs_lik) ≈ -(exp.(x0) .- 2)
     end
 
+    @testset "Nested AD through the y payload (issue #142)" begin
+        # The prep cache keyed only on `eltype(x)`, so an outer AD pass entering through
+        # the `y` payload (with `x` left primal) reused the Float64-typed result buffers,
+        # which can't hold the resulting Duals. The key is now the *compute* eltype, which
+        # also accounts for AD data carried via `y`/hyperparams. The fix is backend-agnostic
+        # (it concerns the prep's buffer eltype), so it covers a dense `AutoForwardDiff`
+        # Hessian and a fixed-pattern `AutoSparse(…; KnownHessianSparsityDetector)` equally.
+        #
+        # We test the dense backend here (self-contained, no sparse-AD extension needed).
+        # Note: the *default* sparse Hessian backend uses a `TracerSparsityDetector`, which
+        # cannot trace a captured `Dual` y at all (a `Dual`×`Tracer` method ambiguity at
+        # sparsity-detection time — a separate limitation, of the same class as the NLSQ
+        # residual-curvature detection workaround); that is outside this buffer-eltype fix.
+        # Inner backend pinned to ForwardDiff so the outer ForwardDiff nests cleanly.
+        x = [0.3, -0.2, 0.5]
+        y0 = [1.0, 2.0, -1.0]
+        # H = Diagonal(-1 .- 0.6 .* y .* x), g = (y .- x) .- 0.3 .* y .* x .^ 2, with y = c .* y0.
+        loglik_func = (x; y) -> -0.5 * sum((y .- x) .^ 2) - 0.1 * sum(y .* x .^ 3)
+        ∂H = -0.6 * sum(y0 .* x)                  # d/dc sum(loghessian) at c = 1
+        ∂G = sum(y0) - 0.3 * sum(y0 .* x .^ 2)    # d/dc sum(loggrad) at c = 1
+        model = AutoDiffObservationModel(
+            loglik_func; n_latent = 3,
+            grad_backend = DI.AutoForwardDiff(), hessian_backend = DI.AutoForwardDiff(),
+        )
+
+        @test ForwardDiff.derivative(c -> sum(loghessian(x, model(c .* y0))), 1.0) ≈ ∂H
+        @test ForwardDiff.derivative(c -> sum(loggrad(x, model(c .* y0))), 1.0) ≈ ∂G
+
+        # Primal path is unaffected (still Float64, correct values).
+        @test eltype(loghessian(x, model(y0))) == Float64
+        @test eltype(loggrad(x, model(y0))) == Float64
+        @test sum(loghessian(x, model(y0))) ≈ -3 - 0.6 * sum(y0 .* x)
+    end
+
     @testset "Pointwise Hessian fast path returns Diagonal" begin
         # With both `pointwise_loglik_func` set and `diagonal_hessian_safe = true`,
         # loghessian returns a `Diagonal` via per-element 1D second derivatives.


### PR DESCRIPTION
Fixes #142.

## Problem

`AutoDiffLikelihood` keyed its DI gradient/Hessian prep cache on `eltype(x)` and prepared at `Float64`. The prep's result buffers are sized from the *input* eltype, but the output also depends on AD-tagged scalars the likelihood carries through the **`y` payload** (or hyperparameters). Under an outer AD pass where a `Dual` arrives via `y` while `x` stays primal, the `Float64` buffers can't hold the `Dual` result:

```
MethodError: no method matching Float64(::ForwardDiff.Dual{…})
```

(`Dual`s arriving via the latent `x` already worked, since the cache keyed on `eltype(x)`.)

## Fix

Key the prep on the **compute eltype** — `eltype(x)` widened by the value eltypes of any AD data carried via `y`/hyperparams (`_ad_compute_eltype`) — prepare the operator at that type, and lift `x` to it for the call (`_as_eltype`, an identity no-op on the primal path). Verified locally that an outer `ForwardDiff` derivative of a `loghessian`/`loggrad`-derived quantity w.r.t. a value carried through `y` now matches analytic + finite differences, and the primal path is unchanged (still `Float64`, alloc-free).

The IFT/hyperparameter path is unaffected: there `x` is lifted to `Dual`, so the compute eltype already equals `eltype(x)` and the new code is a no-op. As a bonus it also repairs the plain-`GMRF{Dual}` + `Dual`-hyperparameter + `AutoDiffLikelihood` route, which has no `x`-lift and previously hit the same `MethodError`.

## Scope

Covers **dense** `AutoForwardDiff` and **fixed-pattern** `AutoSparse(…; KnownHessianSparsityDetector)` Hessian backends — exactly the backends named in the issue. The **default** `TracerSparsityDetector` sparse backend is a separate story: it cannot trace a `Dual` captured through `y` at all — a `Dual`×`Tracer` method ambiguity at *sparsity-detection* time, the same class as the NLSQ residual-curvature detection limitation. That is out of scope here and documented (in code + the `AutoDiffObservationModel` docstring); fixing it would need primal-stripped detection + a known-pattern backend, as NLSQ does. Happy to file a follow-up.

## Notes

Designed and reviewed with multi-agent workflows. The adversarial review was load-bearing here: it traced the dependency sources and corrected my initial (wrong) assumption that the default sparse backend would also be fixed — which is why the test is scoped to the dense backend and the limitation is documented rather than silently shipped.