### PR TITLE
Avoid full selinv materialization in the Dual logdetcov tangent

### DIFF
--- a/ext/forwarddiff/logdetcov.jl
+++ b/ext/forwarddiff/logdetcov.jl
@@ -12,9 +12,10 @@ end
 
 function logdetcov(x::GMRFs.WorkspaceGMRF{<:ForwardDiff.Dual})
     GMRFs.ensure_loaded!(x)
-    Qinv = GMRFs.selinv(x.workspace)
     primal = GMRFs.logdet_cov(x.workspace)
-    # dot(Qinv, Q_dual) naturally produces a Dual via ForwardDiff overloads
-    tangent = -dot(Qinv, x.precision)
+    # tr(Q⁻¹ Q̇) = dot(selinv(Q), Q_dual). `selinv_dot` contracts straight against
+    # the supernodal selected-inverse blocks and accumulates a Dual, skipping the
+    # full selinv `SparseMatrixCSC` materialization (the dominant cost here).
+    tangent = -GMRFs.selinv_dot(x.workspace, x.precision)
     return ForwardDiff.Dual{ForwardDiff.tagtype(tangent)}(primal, ForwardDiff.partials(tangent)...)
 end

--- a/src/workspace/backend.jl
+++ b/src/workspace/backend.jl
@@ -17,8 +17,16 @@ Each backend must implement:
 - `get_selinv(b)` — return the selected inverse (type is backend-specific)
 - `get_selinv_diag(b)` — return diagonal of Q⁻¹ as Vector
 - `backend_backward_solve(b, x)` — compute L^T \\ x for sampling
+
+Optional fast paths (a generic fallback is provided):
+- `selinv_dot(b, B)` — `dot(selinv, B) = tr(Q⁻¹ B)` without materializing selinv
 """
 abstract type WorkspaceBackend end
+
+# Generic fallback: materialize the selected inverse and dot. Backends that can
+# contract against `B` without building the full `SparseMatrixCSC` (e.g.
+# `CHOLMODBackend`) override this.
+selinv_dot(b::WorkspaceBackend, B::AbstractMatrix) = dot(get_selinv(b), B)
 
 """
     CHOLMODBackend{T} <: WorkspaceBackend
@@ -120,6 +128,16 @@ function get_selinv_diag(b::CHOLMODBackend)
             diag(b.selinv_cache)
     end
     return b.selinv_diag_cache
+end
+
+# `tr(Q⁻¹ B) = dot(selinv(Q), B)` for a `B` whose pattern is a subset of the
+# Cholesky factor's. Dots straight against the supernodal selected-inverse blocks
+# (merge-intersecting with `B`'s columns), skipping the full `SparseMatrixCSC`
+# materialization that `get_selinv` would build — which dominates the cost when
+# only this contraction is needed (the ForwardDiff `logdetcov` tangent). Accepts
+# a `ForwardDiff.Dual`-valued `B` directly, accumulating a Dual result.
+function selinv_dot(b::CHOLMODBackend, B::AbstractMatrix)
+    return dot(SelectedInversion.selinv(b.factor; depermute = true).Z, B)
 end
 
 function backend_backward_solve(b::CHOLMODBackend, x::AbstractVector)

--- a/src/workspace/gmrf_workspace.jl
+++ b/src/workspace/gmrf_workspace.jl
@@ -249,6 +249,20 @@ function selinv_diag(ws::GMRFWorkspace)
 end
 
 """
+    selinv_dot(ws::GMRFWorkspace, B::AbstractMatrix)
+
+Return `dot(selinv(Q), B) = tr(Q⁻¹ B)`, the selected inverse contracted against
+`B` (whose pattern must be a subset of the Cholesky factor's). On the CHOLMOD
+backend this dots straight against the supernodal blocks, skipping the full
+selected-inverse `SparseMatrixCSC` build. `B` may carry `ForwardDiff.Dual`
+values, in which case the result is `Dual` — used by the `logdetcov` tangent.
+"""
+function selinv_dot(ws::GMRFWorkspace, B::AbstractMatrix)
+    ensure_selinv!(ws)
+    return selinv_dot(ws.backend, B)
+end
+
+"""
     backward_solve(ws::GMRFWorkspace, x::AbstractVector) -> Vector
 
 Compute L^T \\ x where Q = L L^T. Used for sampling from the GMRF.

--- a/test/workspace/test_gmrf_workspace.jl
+++ b/test/workspace/test_gmrf_workspace.jl
@@ -1,5 +1,5 @@
 using GaussianMarkovRandomFields
-using GaussianMarkovRandomFields: workspace_solve, backward_solve, selinv, selinv_diag
+using GaussianMarkovRandomFields: workspace_solve, backward_solve, selinv, selinv_diag, selinv_dot
 using LinearAlgebra
 using SparseArrays
 using Random
@@ -53,6 +53,16 @@ end
                 @test vals[idx] ≈ Q_inv[row, col] rtol = 1.0e-6
             end
         end
+    end
+
+    @testset "selinv_dot" begin
+        ws = GMRFWorkspace(Q)
+        # tr(Q⁻¹ Q) = tr(I) = n  (selinv has all of Q's pattern, so the contraction is exact)
+        @test selinv_dot(ws, Q) ≈ n rtol = 1.0e-8
+        # Matches the materialized-selinv dot for an arbitrary matrix on Q's pattern
+        B = copy(Q)
+        B.nzval .= randn(length(B.nzval))
+        @test selinv_dot(ws, B) ≈ dot(selinv(ws), B) rtol = 1.0e-10
     end
 
     @testset "Backward solve" begin


### PR DESCRIPTION
## Motivation
ForwardDiff hyperparameter gradients through the workspace Laplace marginal likelihood (INLA-style mode-finding) are dominated by the two `logpdf` evaluations — far more than the Gaussian-approximation Newton itself. Profiling `benchmark/dual_gradient_bench.jl` (warm regime, n=5041) traced each Dual `logpdf` to ~32–51 ms, of which the **selected-inverse materialization was ~28 ms** while the value it feeds — `dot(selinv, Q̇)` — was 0.48 ms.

The `logdetcov` tangent needs only `tr(Q⁻¹ Q̇) = dot(selinv(Q), Q̇)` over Q's pattern, but the old path built the **entire** selected inverse as a `SparseMatrixCSC` at the factor fill pattern. The `sparse()` build (17.7 ms) cost *more than the Takahashi recursion itself* (9.7 ms), and everything outside Q's pattern was discarded.

## Change
- New `selinv_dot(ws, B)` = `tr(Q⁻¹ B)`. On the CHOLMOD backend it dots straight against the supernodal selected-inverse blocks via SelectedInversion's `dot(::SupernodalMatrix, ::SparseMatrixCSC)` (merge-intersecting with `B`'s columns), accumulating a `Dual` result — **no full materialization**. Generic backends fall back to `dot(get_selinv(b), B)`.
- The Dual `logdetcov(::WorkspaceGMRF)` now calls `selinv_dot` instead of `dot(selinv(ws), x.precision)`.

## Results — `benchmark/dual_gradient_bench.jl`, warm regime (ForwardDiff/primal)

| n | before | after |
|------:|------:|------:|
| 1296 | 5.62x | **2.57x** |
| 2500 | 3.84x | **2.39x** |
| 5041 | 4.57x | **2.70x** |
| 10000 | 5.22x | **2.48x** |

All warm ratios now land in the documented ~2–3x target band; cold improved too (e.g. n=5041 cold 2.03x → 1.69x). The `selinv_dot` micro-benchmark drops 30.3 ms → 11.2 ms per call.

## Correctness
The optimization is exact — `max|Δ|` of the gradient vs FiniteDiff is **identical** to before (3.1e-7 … 2.5e-5 across sizes). `selinv_dot` matches the materialized-selinv dot to 0 (simplicial) / ~1e-13 (supernodal block reordering) for both `Float64` and `Dual` inputs. New unit test (`tr(Q⁻¹Q) = n` + match against `dot(selinv(ws), B)`); workspace suite + ForwardDiff-ext Dual/logdetcov/Laplace/constrained tests green.