### PR TITLE
Materialize CHOLMOD selected inverse lazily

### DIFF
--- a/benchmarks/benchmarks.jl
+++ b/benchmarks/benchmarks.jl
@@ -23,6 +23,7 @@ Usage (via PkgBenchmark):
 """
 
 using GaussianMarkovRandomFields
+using GaussianMarkovRandomFields: selinv, selinv_diag
 using BenchmarkTools
 using Distributions: Poisson, logpdf
 using SparseArrays
@@ -92,6 +93,42 @@ end
 
 const BESAG_ADJ = _grid_adjacency(20, 20)  # 400 nodes, mirrors typical spatial use cases
 
+# 3D grid graph-Laplacian precision (7-point stencil + diagonal). A 3D grid
+# produces the dense Cholesky fill that makes selected inversion non-trivial,
+# unlike the near-banded 1D/2D models above. Used for the workspace selinv
+# benchmarks below.
+function _grid_precision_3d(nx, ny, nz; c = 0.1)
+    n = nx * ny * nz
+    lin(i, j, k) = ((k - 1) * ny + (j - 1)) * nx + i
+    I = Int[]; J = Int[]; V = Float64[]
+    for k in 1:nz, j in 1:ny, i in 1:nx
+        p = lin(i, j, k)
+        deg = 0
+        for (di, dj, dk) in ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+            ii, jj, kk = i + di, j + dj, k + dk
+            if 1 <= ii <= nx && 1 <= jj <= ny && 1 <= kk <= nz
+                push!(I, p); push!(J, lin(ii, jj, kk)); push!(V, -1.0)
+                deg += 1
+            end
+        end
+        push!(I, p); push!(J, p); push!(V, deg + c)
+    end
+    return sparse(I, J, V, n, n)
+end
+
+const Q_GRID3D = _grid_precision_3d(12, 12, 12)  # 1728 DOF, dense Cholesky fill
+const WS_GRID3D = GMRFWorkspace(Q_GRID3D)
+
+# Reset only the selected-inverse caches so each benchmark sample re-runs the
+# selected inversion while reusing the numeric factorization. This isolates the
+# selinv cost (the subject of the benchmark) from refactorization.
+function _reset_selinv!(ws)
+    ws.selinv_valid = false
+    ws.backend.selinv_cache = nothing
+    ws.backend.selinv_diag_cache = nothing
+    return ws
+end
+
 # Autodiff pipeline data (matches the existing autodiff_comparison.jl shape).
 let
     Random.seed!(123)
@@ -153,6 +190,14 @@ SUITE["gmrf"]["logpdf_cholmod"] = @benchmarkable logpdf($GMRF_MED_CHOLMOD, $X_ME
 SUITE["gmrf"]["var_selinv"] = @benchmarkable var($GMRF_MED_CHOLMOD)
 SUITE["gmrf"]["rand_backward_solve"] =
     @benchmarkable rand(rng, $GMRF_MED_LDLT) setup = (rng = MersenneTwister(0))
+
+# Workspace selected inverse (GMRFWorkspace CHOLMOD backend). Exercises the
+# selinv conversion that compute_selinv!/get_selinv cache — the full path builds
+# the sparse matrix, the diagonal path skips it.
+SUITE["gmrf"]["workspace_selinv_full"] =
+    @benchmarkable selinv(ws) setup = (ws = _reset_selinv!($WS_GRID3D))
+SUITE["gmrf"]["workspace_selinv_diag"] =
+    @benchmarkable selinv_diag(ws) setup = (ws = _reset_selinv!($WS_GRID3D))
 
 # ---------------------------------------------------------------------------
 # 3. Gaussian approximation (Fisher scoring hot path)

--- a/src/workspace/backend.jl
+++ b/src/workspace/backend.jl
@@ -13,8 +13,8 @@ Each backend must implement:
 - `refactorize!(b, Q::Symmetric)` — numeric-only refactorization reusing symbolic
 - `backend_solve(b, rhs)` — solve Q x = rhs
 - `compute_logdet(b)` — log determinant of Q
-- `compute_selinv!(b)` — compute and cache selected inverse internally
-- `get_selinv(b)` — return cached selected inverse (type is backend-specific)
+- `compute_selinv!(b)` — prepare the selected inverse caches (may be lazy)
+- `get_selinv(b)` — return the selected inverse (type is backend-specific)
 - `get_selinv_diag(b)` — return diagonal of Q⁻¹ as Vector
 - `backend_backward_solve(b, x)` — compute L^T \\ x for sampling
 """
@@ -27,7 +27,10 @@ CHOLMOD-based factorization backend. Owns a `CHOLMOD.Factor` whose symbolic
 factorization (permutation, elimination tree, supernodes) is computed once
 and reused across numeric refactorizations.
 
-Caches the selected inverse as a `SparseMatrixCSC` after `compute_selinv!`.
+Materializes the selected inverse lazily: callers needing only the diagonal
+(marginal variances) skip building the full `SparseMatrixCSC`, and the full
+matrix is built only when actually requested. Both caches are reset on
+`refactorize!`.
 """
 mutable struct CHOLMODBackend{T} <: WorkspaceBackend
     factor::SparseArrays.CHOLMOD.Factor{T}
@@ -55,16 +58,31 @@ function compute_logdet(b::CHOLMODBackend)
 end
 
 function compute_selinv!(b::CHOLMODBackend)
-    b.selinv_cache = SelectedInversion.selinv(b.factor; depermute = true).Z
-    b.selinv_diag_cache = diag(b.selinv_cache)
+    # The full sparse selected inverse and its diagonal are materialized lazily
+    # by the getters below. The `var` path needs only the diagonal while the
+    # autodiff path needs only the full matrix, so eagerly computing both here
+    # wasted work on every factorization. Caches are reset in `refactorize!`.
     return nothing
 end
 
 function get_selinv(b::CHOLMODBackend)
+    if b.selinv_cache === nothing
+        # `sparse` builds the result directly from the supernodal blocks. The
+        # generic `SparseMatrixCSC` convert would instead call supernodal
+        # `getindex` once per structural entry — orders of magnitude slower.
+        b.selinv_cache = sparse(SelectedInversion.selinv(b.factor; depermute = true).Z)
+    end
     return b.selinv_cache
 end
 
 function get_selinv_diag(b::CHOLMODBackend)
+    if b.selinv_diag_cache === nothing
+        # Reuse the full selected inverse if it is already materialized;
+        # otherwise compute just the diagonal, skipping the sparse build.
+        b.selinv_diag_cache = b.selinv_cache === nothing ?
+            SelectedInversion.selinv_diag(b.factor) :
+            diag(b.selinv_cache)
+    end
     return b.selinv_diag_cache
 end
 

--- a/test/workspace/test_gmrf_workspace.jl
+++ b/test/workspace/test_gmrf_workspace.jl
@@ -148,4 +148,26 @@ end
         d2 = selinv_diag(ws)
         @test d1 === d2  # Same object (cached)
     end
+
+    @testset "Selinv lazy materialization" begin
+        # Issue #144: the CHOLMOD backend materializes the selected inverse
+        # lazily. Callers needing only the diagonal must not build the full
+        # sparse matrix, and an already-built full selinv should be reused for
+        # the diagonal rather than recomputed.
+
+        # Diagonal-only access never materializes the full sparse selected inverse.
+        ws = GMRFWorkspace(Q)
+        d = selinv_diag(ws)
+        @test d ≈ diag(Q_inv) rtol = 1.0e-8
+        @test ws.backend.selinv_cache === nothing
+
+        # When the full selinv is already built, the diagonal is taken from it.
+        ws2 = GMRFWorkspace(Q)
+        S = selinv(ws2)
+        @test ws2.backend.selinv_cache !== nothing
+        @test selinv_diag(ws2) == diag(S)
+
+        # The diagonal-only path and the full path agree bit-for-bit.
+        @test selinv_diag(GMRFWorkspace(Q)) == diag(selinv(GMRFWorkspace(Q)))
+    end
 end


### PR DESCRIPTION
## Summary

Fixes #144. `CHOLMODBackend.compute_selinv!` materialized the selected inverse by assigning `SelectedInversion.selinv(...).Z` (a `SupernodalMatrix`) into a field typed `SparseMatrixCSC`. That assignment went through the generic `SparseMatrixCSC(::AbstractMatrix)` convert, which calls supernodal `getindex` once per structural entry (a `searchsorted` each) — orders of magnitude slower than SelectedInversion's vectorized `sparse()`.

This defers materialization to the getters:

- `get_selinv` builds the full sparse matrix via `sparse(...)`.
- `get_selinv_diag` computes only the diagonal via `SelectedInversion.selinv_diag` when the full matrix isn't needed, and reuses the full cache when it is.

The `var` path needs only the diagonal and the autodiff path needs only the full matrix, so eagerly computing both on every factorization was wasted work. The same vectorized `sparse(...)` idiom is already used in `src/solvers/selinv.jl`.

## Benchmark

On a 1728-DOF 3D-grid precision with ~280k nonzeros in the selected inverse:

| path | before | after | speedup |
|---|---|---|---|
| `selinv(ws)` (full) | 381 ms | 28 ms | ~14× |
| `selinv_diag(ws)` (diagonal) | 356 ms | 17 ms | ~22× |

Results are **bit-identical** (max abs error vs dense inverse: 3.9e-16, same as before). Component breakdown on the same problem confirms the cause: generic `SparseMatrixCSC(Z)` = 388 ms vs vectorized `sparse(Z)` = 6.7 ms vs `selinv_diag(F)` = 26 ms.

## Tests

- Existing `selinv` / `selinv_diag` correctness tests pass unchanged.
- New "Selinv lazy materialization" testset in `test/workspace/test_gmrf_workspace.jl` asserts the diagonal path skips building the full sparse matrix, the full cache is reused for the diagonal, and both paths agree bit-for-bit.

## Benchmarks suite

Adds `gmrf/workspace_selinv_full` and `gmrf/workspace_selinv_diag` to `benchmarks/benchmarks.jl` (with a 3D-grid precision that produces dense Cholesky fill) to guard against regression.