### PR TITLE
Fix benchmark comparison: nested-group crash + time-only judgement

### DIFF
--- a/benchmarks/compare_results.jl
+++ b/benchmarks/compare_results.jl
@@ -26,15 +26,58 @@ pr = BenchmarkTools.load(pr_path)[1]::BenchmarkGroup
 # Regression threshold: how much slower the PR can be before we flag it.
 # CI runners are noisy, so use a generous threshold by default.
 const REGRESSION_TOLERANCE = 0.5  # 50% slowdown triggers a regression flag
-const IMPROVEMENT_TOLERANCE = 0.2 # 20% speedup highlighted as improvement
 
-judgement = judge(median(pr), median(baseline); time_tolerance = REGRESSION_TOLERANCE)
+# Work on the median estimate trees: `judge` compares these, so the keys of its
+# leaves index exactly into them. (Re-indexing the *raw* groups with those keys
+# can land on a sub-group when the two suites differ in shape, and
+# `time(median(group))` returns a BenchmarkGroup rather than a number.)
+med_baseline = median(baseline)
+med_pr = median(pr)
 
-regressions_list = BenchmarkTools.leaves(regressions(judgement))
-improvements_list = BenchmarkTools.leaves(improvements(judgement))
+judgement = judge(med_pr, med_baseline; time_tolerance = REGRESSION_TOLERANCE)
 
-function fmt_time(ns)
-    return BenchmarkTools.prettytime(ns)
+# Flag on the median *time* only. `regressions`/`improvements` also fire on memory, but the
+# default memory tolerance is ~1% — far too sensitive for noisy CI runners, where a
+# sub-percent allocation wobble would fail the job even when time is unchanged or improved.
+_judged_leaves = BenchmarkTools.leaves(judgement)
+regressions_list = [(keys, j) for (keys, j) in _judged_leaves if time(j) === :regression]
+improvements_list = [(keys, j) for (keys, j) in _judged_leaves if time(j) === :improvement]
+
+fmt_time(ns) = BenchmarkTools.prettytime(ns)
+
+# Walk a (possibly nested) BenchmarkGroup along `keys`; return the leaf or `nothing`
+# if the path is missing or stops at a sub-group rather than a leaf estimate.
+function _safe_get(group, keys)
+    g = group
+    for k in keys
+        g isa BenchmarkGroup || return nothing
+        haskey(g, k) || return nothing
+        g = g[k]
+    end
+    return g
+end
+
+# Median time (ns) of the leaf at `keys` in a median estimate tree, or `nothing`.
+function _leaf_time(med_group, keys)
+    g = _safe_get(med_group, keys)
+    return g isa BenchmarkTools.TrialEstimate ? time(g) : nothing
+end
+
+# Emit a table for the given leaf list; returns the number of rows actually written.
+function _emit_rows!(io, leaf_list; bold_ratio::Bool)
+    rows = 0
+    for (keys, _judgement) in leaf_list
+        b_time = _leaf_time(med_baseline, keys)
+        p_time = _leaf_time(med_pr, keys)
+        (b_time === nothing || p_time === nothing) && continue
+        name = join(keys, " / ")
+        ratio = p_time / b_time
+        ratio_str = bold_ratio ? string("**", round(ratio; digits = 2), "x**") :
+            string(round(ratio; digits = 2), "x")
+        println(io, "| `", name, "` | ", fmt_time(b_time), " | ", fmt_time(p_time), " | ", ratio_str, " |")
+        rows += 1
+    end
+    return rows
 end
 
 io = IOBuffer()
@@ -52,16 +95,7 @@ else
     println(io)
     println(io, "| Benchmark | Baseline | PR | Ratio |")
     println(io, "|---|---:|---:|---:|")
-    for (keys, trial) in regressions_list
-        name = join(keys, " / ")
-        b_time = time(median(baseline[keys...]))
-        p_time = time(median(pr[keys...]))
-        ratio = p_time / b_time
-        println(
-            io, "| `", name, "` | ", fmt_time(b_time), " | ", fmt_time(p_time),
-            " | **", round(ratio; digits = 2), "x** |"
-        )
-    end
+    _emit_rows!(io, regressions_list; bold_ratio = true)
     println(io)
 end
 
@@ -70,27 +104,8 @@ if !isempty(improvements_list)
     println(io)
     println(io, "| Benchmark | Baseline | PR | Ratio |")
     println(io, "|---|---:|---:|---:|")
-    for (keys, trial) in improvements_list
-        name = join(keys, " / ")
-        b_time = time(median(baseline[keys...]))
-        p_time = time(median(pr[keys...]))
-        ratio = p_time / b_time
-        println(
-            io, "| `", name, "` | ", fmt_time(b_time), " | ", fmt_time(p_time),
-            " | ", round(ratio; digits = 2), "x |"
-        )
-    end
+    _emit_rows!(io, improvements_list; bold_ratio = false)
     println(io)
-end
-
-function _safe_get(group, keys)
-    g = group
-    for k in keys
-        g isa BenchmarkGroup || return nothing
-        haskey(g, k) || return nothing
-        g = g[k]
-    end
-    return g
 end
 
 # Always include the full table for visibility.
@@ -99,17 +114,13 @@ println(io, "<summary>Full results</summary>")
 println(io)
 println(io, "| Benchmark | Baseline | PR | Ratio |")
 println(io, "|---|---:|---:|---:|")
-for (keys, trial) in BenchmarkTools.leaves(pr)
+for (keys, est) in BenchmarkTools.leaves(med_pr)
     name = join(keys, " / ")
-    p_time = time(median(trial))
-    baseline_trial = _safe_get(baseline, keys)
-    if baseline_trial !== nothing
-        b_time = time(median(baseline_trial))
+    p_time = time(est)
+    b_time = _leaf_time(med_baseline, keys)
+    if b_time !== nothing
         ratio = p_time / b_time
-        println(
-            io, "| `", name, "` | ", fmt_time(b_time), " | ", fmt_time(p_time),
-            " | ", round(ratio; digits = 2), "x |"
-        )
+        println(io, "| `", name, "` | ", fmt_time(b_time), " | ", fmt_time(p_time), " | ", round(ratio; digits = 2), "x |")
     else
         println(io, "| `", name, "` | _new_ | ", fmt_time(p_time), " | — |")
     end


### PR DESCRIPTION
The `Performance regression benchmarks` job has been failing since #139 made the compare step actually run. Two bugs in `compare_results.jl`, both fixed here and verified against the **real failing CI artifacts** (downloaded from the failed run).

## 1. Crash on nested groups

```
MethodError: no method matching /(::BenchmarkGroup, ::BenchmarkGroup)  @ compare_results.jl:59
```

The regression/improvement report loops took keys from the *judgement* leaves but re-indexed the **raw** benchmark groups (`baseline[keys...]`). When a key lands on a sub-group rather than a leaf, `time(median(group))` returns a `BenchmarkGroup`, and the `p_time / b_time` ratio blows up. Fixed by indexing the **median trees that `judge` actually compared**, via a safe walk (`_safe_get`) that returns `nothing` for missing/non-leaf paths and is skipped.

## 2. Memory noise fails the job

After the crash fix, the real artifacts still flagged a "regression": `autodiff / zygote_grad_full_pipeline` at **0.62x** — i.e. *faster*. It was firing on **memory** (`time=invariant, memory=regression`): `regressions()` considers memory too, and the default `memory_tolerance` is ~1%, far too sensitive for noisy CI runners. The script’s intent (per its docstring) is *time* regressions, so it now judges on the median **time** only.

## Verification

- Real failing CI `baseline.json`/`pr.json` (from the #150 run): **now exits 0, "No regressions detected"** (was a crash).
- Synthetic 2× time regression: still flagged, **exits 1**.
- Nested groups and *new* benchmarks (present in PR, absent in baseline) render correctly (`_new_`).

Separate from any feature work — this just makes the benchmark check usable again.