### PR TITLE
Defer the final factorization in workspace gaussian_approximation (#162)

### DIFF
--- a/src/workspace/gaussian_approximation.jl
+++ b/src/workspace/gaussian_approximation.jl
@@ -263,15 +263,19 @@ function gaussian_approximation(
                 (mean_change < mean_change_tol) ||
                 (mean_change_rel < mean_change_tol)
             verbose && println("  Converged after $iter iterations")
-            # Refresh ws.Q to Q_post(x_new) so `_build_result` snapshots the
-            # correct posterior precision. Without this, the line search's
-            # reload of Q_prior (via `ensure_loaded!` when the constrained
-            # branch uses a fresh `base_prior`, or whenever
-            # `_update_hessian!` tags the workspace as unowned) would leave
-            # ws.Q mismatched with x_new.
+            # Restore ws.Q to Q_post(x_new) so `_build_result` snapshots the correct
+            # posterior precision (the line search reloads Q_prior into ws.Q via
+            # `ensure_loaded!`, and `_update_hessian!` tags the workspace unowned).
+            # We set the VALUES but deliberately do NOT eagerly factorize:
+            # `_update_hessian!` marks the factorization invalid, and the first consumer
+            # of the returned posterior (`var`/`logdet`/`solve`/AD, or the constrained
+            # `ConstraintInfo` build) factorizes the snapshot on demand anyway — because
+            # `ws.loaded_version` is reset to 0 here, `ensure_loaded!(result)` reloads and
+            # refactorizes regardless. An eager `ensure_numeric!` would just be discarded
+            # and rebuilt, so deferring it saves one factorization per call with
+            # bit-identical results.
             H_final = loghessian(x_new, obs_lik)
             sparse_hess_map = _update_hessian!(ws, H_final, prior_nzval, diag_idx, sparse_hess_map)
-            ensure_numeric!(ws)
             return _build_result(ws, x_new, constraints)
         end
 
@@ -280,9 +284,10 @@ function gaussian_approximation(
 
     verbose && println("  Reached max_iter = $max_iter without convergence")
 
+    # Same as the converged branch: restore the precision values but defer the
+    # factorization to the first consumer (see the comment above).
     H_k = loghessian(x_k, obs_lik)
     sparse_hess_map = _update_hessian!(ws, H_k, prior_nzval, diag_idx, sparse_hess_map)
-    ensure_numeric!(ws)
 
     return _build_result(ws, x_k, constraints)
 end

--- a/test/workspace/test_workspace_gaussian_approximation.jl
+++ b/test/workspace/test_workspace_gaussian_approximation.jl
@@ -85,10 +85,17 @@ using SparseArrays
         ws_gmrf = WorkspaceGMRF(μ_prior, Q_prior)
         ws_result = gaussian_approximation(ws_gmrf, obs_lik)
 
-        # The workspace should hold Q_post's factorization, so var/logdet should work
+        # #162: the final factorization is deferred. The unconstrained path sets
+        # Q_post's *values* but does not eagerly refactorize (the first consumer
+        # would reload + refactorize the snapshot anyway), so right after GA the
+        # numeric factorization is not yet valid...
+        @test !ws_result.workspace.numeric_valid
+
+        # ...and the first consumer builds it on demand from the exact snapshot.
         v = var(ws_result)
         @test all(v .> 0)
         @test length(v) == n
+        @test ws_result.workspace.numeric_valid
 
         ld = logdetcov(ws_result)
         @test isfinite(ld)


### PR DESCRIPTION
Addresses the "related" note in #162 — the redundant final refactorization in the workspace Gaussian approximation — resolved **exactly** (no accuracy trade).

> Stacked on #161 (the JET fix). Base it on `main` once #161 merges; the change itself only touches `src/workspace/gaussian_approximation.jl`.

## The finding

On convergence the loop refreshes `ws.Q` to `Q_post(x_new)` and **eagerly refactorizes** it (line 274). But `_update_hessian!` resets `ws.loaded_version = 0`, so the first consumer of the returned posterior (`var`/`logdet`/`solve`/the AD backward-solve, or the constrained `ConstraintInfo` build) calls `ensure_loaded!(result)`, sees the version mismatch, **reloads the snapshot and refactorizes it anyway**. So the eager factor is built and immediately thrown away.

Measured on a warm Poisson solve: the GA does **3** factorizations, then the first `var(post)` does a **4th** — the eager final factorization was pure waste.

## The fix

Still `_update_hessian!` to set `Q_post(x_new)`'s exact *values*, but **skip the eager `ensure_numeric!`**. The existing lazy mechanism builds the factor on demand, from the exact snapshot — which the consumer was going to do regardless.

This is the same shape as @timweiland's "set the precision but don't factorize it" — and crucially it's **not** the stale-`x_k`-factor skip I'd first reasoned about, so there's no mean/precision inconsistency and no ~1e-4 (the reason the refresh was added in #83 stands).

## Verified

- **Bit-identical**: deferred workspace GA vs the unchanged condition-GA path — mode matches, `var` matches with `maxabs diff = 0.0`.
- **One fewer factorization**: warm Poisson `3 → 2` (with first consumer, `4 → 3`).
- **AD accuracy preserved** (the thing #83 guards): Zygote (6/6), ForwardDiff (6/6), reuse-path (8/8), each vs FiniteDiff.
- Core `Workspace Gaussian Approximation` tests pass; constrained path correct (there the `ConstraintInfo` build triggers the on-demand factorization).
- Added an assertion that the factorization is deferred (and built by the first consumer) to lock the optimization in.

The condition-GA (non-workspace) path uses a private solver cache (no reload), so the redundancy is workspace-specific; left unchanged. The issue's main body — the persistent `CHOLMOD.Sparse` in `refactorize!` — is independent and can stack on top.