### PR TITLE
Cache κ-independent C, G matrices on MaternModel (#145)

### DIFF
--- a/ext/GaussianMarkovRandomFieldsFEM/matern_model.jl
+++ b/ext/GaussianMarkovRandomFieldsFEM/matern_model.jl
@@ -17,7 +17,10 @@ function MaternModel(discretization::F; smoothness::S, alg = CHOLMODFactorizatio
     smoothness >= 0 || throw(ArgumentError("Smoothness must be non-negative, got smoothness=$smoothness"))
     n = ndofs(discretization)
     processed_constraint = _process_constraint(constraint, n)
-    return MaternModel{F, S, typeof(alg), typeof(processed_constraint), typeof(observation_points)}(discretization, smoothness, alg, processed_constraint, observation_points)
+    # Assemble the κ-independent FEM matrices once; reused on every precision_matrix call.
+    C, G = assemble_matern_C_G(discretization)
+    fem_matrices = (; C, G)
+    return MaternModel{F, S, typeof(alg), typeof(processed_constraint), typeof(observation_points), typeof(fem_matrices)}(discretization, smoothness, alg, processed_constraint, observation_points, fem_matrices)
 end
 
 """
@@ -99,7 +102,8 @@ function precision_matrix(model::MaternModel{F, S}; τ::Real, range::Real, kwarg
     D = ndim(model.discretization)
     ν = smoothness_to_ν(model.smoothness, D)
     κ = range_to_κ(range, ν)
-    Q_unscaled = matern_precision_only(model.discretization, model.smoothness, κ)
+    (; C, G) = model.fem_matrices
+    Q_unscaled = matern_precision_only(model.discretization, model.smoothness, κ, C, G)
     return τ * Q_unscaled
 end
 

--- a/ext/GaussianMarkovRandomFieldsFEM/matern_spde.jl
+++ b/ext/GaussianMarkovRandomFieldsFEM/matern_spde.jl
@@ -231,10 +231,39 @@ function _matern_precision_only(
 end
 
 """
+    assemble_matern_C_G(disc::FEMDiscretization{D}) where {D}
+
+Assemble the κ-independent FEM matrices for a Matérn discretization: the lumped
+mass matrix `C` and the stiffness matrix `G` (with identity diffusion). These
+depend only on the discretization (mesh, interpolation, quadrature), so they can
+be assembled once and reused across `precision_matrix` / `matern_precision_only`
+calls with different κ.
+"""
+function assemble_matern_C_G(disc::FEMDiscretization{D}) where {D}
+    cellvalues = CellValues(
+        disc.quadrature_rule,
+        disc.interpolation,
+        disc.geom_interpolation,
+    )
+    diffusion_factor = Matrix{Float64}(I, D, D)
+    return assemble_C_G_matrices(
+        cellvalues,
+        disc.dof_handler,
+        disc.interpolation,
+        diffusion_factor,
+    )
+end
+
+"""
     matern_precision_only(disc::FEMDiscretization{D}, smoothness::Integer, κ; σ²=1.0) where {D}
+    matern_precision_only(disc, smoothness, κ, C, G; σ²=1.0)
 
 Compute the Matérn precision matrix directly from a FEM discretization without
 constructing a GMRF. Avoids all factorizations, so supports ForwardDiff.Dual values for κ.
+
+The κ-independent matrices `C` (lumped mass) and `G` (stiffness) may be supplied
+pre-assembled (e.g. cached on a `MaternModel`); otherwise they are assembled on
+each call via [`assemble_matern_C_G`](@ref).
 """
 function matern_precision_only(
         disc::FEMDiscretization{D},
@@ -242,22 +271,20 @@ function matern_precision_only(
         κ;
         σ² = 1.0,
     ) where {D}
+    C, G = assemble_matern_C_G(disc)
+    return matern_precision_only(disc, smoothness, κ, C, G; σ² = σ²)
+end
+
+function matern_precision_only(
+        disc::FEMDiscretization{D},
+        smoothness::Integer,
+        κ,
+        C::SparseMatrixCSC,
+        G::SparseMatrixCSC;
+        σ² = 1.0,
+    ) where {D}
     ν = smoothness_to_ν(smoothness, D)
     α_val = Integer(ν + D // 2)
-
-    # Assemble FEM matrices at Float64 (κ-independent)
-    cellvalues = CellValues(
-        disc.quadrature_rule,
-        disc.interpolation,
-        disc.geom_interpolation,
-    )
-    diffusion_factor = Matrix{Float64}(I, D, D)
-    C, G = assemble_C_G_matrices(
-        cellvalues,
-        disc.dof_handler,
-        disc.interpolation,
-        diffusion_factor,
-    )
 
     # Form K (may carry Dual type from κ)
     K = κ^2 * C + G

--- a/src/fem/types.jl
+++ b/src/fem/types.jl
@@ -195,18 +195,23 @@ ConcreteConstantMeshSTGMRF(args...; kwargs...) =
 
 # --- Matérn latent model -----------------------------------------------------
 """
-    MaternModel{F, S, Alg, C, P} <: LatentModel
+    MaternModel{F, S, Alg, C, P, M} <: LatentModel
 
 A Matérn latent model for constructing spatial GMRFs from discretized Matérn
 SPDEs. Validated user-facing constructors live in the
 `GaussianMarkovRandomFieldsFEM` extension.
+
+The κ-independent FEM matrices (the lumped mass matrix `C` and the stiffness
+matrix `G`) are assembled once at construction and cached in `fem_matrices`, so
+that repeated `precision_matrix` calls only redo the κ-dependent work.
 """
-struct MaternModel{F, S <: Integer, Alg, C, P} <: LatentModel
+struct MaternModel{F, S <: Integer, Alg, C, P, M} <: LatentModel
     discretization::F
     smoothness::S
     alg::Alg
     constraint::C
     observation_points::P
+    fem_matrices::M
 end
 
 # COV_EXCL_START

--- a/test/latent_models/test_matern.jl
+++ b/test/latent_models/test_matern.jl
@@ -305,6 +305,30 @@ using Ferrite
         @test size(A_explicit, 1) == 2
     end
 
+    @testset "Cached κ-independent FEM matrices" begin
+        # Regression guard for issue #145: precision_matrix reuses the C, G
+        # matrices cached at construction and must stay bit-identical to
+        # re-assembling them from scratch on every call.
+        grid = generate_grid(Triangle, (3, 3))
+        disc = FEMDiscretization(grid, Lagrange{RefTriangle, 1}(), QuadratureRule{RefTriangle}(2))
+
+        for smoothness in [0, 1, 2]
+            model = MaternModel(disc; smoothness = smoothness)
+
+            # C and G are assembled once and stored on the model.
+            @test haskey(model.fem_matrices, :C)
+            @test haskey(model.fem_matrices, :G)
+
+            ν = smoothness_to_ν(smoothness, 2)
+            for (τ, range) in [(1.0, 0.3), (2.0, 0.7), (0.5, 1.5)]
+                κ = range_to_κ(range, ν)
+                Q_cached = precision_matrix(model; τ = τ, range = range)
+                Q_fresh = τ * GaussianMarkovRandomFields.matern_precision_only(disc, smoothness, κ)
+                @test Matrix(Q_cached) == Matrix(Q_fresh)  # bit-identical
+            end
+        end
+    end
+
     @testset "1D MaternModel" begin
         # Test 1D points - need to reshape as N×1 matrix
         points_1d = reshape(sort!(rand(100) * 10.0), :, 1)  # 100×1 matrix


### PR DESCRIPTION
Closes #145.

## Problem

`matern_precision_only` (`ext/GaussianMarkovRandomFieldsFEM/matern_spde.jl`) assembled the mass/stiffness matrices `C, G` on **every** call:

```julia
C, G = assemble_C_G_matrices(...)
K = κ^2 * C + G
```

But `C` and `G` depend only on the discretisation (mesh + interpolation + quadrature), not on κ. So `precision_matrix(model; τ, range)` re-did the dominant assembly cost on every hyperparameter value (e.g. when sweeping `range`) and on every gradient evaluation under AD, even though the assembled result is identical across calls.

## Fix

- Factor the κ-independent assembly into `assemble_matern_C_G(disc)` (identity diffusion).
- Assemble `C, G` **once** at `MaternModel` construction, cached in a new `fem_matrices` field.
- `matern_precision_only` gains a method taking pre-assembled `C, G`; `precision_matrix` passes the cached matrices through. Only the κ-dependent work (`K = κ²C + G`, the variance scaling, and `_matern_precision_only`) runs per call.

The existing 3-argument `matern_precision_only(disc, smoothness, κ)` still works (it now assembles via `assemble_matern_C_G`), so external callers and the `discretize(::MaternSPDE, …)` path are unaffected.

## Results

Benchmarked on a deterministic ~1.7k-DOF Matérn model (`generate_grid(Triangle, (40,40))`, 1681 DOFs):

| path | mean / call | best / call |
|---|---|---|
| `matern_precision_only` (re-assembles C, G) | 9.26 ms | 8.19 ms |
| `precision_matrix` (cached C, G) | 1.38 ms | 0.95 ms |

~8.6× faster on best-case, and **bit-identical** (`max |Δ| = 0.0`) to the re-assembling path across smoothness ∈ {0,1,2,3} and several (τ, range) values.

## Tests

- `test/latent_models/test_matern.jl`: **126/126 pass** (111 existing + a new "Cached κ-independent FEM matrices" regression testset asserting the cached path stays bit-identical to a fresh re-assembly).
- ForwardDiff through `precision_matrix` (both `range` and `τ` derivatives) verified to still match finite differences with the cached Float64 `C, G`.