### PR TITLE
Error on out-of-mesh points in FEM evaluation_matrix

### DIFF
--- a/ext/GaussianMarkovRandomFieldsFEM/fem_discretization.jl
+++ b/ext/GaussianMarkovRandomFieldsFEM/fem_discretization.jl
@@ -120,7 +120,19 @@ function evaluation_matrix(f::FEMDiscretization, X::AbstractVector; field = :def
         field = first(f.dof_handler.field_names)
     end
     dof_idcs = dof_range(f.dof_handler, field)
-    peh = PointEvalHandler(f.grid, X)
+    peh = PointEvalHandler(f.grid, X; warn = false)
+    # Points outside the mesh are not located in any cell (`cells[i] === nothing`).
+    # Evaluating there is undefined, so error clearly instead of silently dropping
+    # the row (which would silently discard observations / yield misleading zeros).
+    outside = findall(isnothing, peh.cells)
+    isempty(outside) || throw(
+        ArgumentError(
+            "evaluation_matrix: $(length(outside)) query point(s) lie outside the mesh " *
+                "and cannot be located in any cell. Offending indices: $(outside); " *
+                "coordinates: $(X[outside]). Restrict evaluation to points inside the " *
+                "discretization domain.",
+        ),
+    )
     cc = CellCache(f.dof_handler)
     Is = Int64[]
     Js = Int64[]

--- a/test/formula/test_formula_interface.jl
+++ b/test/formula/test_formula_interface.jl
@@ -570,8 +570,10 @@ end
         y_train = randn(20)
         train = (y = randn(20), x_coord = x_train, y_coord = y_train)
 
-        x_test = randn(5)
-        y_test = randn(5)
+        # Query a subset of the training points so the points are guaranteed to
+        # lie inside the discretization mesh (evaluating outside it is an error).
+        x_test = x_train[1:5]
+        y_test = y_train[1:5]
         test = (x_coord = x_test, y_coord = y_test)
 
         matern = Matern(smoothness = 1)

--- a/test/spdes/fem/test_fem_discretization.jl
+++ b/test/spdes/fem/test_fem_discretization.jl
@@ -24,6 +24,12 @@ using GaussianMarkovRandomFields, Ferrite, SparseArrays
     A_matrix = evaluation_matrix(f, X_matrix)
     @test A_matrix ≈ A
 
+    # Points outside the mesh cannot be located in any cell and must raise a
+    # clear error rather than silently producing an empty row.
+    X_oob = [Vec(0.5, 0.45), Vec(5.0, 5.0)]  # second point lies outside [-1, 1]^2
+    @test_throws ArgumentError evaluation_matrix(f, X_oob)
+    @test_throws ArgumentError evaluation_matrix(f, [0.5 0.45; 5.0 5.0])
+
 
     node_idcs = [6, 13]
     B = node_selection_matrix(f, node_idcs)


### PR DESCRIPTION
## Problem

`evaluation_matrix(::FEMDiscretization, X)` crashes when a query point in `X` falls outside the mesh. `PointEvalHandler` sets `peh.cells[i] === nothing` for points it can't locate in a cell, and the loop then calls `Ferrite.reinit!(cc, nothing)`, throwing a cryptic:

```
MethodError: no method matching reinit!(::Ferrite.CellCache{…}, ::Nothing)
```

This surfaced intermittently as a hard error in the `"Matern — reuses discretization"` formula test, which fed unseeded random query points that routinely land outside the mesh. The bug predates recent work; the recent Ferrite bump just removed the `reinit!(::CellCache, ::Nothing)` fallback that masked it.

## Fix

`evaluation_matrix` is also the **observation design matrix** (`PointEvaluationObsModel`, via `fem_obs_models.jl`) and the **prediction** operator (`matern_model.jl`). Silently turning out-of-mesh points into empty rows would therefore *discard observations* or return a *misleading zero* prediction — a footgun. Evaluating a FEM field outside its discretization is genuinely undefined, so this raises a clear `ArgumentError` naming the offending point indices and coordinates instead:

```
evaluation_matrix: 1 query point(s) lie outside the mesh and cannot be located
in any cell. Offending indices: [2]; coordinates: [[5.0, 5.0]]. Restrict
evaluation to points inside the discretization domain.
```

No legitimate caller passes out-of-mesh points: the Makie plot grid spans exactly the mesh bounding box, and obs/prediction points are user-supplied. `PointEvalHandler` is now constructed with `warn = false` since we own the (clearer) error.

## Tests

- `test/spdes/fem/test_fem_discretization.jl`: out-of-mesh points (vector and matrix interfaces) now `@test_throws ArgumentError`.
- `test/formula/test_formula_interface.jl`: the `"Matern — reuses discretization"` test now queries a subset of the (in-mesh) training points instead of fresh random points, de-flaking it.

Verified locally against the FEM weakdep stack (Ferrite/FerriteGmsh/Gmsh/LibGEOS): in-mesh evaluation keeps partition-of-unity, out-of-mesh raises the error, and a Matern model evaluated at its own training points does not error.