### PR TITLE
Variance-scaled RW models: scale_model option for RWModel (#149)

### DIFF
--- a/ext/GaussianMarkovRandomFieldsFormula/build.jl
+++ b/ext/GaussianMarkovRandomFieldsFormula/build.jl
@@ -30,7 +30,7 @@ function _latent_model(term::RandomWalkTerm{Order}, data) where {Order}
         end
     end
 
-    return RWModel{Order}(n; additional_constraints = term.additional_constraints, levels = collect(levels))
+    return RWModel{Order}(n; additional_constraints = term.additional_constraints, levels = collect(levels), scale_model = term.scale_model)
 end
 
 function _latent_model(term::ARTerm{P}, data) where {P}

--- a/ext/GaussianMarkovRandomFieldsFormula/terms.jl
+++ b/ext/GaussianMarkovRandomFieldsFormula/terms.jl
@@ -25,6 +25,7 @@ StatsModels.termvars(term::IIDTerm) = [term.variable]
 struct RandomWalkTerm{Order} <: FormulaRandomEffectTerm
     variable::Symbol
     additional_constraints::Union{Nothing, Tuple{AbstractMatrix, AbstractVector}}
+    scale_model::Bool
 end
 
 # RandomWalk instance (e.g., rw1 = RandomWalk(); @formula(y ~ rw1(time)) or rw1 = RandomWalk(1); @formula(y ~ rw1(time)))
@@ -36,7 +37,7 @@ function StatsModels.apply_schema(
     var_term = only(t.args)
     order = t.f.order
     order isa Integer || throw(ArgumentError("RandomWalk order must be an integer, got $(typeof(order))"))
-    return RandomWalkTerm{Int(order)}(var_term.sym, t.f.additional_constraints)
+    return RandomWalkTerm{Int(order)}(var_term.sym, t.f.additional_constraints, t.f.scale_model)
 end
 
 StatsModels.termvars(term::RandomWalkTerm) = [term.variable]

--- a/src/formula/constructors.jl
+++ b/src/formula/constructors.jl
@@ -62,7 +62,7 @@ end
 (::IID)(args...) = throw(ArgumentError("IID(...) functor is only intended for use inside @formula; not callable directly.")) # COV_EXCL_LINE
 
 """
-    RandomWalk(order=1; additional_constraints = nothing)
+    RandomWalk(order=1; additional_constraints = nothing, scale_model = false)
 
 Formula functor for RandomWalk random effects of any order.
 
@@ -73,6 +73,9 @@ Formula functor for RandomWalk random effects of any order.
   Can be:
   - `nothing` (default): Only the built-in null space constraints
   - `(A, e)`: Custom additional linear constraint matrix and vector where `Ax = e`
+- `scale_model`: When `true`, apply the Sørbye–Rue (2014) variance normalization so the
+  precision parameter `τ` is interpretable and comparable across `n` and order (see
+  [`RWModel`](@ref)). Default `false`.
 
 # Usage
 ```julia
@@ -101,9 +104,10 @@ st = Separable(rw1, besag)
 struct RandomWalk
     order::Int
     additional_constraints::Union{Nothing, Tuple{AbstractMatrix, AbstractVector}}
+    scale_model::Bool
 
-    function RandomWalk(order::Integer = 1; additional_constraints = nothing)
-        return new(Int(order), additional_constraints)
+    function RandomWalk(order::Integer = 1; additional_constraints = nothing, scale_model::Bool = false)
+        return new(Int(order), additional_constraints, scale_model)
     end
 end
 

--- a/src/latent_models/rw.jl
+++ b/src/latent_models/rw.jl
@@ -37,13 +37,22 @@ function _difference_operator(n::Int, ::Val{Order}) where {Order}
 end
 
 """
-    RWModel{Order}(n::Int; regularization=1e-5, alg=<auto>, additional_constraints=nothing)
+    RWModel{Order}(n::Int; regularization=1e-5, alg=<auto>, additional_constraints=nothing, scale_model=false)
 
 A random walk latent model of arbitrary order for constructing intrinsic GMRFs.
 
 The RW model of order k represents a process where k-th order differences are
 i.i.d. Gaussian: Δᵏx[i] ~ N(0, τ⁻¹). This creates a singular precision matrix
 Q = τ * Dₖ'Dₖ with rank n-k, where Dₖ is the k-th order difference operator.
+
+# Variance scaling
+With `scale_model = true`, the intrinsic precision is normalized following Sørbye & Rue
+(2014): the precision is multiplied by a constant so the geometric mean of the marginal
+variances (of the constrained model) is 1. This makes `τ` interpretable as a precision and
+comparable across `n` and across orders, so a prior on `τ` (e.g. `PCPrior.Precision`)
+transfers between models. Unscaled (`scale_model = false`, the default) reproduces the
+previous behavior, where `τ = 1` implies an `n`- and order-dependent marginal variance.
+This is the same normalization `BesagModel`/`BYM2Model` apply.
 
 # Orders
 - **Order 1 (RW1)**: First differences x[i+1] - x[i] ~ N(0, τ⁻¹). Tridiagonal precision.
@@ -62,9 +71,10 @@ intrinsic GMRF with k constraints from the polynomial null space (degrees 0, 1, 
 
 # Fields
 - `n::Int`: Length of the process
-- `regularization::Float64`: Small value added to diagonal after scaling (default 1e-5)
+- `regularization::Float64`: Small value added to diagonal after scaling (default 1e-5). Keep it small when `scale_model = true`: the variance normalization is computed at a negligible internal regularization, so a large `regularization` would shift the realized marginal variances away from the normalized scale.
 - `alg::Alg`: LinearSolve algorithm (default: `LDLtFactorization()` for Order=1, `CHOLMODFactorization()` for Order≥2)
 - `additional_constraints::C`: Optional additional constraints beyond the required null space constraints
+- `scale_factor::Float64`: Sørbye–Rue variance-normalization factor multiplying the intrinsic precision (`1.0` when `scale_model = false`)
 
 # Example
 ```julia
@@ -87,22 +97,58 @@ struct RWModel{Order, Alg, C, L} <: LatentModel
     alg::Alg
     additional_constraints::C
     levels::L
+    scale_factor::Float64
 
-    function RWModel{Order, Alg, C, L}(n::Int, regularization::Float64, alg::Alg, additional_constraints::C, levels::L) where {Order, Alg, C, L}
+    function RWModel{Order, Alg, C, L}(n::Int, regularization::Float64, alg::Alg, additional_constraints::C, levels::L, scale_factor::Float64) where {Order, Alg, C, L}
         Order isa Int && Order >= 1 || throw(ArgumentError("Order must be a positive integer, got Order=$Order"))
         n > Order || throw(ArgumentError("RW$Order requires length n > $Order, got n=$n"))
         regularization >= 0 || throw(ArgumentError("Regularization must be non-negative, got $regularization"))
-        return new{Order, Alg, C, L}(n, regularization, alg, additional_constraints, levels)
+        scale_factor > 0 || throw(ArgumentError("scale_factor must be positive, got $scale_factor"))
+        return new{Order, Alg, C, L}(n, regularization, alg, additional_constraints, levels, scale_factor)
     end
 end
 
-function RWModel{Order}(n::Int; regularization::Float64 = 1.0e-5, alg = _default_rw_alg(Val(Order)), additional_constraints = nothing, levels = nothing) where {Order}
+function RWModel{Order}(n::Int; regularization::Float64 = 1.0e-5, alg = _default_rw_alg(Val(Order)), additional_constraints = nothing, levels = nothing, scale_model::Bool = false) where {Order}
     if additional_constraints === :sumtozero
         throw(ArgumentError("RWModel already includes null space constraints by default. Use additional_constraints for extra constraints beyond the built-in ones."))
     end
 
     processed_additional = _process_constraint(additional_constraints, n)
-    return RWModel{Order, typeof(alg), typeof(processed_additional), typeof(levels)}(n, regularization, alg, processed_additional, levels)
+    scale_factor = if scale_model
+        n > Order || throw(ArgumentError("RW$Order requires length n > $Order, got n=$n"))
+        _rw_scale_factor(Val(Order), n)
+    else
+        1.0
+    end
+    return RWModel{Order, typeof(alg), typeof(processed_additional), typeof(levels)}(n, regularization, alg, processed_additional, levels, scale_factor)
+end
+
+# Polynomial null-space constraint matrix of D_kᵀD_k: rows j^d (d = 0, …, Order-1).
+function _rw_nullspace_constraints(n::Int, ::Val{Order}) where {Order}
+    A = zeros(Order, n)
+    for d in 0:(Order - 1), j in 1:n
+        A[d + 1, j] = Float64(j)^d
+    end
+    return A
+end
+
+# Tiny fixed regularization that makes the singular `DₖᵀDₖ` factorizable for the
+# scale-factor variance solve. Decoupled from the model's own `regularization`, matching
+# `BesagModel`'s `_compute_normalization`; the null-space constraint removes the actual
+# singular directions, so this only needs to nudge the factorization.
+const _RW_SCALE_REG = 1.0e-5
+
+# Sørbye & Rue (2014) variance scaling. Returns the factor `c` such that the precision
+# `c · DₖᵀDₖ` (under the model's null-space constraints) has geometric-mean marginal
+# variance 1. That factor is the geometric mean of the marginal variances of the *unscaled*
+# constrained intrinsic model — equivalently the geomean of `diag(Q⁺)`, the Moore–Penrose
+# pseudoinverse diagonal. Computed once at construction.
+function _rw_scale_factor(::Val{Order}, n::Int) where {Order}
+    D = _difference_operator(n, Val(Order))
+    Q = sparse(D' * D) + _RW_SCALE_REG * I
+    A = _rw_nullspace_constraints(n, Val(Order))
+    x = ConstrainedGMRF(GMRF(zeros(n), Q), A, zeros(Order))
+    return _geomean(var(x))
 end
 
 """Backward-compatible alias for `RWModel{1}`."""
@@ -130,13 +176,14 @@ function precision_matrix(model::RWModel{1}; τ::Real, kwargs...)
 
     n = model.n
     T = promote_type(typeof(τ), Float64)
+    sτ = model.scale_factor * τ   # Sørbye–Rue variance scaling (factor is 1 when unscaled)
 
     main_diag = map(1:n) do i
         base_val = (i == 1 || i == n) ? T(1) : T(2)
-        base_val * τ + model.regularization
+        base_val * sτ + model.regularization
     end
 
-    off_diag = fill(-T(τ), n - 1)
+    off_diag = fill(-T(sτ), n - 1)
 
     return SymTridiagonal(main_diag, off_diag)
 end
@@ -149,7 +196,7 @@ function precision_matrix(model::RWModel{Order}; τ::Real, kwargs...) where {Ord
     T = promote_type(typeof(τ), Float64)
 
     D = _difference_operator(n, Val(Order))
-    Q = T(τ) * (D' * D) + model.regularization * sparse(T(1) * I, n, n)
+    Q = T(model.scale_factor * τ) * (D' * D) + model.regularization * sparse(T(1) * I, n, n)
 
     return Q
 end
@@ -161,14 +208,8 @@ end
 function constraints(model::RWModel{Order}; kwargs...) where {Order}
     n = model.n
 
-    # Null space of D_k'*D_k: polynomials of degree 0, 1, ..., k-1
-    # Row d+1 corresponds to j^d for j = 1, ..., n
-    A_nullspace = zeros(Order, n)
-    for d in 0:(Order - 1)
-        for j in 1:n
-            A_nullspace[d + 1, j] = Float64(j)^d
-        end
-    end
+    # Null space of D_k'*D_k: polynomials of degree 0, 1, ..., k-1 (row d+1 is j^d).
+    A_nullspace = _rw_nullspace_constraints(n, Val(Order))
     e_nullspace = zeros(Order)
 
     if model.additional_constraints === nothing

--- a/src/latent_models/rw.jl
+++ b/src/latent_models/rw.jl
@@ -125,11 +125,7 @@ end
 
 # Polynomial null-space constraint matrix of D_kᵀD_k: rows j^d (d = 0, …, Order-1).
 function _rw_nullspace_constraints(n::Int, ::Val{Order}) where {Order}
-    A = zeros(Order, n)
-    for d in 0:(Order - 1), j in 1:n
-        A[d + 1, j] = Float64(j)^d
-    end
-    return A
+    return Float64[Float64(j)^(d - 1) for d in 1:Order, j in 1:n]
 end
 
 # Tiny fixed regularization that makes the singular `DₖᵀDₖ` factorizable for the
@@ -147,7 +143,7 @@ function _rw_scale_factor(::Val{Order}, n::Int) where {Order}
     D = _difference_operator(n, Val(Order))
     Q = sparse(D' * D) + _RW_SCALE_REG * I
     A = _rw_nullspace_constraints(n, Val(Order))
-    x = ConstrainedGMRF(GMRF(zeros(n), Q), A, zeros(Order))
+    x = ConstrainedGMRF(GMRF(zeros(n), Q), A, zeros(size(A, 1)))
     return _geomean(var(x))
 end
 

--- a/test/formula/test_formula_interface.jl
+++ b/test/formula/test_formula_interface.jl
@@ -307,6 +307,19 @@ end
         @test length(s) == n
     end
 
+    @testset "RandomWalk scale_model threads through the formula interface" begin
+        _gm(v) = exp(sum(log, v) / length(v))
+        rws = RandomWalk(1; scale_model = true)
+        rwu = RandomWalk(1)
+        comp_s = build_formula_components(@formula(y ~ 0 + rws(time)), data; family = Normal)
+        comp_u = build_formula_components(@formula(y ~ 0 + rwu(time)), data; family = Normal)
+        vs = var(comp_s.combined_model(τ_rw1 = 1.0))
+        vu = var(comp_u.combined_model(τ_rw1 = 1.0))
+        # Scaled: geometric-mean marginal variance ≈ 1 (Sørbye–Rue). Unscaled: n-dependent.
+        @test isapprox(_gm(vs), 1.0; rtol = 0.05)
+        @test _gm(vs) < _gm(vu)
+    end
+
     @testset "AR(2) via formula interface" begin
         ar2 = AR(2)
         comp = build_formula_components(@formula(y ~ 0 + ar2(time)), data; family = Normal)

--- a/test/latent_models/test_rw.jl
+++ b/test/latent_models/test_rw.jl
@@ -372,3 +372,75 @@ end
         end
     end
 end
+
+@testset "RWModel variance scaling (scale_model)" begin
+    _gm(v) = exp(sum(log, v) / length(v))   # geometric mean
+
+    @testset "default is unscaled (backward compatible)" begin
+        for k in 1:3
+            m = RWModel{k}(15)
+            @test m.scale_factor == 1.0
+            @test precision_matrix(m; τ = 2.0) ≈
+                precision_matrix(RWModel{k}(15; scale_model = false); τ = 2.0)
+        end
+    end
+
+    @testset "scale factor = geomean of pseudo-inverse marginal variances (Sørbye–Rue)" begin
+        # Independent reference: the Sørbye–Rue factor is the geometric mean of the marginal
+        # variances of the constrained intrinsic model, i.e. geomean(diag(Q⁺)) for Q = DₖᵀDₖ,
+        # computed here via the Moore–Penrose pseudoinverse (no GMRF machinery involved).
+        for (k, n) in ((1, 10), (1, 25), (2, 12), (2, 20), (3, 14))
+            m = RWModel{k}(n; scale_model = true)
+            D = _test_diff_operator(n, k)
+            ref = _gm(diag(pinv(Matrix(D' * D))))
+            @test isapprox(m.scale_factor, ref; rtol = 5.0e-3)
+            @test m.scale_factor > 1.0   # these intrinsic models have generalized variance > 1
+        end
+    end
+
+    @testset "scaled model has geomean marginal variance ≈ 1 (defining property)" begin
+        for (k, n) in ((1, 12), (2, 15), (3, 18))
+            m = RWModel{k}(n; scale_model = true)
+            @test isapprox(_gm(var(m(τ = 1.0))), 1.0; rtol = 1.0e-2)
+        end
+    end
+
+    @testset "scaling multiplies the intrinsic precision by the factor" begin
+        for k in 1:3
+            n = 16
+            ms = RWModel{k}(n; scale_model = true)
+            mu = RWModel{k}(n; scale_model = false)
+            # Scaled precision at τ equals the unscaled precision at scale_factor·τ.
+            @test Matrix(precision_matrix(ms; τ = 1.3)) ≈
+                Matrix(precision_matrix(mu; τ = 1.3 * ms.scale_factor))
+        end
+    end
+
+    @testset "τ becomes interpretable as a precision (geomean var ≈ 1/τ)" begin
+        m = RWModel{2}(20; scale_model = true)
+        for τ in (0.5, 2.0, 5.0)
+            @test isapprox(_gm(var(m(τ = τ))), 1 / τ; rtol = 2.0e-2)
+        end
+    end
+
+    @testset "scaling factor independent of τ (constant multiplier)" begin
+        m = RWModel{1}(10; scale_model = true)
+        # precision is linear in τ with slope scale_factor·(base); a finite difference in τ
+        # recovers scale_factor·base on the precision entries away from the boundary.
+        Q1 = Matrix(precision_matrix(m; τ = 1.0))
+        Q2 = Matrix(precision_matrix(m; τ = 2.0))
+        @test (Q2[3, 3] - Q1[3, 3]) ≈ 2 * m.scale_factor    # interior diagonal slope = 2·factor
+        @test (Q2[3, 4] - Q1[3, 4]) ≈ -m.scale_factor       # off-diagonal slope = -factor
+    end
+
+    @testset "scale factor ignores additional_constraints (intrinsic property)" begin
+        # The Sørbye–Rue factor is a property of the intrinsic null-space only, so extra
+        # user constraints must not change it (matching BesagModel's normalization).
+        n = 14
+        A = zeros(1, n)
+        A[1, 1] = 1.0   # extra constraint x[1] = 0, beyond the built-in null space
+        m_extra = RWModel{2}(n; scale_model = true, additional_constraints = (A, [0.0]))
+        m_plain = RWModel{2}(n; scale_model = true)
+        @test m_extra.scale_factor == m_plain.scale_factor
+    end
+end


### PR DESCRIPTION
Closes #149.

## What

Adds a `scale_model` option to `RWModel{Order}` that applies the Sørbye & Rue (2014) variance normalization — the same generalized-variance scaling `BesagModel`/`BYM2Model` already use.

```julia
m = RWModel{2}(100; scale_model = true)   # τ is now an interpretable precision
```

`RWModel` built the **raw** intrinsic precision `τ·DₖᵀDₖ`, so `τ = 1` implies a marginal variance that depends on `n` and the order. That makes `τ` incomparable across models/sizes and mis-calibrates a prior placed on it (e.g. `PCPrior.Precision`). With `scale_model = true`, the precision is multiplied by a constant so the **geometric mean of the constrained model's marginal variances is 1**, so `τ` is interpretable as a precision and a prior on it transfers across graphs/orders.

Default is `scale_model = false` (unscaled), so existing behavior is byte-identical.

## Implementation

- New `scale_factor::Float64` field (1.0 when unscaled), computed once at construction via `_rw_scale_factor`: build `DₖᵀDₖ + 1e-5·I`, apply the polynomial null-space constraints, and take the geometric mean of the `ConstrainedGMRF` marginal variances (reusing `besag.jl`'s `_geomean`). `precision_matrix` multiplies `τ` by the factor; the regularization is unchanged.
- The factor depends only on the intrinsic null space (not on `additional_constraints`), matching Besag.

## Getting the scaling right (verification)

The scale factor is checked **two independent ways** in the test:

1. **Against the mathematical definition** — `scale_factor ≈ geomean(diag(Q⁺))` where `Q⁺` is the Moore–Penrose pseudoinverse of `DₖᵀDₖ`, computed with `pinv` (no GMRF machinery). Agreement is ~1e-4–2e-3 across RW1/RW2/RW3 and several `n` (the gap is the 1e-5 variance-solve regularization).
2. **The defining property** — the scaled model's geometric-mean marginal variance is `≈ 1` (and `≈ 1/τ` for general `τ`).

Plus: the scaling multiplies the precision exactly by the factor, the unscaled path is byte-identical, the factor is `τ`-independent (AD-through-`τ` works), and `additional_constraints` don't change it.

Designed and reviewed with multi-agent workflows (adversarial review came back clean — only by-design nits matching the existing Besag convention).

## Follow-up (not in this PR)

The formula DSL (`RandomWalk(...)` in the Formula extension) materializes `RWModel` at `build.jl`; threading `scale_model` through `RandomWalk` → `RandomWalkTerm` → `_latent_model` would expose scaling to `@formula` users. Small, clean 3-site change — happy to do it next if wanted.