### PR TITLE
Include the offset in linear_predictor_marginals (fixes #154)

### DIFF
--- a/src/linear_predictor_marginals.jl
+++ b/src/linear_predictor_marginals.jl
@@ -18,8 +18,10 @@ The dispatch recurses on the observation likelihood structure:
   `indices === nothing`). `μ_η` and `v_η` are the corresponding slices of
   `mean(ga)` / `var(ga)`; `eta_likelihood` is the same likelihood with
   `indices === nothing` so it consumes the returned (smaller) `μ_η` directly.
-- `LinearlyTransformedLikelihood`: `η = A x`, giving `μ_η = A · mean(ga)` and
-  `v_η = diag(A · Σ · Aᵀ)` from the posterior's selected-inversion output.
+- `LinearlyTransformedLikelihood`: affine predictor `η = A x + b` (the offset
+  `b = lik.offset` is omitted when `nothing`), giving `μ_η = A · mean(ga) + b`
+  and `v_η = diag(A · Σ · Aᵀ)` from the posterior's selected-inversion output
+  (the constant `b` does not affect the variance).
   `eta_likelihood = lik.base_likelihood`. Assumes the base's own `indices`
   field is `nothing` (the standard wrapping pattern); an indexed base is
   unusual and not specially handled.
@@ -70,6 +72,9 @@ end
 function linear_predictor_marginals(ga::AbstractGMRF, lik::LinearlyTransformedLikelihood)
     A = lik.design_matrix
     μ_η = A * mean(ga)
+    # Affine predictor η = A·x + b: include the additive offset in the mean.
+    # (The constant b does not affect the variance.)
+    lik.offset !== nothing && (μ_η = μ_η .+ lik.offset)
     v_η = _row_diag_AΣAt(A, ga)
     _apply_lpm_constraint_correction!(v_η, A, ga)
     return (Vector{Float64}(μ_η), v_η, lik.base_likelihood)

--- a/test/observation_models/test_linear_predictor_marginals.jl
+++ b/test/observation_models/test_linear_predictor_marginals.jl
@@ -60,6 +60,28 @@ using Random
         @test loglik(μ_η, inner) ≈ loglik(mean(prior), lik)
     end
 
+    @testset "LinearlyTransformedLikelihood with offset: μ_η = A μ + b" begin
+        k = 4
+        A = sparse(randn(k, n_latent))
+        b = randn(k)
+        m = LinearlyTransformedObservationModel(ExponentialFamily(Normal), A; offset = b)
+        y = randn(k)
+        lik = m(y; σ = 0.3)
+
+        μ_η, v_η, inner = linear_predictor_marginals(prior, lik)
+        @test μ_η ≈ A * mean(prior) .+ b
+        # The additive offset shifts the mean but leaves the variance unchanged.
+        @test v_η ≈ diag(A * Σ_ref * A')
+        @test inner === lik.base_likelihood
+        @test loglik(μ_η, inner) ≈ loglik(mean(prior), lik)
+
+        # Regression guard for #154: the offset must actually reach μ_η.
+        lik0 = LinearlyTransformedObservationModel(ExponentialFamily(Normal), A)(y; σ = 0.3)
+        μ_η0, = linear_predictor_marginals(prior, lik0)
+        @test μ_η ≈ μ_η0 .+ b
+        @test !isapprox(μ_η, μ_η0)
+    end
+
     @testset "LinearlyTransformedLikelihood on WorkspaceGMRF" begin
         k = 4
         A = sparse(randn(k, n_latent))


### PR DESCRIPTION
## Problem

`linear_predictor_marginals(ga, ::LinearlyTransformedLikelihood)` computes the predictor mean as `μ_η = A · mean(ga)` and silently ignores the likelihood's `offset` field. For an affine predictor `η = A·x + b` the returned `μ_η` should be `A·mean(ga) + b`. The variance is correct (an additive constant doesn't affect it); only the mean was wrong.

## Fix

Add the offset to `μ_η` when present:

```julia
μ_η = A * mean(ga)
lik.offset !== nothing && (μ_η = μ_η .+ lik.offset)
```

The single `LinearlyTransformedLikelihood` method backs the `GMRF`, `WorkspaceGMRF`, and `ConstrainedGMRF` paths (and is reached recursively for composite-of-LTL), so all of them are fixed uniformly. The docstring is updated from `η = A x` to the affine `η = A x + b`.

## Tests

Added a TDD testset in `test/observation_models/test_linear_predictor_marginals.jl` asserting `μ_η ≈ A·mean + b`, that the variance is unchanged by the offset, full-path `loglik` consistency, and a regression guard that the offset actually reaches `μ_η`. Confirmed the test fails on `main` and passes with the fix (51/51 green locally).

Fixes #154.