### PR TITLE
Speed up LTL loghessian under ForwardDiff.Dual (closes #157)

### DIFF
--- a/benchmarks/benchmarks.jl
+++ b/benchmarks/benchmarks.jl
@@ -23,7 +23,7 @@ Usage (via PkgBenchmark):
 """
 
 using GaussianMarkovRandomFields
-using GaussianMarkovRandomFields: selinv, selinv_diag
+using GaussianMarkovRandomFields: selinv, selinv_diag, loghessian, LinearlyTransformedLikelihood
 using BenchmarkTools
 using Distributions: Poisson, logpdf
 using SparseArrays
@@ -70,6 +70,29 @@ const Y_POISSON_SMALL = PoissonObservations(
 )
 const OBS_LIK_POISSON_SMALL = ExponentialFamily(Poisson)(Y_POISSON_SMALL)
 const GMRF_PRIOR_SMALL = GMRF(MU_SMALL, Q_RW1_SMALL, LinearSolve.LDLtFactorization())
+
+# LinearlyTransformedLikelihood on the ForwardDiff.Dual (AD-through-hyperparameter)
+# path: the `loghessian` transpose product Aᵀ·hess_η·A specialized in #157. The design
+# matrix is a sparse local transform (~3 nonzeros/row), as in FEM / evaluation-matrix
+# observation models, and the latent field carries Dual partials (as on the IFT path).
+const LTL_BENCH_A = let Is = Int[], Js = Int[], Vs = Float64[], r = MersenneTwister(20260525)
+    for i in 1:200
+        cols = rand(r, 1:N_SMALL, 3)
+        w = rand(r, 3)
+        w ./= sum(w)
+        append!(Is, fill(i, 3))
+        append!(Js, cols)
+        append!(Vs, w)
+    end
+    sparse(Is, Js, Vs, 200, N_SMALL)
+end
+const LTL_BENCH_LIK = LinearlyTransformedLikelihood(
+    ExponentialFamily(Poisson)(PoissonObservations(rand(MersenneTwister(7), 0:5, 200))),
+    LTL_BENCH_A,
+)
+const LTL_BENCH_X_DUAL = let r = MersenneTwister(11)
+    [ForwardDiff.Dual{:bench}(randn(r), ForwardDiff.Partials((randn(r), randn(r)))) for _ in 1:N_SMALL]
+end
 
 # Adjacency matrix for a small 2D grid (Besag spatial model).
 function _grid_adjacency(nx::Int, ny::Int)
@@ -205,6 +228,10 @@ SUITE["gmrf"]["workspace_selinv_diag"] =
 SUITE["gaussian_approximation"] = BenchmarkGroup()
 SUITE["gaussian_approximation"]["poisson_rw1_small"] =
     @benchmarkable gaussian_approximation($GMRF_PRIOR_SMALL, $OBS_LIK_POISSON_SMALL)
+# loghessian for a LinearlyTransformedLikelihood on the Dual path (#157): guards the
+# transpose-materialization that keeps this ~70-90x off the lazy-Adjoint fallback.
+SUITE["gaussian_approximation"]["loghessian_ltl_dual"] =
+    @benchmarkable loghessian($LTL_BENCH_X_DUAL, $LTL_BENCH_LIK)
 
 # ---------------------------------------------------------------------------
 # 4. Autodiff pipeline — gradient through full workflow.

--- a/ext/forwarddiff/autodiff_likelihood_dual.jl
+++ b/ext/forwarddiff/autodiff_likelihood_dual.jl
@@ -104,6 +104,27 @@ _strip_offset_partials(::Nothing) = nothing
 _strip_offset_partials(b::AbstractVector{<:ForwardDiff.Dual}) = ForwardDiff.value.(b)
 _strip_offset_partials(b::AbstractVector) = b
 
+# Issue #157: when the latent field is Dual-valued (differentiating through
+# `gaussian_approximation` w.r.t. hyperparameters), `hess_η = loghessian(η, base)` is
+# `Diagonal{<:ForwardDiff.Dual}`, and the generic `Symmetric(A' * hess_η * A)` — with a
+# lazy `Adjoint` `A'` — drops into an allocation-heavy generic fallback that is ~70–90×
+# slower than materializing the transpose and right-associating. This Dual-specialized
+# method does the latter. It is numerically identical to the generic form up to
+# floating-point reassociation, and the offset is folded in identically via
+# `_linear_predictor` (η = A·x + b is affine in x, so ∂η/∂x = A and the offset only
+# shifts the point at which `hess_η` is evaluated). The `Float64` generic method is left
+# untouched on purpose: there the lazy `Adjoint` already hits an optimized `SparseArrays`
+# kernel and materializing would be marginally slower.
+function GMRFs.loghessian(
+        x_full::AbstractVector{<:ForwardDiff.Dual},
+        ltlik::GMRFs.LinearlyTransformedLikelihood,
+    )
+    η = GMRFs._linear_predictor(ltlik.design_matrix, x_full, ltlik.offset)
+    hess_η = GMRFs.loghessian(η, ltlik.base_likelihood)
+    A = ltlik.design_matrix
+    return Symmetric(sparse(transpose(A)) * (hess_η * A))
+end
+
 # NonlinearLeastSquaresLikelihood: strip the σ-derived numeric fields (Dual when σ
 # carried partials) and the stored residual hyperparameters (Dual when an `f(x; θ...)`
 # hyperparameter carried partials). `f` and the cached backends (`jac_backend`,

--- a/test/autodiff/test_forwarddiff_extension.jl
+++ b/test/autodiff/test_forwarddiff_extension.jl
@@ -597,4 +597,47 @@ using Test
             @test all(eigs .> 0)
         end
     end
+
+    @testset "loghessian LinearlyTransformedLikelihood: Dual specialization (#157)" begin
+        # The Dual-specialized loghessian materializes the transpose and
+        # right-associates (Aᵀ * (hess_η * A)); it must match the generic chain
+        # rule `Aᵀ * hess_η * A` up to floating-point reassociation, on the Dual
+        # value AND every partial component, for any base likelihood and offset.
+        rng = MersenneTwister(157)
+        m, n, P = 8, 20, 3
+        A = sprandn(rng, m, n, 0.35)
+        x0 = randn(rng, n)
+        seeds = randn(rng, n, P)
+        xd = [
+            ForwardDiff.Dual{:t}(x0[i], ForwardDiff.Partials(ntuple(k -> seeds[i, k], P)))
+                for i in 1:n
+        ]
+
+        # Full Dual-matrix agreement: values and each partial component.
+        function dual_mat_approx(X, Y)
+            ForwardDiff.value.(X) ≈ ForwardDiff.value.(Y) || return false
+            return all(ForwardDiff.partials.(X, k) ≈ ForwardDiff.partials.(Y, k) for k in 1:P)
+        end
+
+        bases = [
+            ("Normal", ExponentialFamily(Normal)(randn(rng, m); σ = 0.7)),
+            ("Poisson", ExponentialFamily(Poisson)(PoissonObservations(rand(rng, 0:5, m)))),
+        ]
+        for (_, base) in bases, offset in (nothing, randn(rng, m))
+            ltlik = LinearlyTransformedLikelihood(base, A, offset)
+            η = offset === nothing ? A * xd : A * xd .+ offset
+            hess_η = loghessian(η, base)
+            ref = Symmetric(Matrix(transpose(A)) * Matrix(hess_η) * Matrix(A))  # generic, dense
+            got = loghessian(xd, ltlik)                                          # new Dual method
+            @test got isa Symmetric
+            @test dual_mat_approx(Matrix(got), Matrix(ref))
+        end
+
+        # Dispatch guard: a Float64 latent field stays on the (exact) generic method.
+        ltlik_f = LinearlyTransformedLikelihood(
+            ExponentialFamily(Poisson)(PoissonObservations(rand(rng, 0:5, m))), A,
+        )
+        Hf = loghessian(randn(rng, n), ltlik_f)
+        @test eltype(Hf) <: AbstractFloat
+    end
 end


### PR DESCRIPTION
## Problem

`loghessian(x, ltlik::LinearlyTransformedLikelihood)` returns `Symmetric(A' * hess_η * A)` where `A'` is a **lazy** `Adjoint{Float64, SparseMatrixCSC}`. When `hess_η` is `Diagonal{<:ForwardDiff.Dual}` — exactly the case when differentiating through `gaussian_approximation` w.r.t. hyperparameters (the ForwardDiff/IFT path evaluates `loghessian` at a `Dual`-valued latent field) — the `Adjoint * Diagonal{Dual} * SparseMatrixCSC` product drops into a generic, allocation-heavy fallback. It's **~70–90× slower** than materializing the transpose and right-associating `Aᵀ * (hess_η * A)`, and it runs on every gradient step, so it dominates.

The slowdown is `Dual`-specific: for `Float64` `hess_η` the lazy form already hits an optimized `SparseArrays` kernel (materializing is marginally *slower*), so the fix is `Dual`-specialized and leaves the generic `Float64` method untouched.

## Fix

A `Dual`-specialized method in the ForwardDiff extension (`ext/forwarddiff/autodiff_likelihood_dual.jl`):

```julia
function GMRFs.loghessian(
        x_full::AbstractVector{<:ForwardDiff.Dual},
        ltlik::GMRFs.LinearlyTransformedLikelihood,
    )
    η = GMRFs._linear_predictor(ltlik.design_matrix, x_full, ltlik.offset)
    hess_η = GMRFs.loghessian(η, ltlik.base_likelihood)
    A = ltlik.design_matrix
    return Symmetric(sparse(transpose(A)) * (hess_η * A))
end
```

Numerically identical to the generic form up to floating-point reassociation (~1e-17); the offset is folded in identically via `_linear_predictor` (η = A·x + b is affine, so ∂η/∂x = A); dispatch is unambiguous since the generic method's `x_full` is untyped.

## Verification

- **Correctness** (new test): the Dual method matches the generic chain rule on the value *and* every partial component, for Normal and Poisson bases, with and without an affine offset; a Float64 latent field still selects the exact generic method.
- **Speed**: ~79× on a 200×1680 sparse transform with `Dual` `hess_η` (2489 µs → 32 µs), confirmed on the package's own types; the existing `Float64` path is unchanged.
- **End-to-end**: differentiating `gaussian_approximation` through an LTL Poisson obs model gives a finite, correct derivative (the existing MaternModel→gaussian_approximation pipeline test is the regression anchor).
- **Regression benchmark**: added `gaussian_approximation/loghessian_ltl_dual` to guard against reverting to the slow path.

Closes #157.