### PR TITLE
Drop the prior log-determinant from the workspace GA line search

### DIFF
--- a/src/workspace/gaussian_approximation.jl
+++ b/src/workspace/gaussian_approximation.jl
@@ -164,6 +164,24 @@ function _build_result(ws::GMRFWorkspace, x::Vector, prior_constraints::Constrai
 end
 
 """
+    _line_search_energy(base_prior::WorkspaceGMRF, obs_lik, x)
+
+Backtracking-line-search objective: `neg_log_posterior` with the x-independent
+prior normalizer (`0.5·log|Q_prior| + 0.5·n·log2π`) dropped. The line search only
+compares this at different `x` for the same prior, where that constant cancels
+exactly — so the accept/reject decisions are bit-identical to using the full
+`neg_log_posterior`. Dropping it avoids `logpdf(base_prior, x)` → `logdetcov`,
+which on the shared workspace would reload `Q_prior` and **factorize it** on every
+`gaussian_approximation` call (the workspace is otherwise factorized at `Q_post`
+for the Newton step). The quadratic term uses the precision matrix directly (a
+matvec, no factorization).
+"""
+function _line_search_energy(base_prior::WorkspaceGMRF, obs_lik, x)
+    r = x .- base_prior.mean
+    return 0.5 * dot(r, base_prior.precision * r) - loglik(x, obs_lik)
+end
+
+"""
     gaussian_approximation(prior::WorkspaceGMRF, obs_lik::ObservationLikelihood; kwargs...)
 
 Workspace-aware Gaussian approximation via Fisher scoring.
@@ -218,12 +236,12 @@ function gaussian_approximation(
         step = _workspace_constrain_step(step, ws, constraints)
 
         if adaptive_stepsize
-            obj_current = neg_log_posterior(base_prior, obs_lik, x_k)
+            obj_current = _line_search_energy(base_prior, obs_lik, x_k)
             step_accepted = false
 
             for ls_iter in 1:max_linesearch_iter
                 candidate = x_k - α * step
-                obj_candidate = neg_log_posterior(base_prior, obs_lik, candidate)
+                obj_candidate = _line_search_energy(base_prior, obs_lik, candidate)
 
                 if obj_candidate <= obj_current
                     μ_new = candidate


### PR DESCRIPTION
## Motivation
Continuing the ForwardDiff hyperparameter-gradient optimization (after #165). A factorization-count profile of the workspace Laplace marginal likelihood showed the Gaussian approximation doing **3 factorizations per Dual gradient**, one of which is pure waste:

| step | factorizations |
|--|--|
| GA | `#A` Q_post (Newton step), **`#B` Q_prior (line search)**, `#C` Q_post (IFT solves) |
| logpdf(prior) | 1 |
| logpdf(post) | 1 |

`#B`: the backtracking line search compares `neg_log_posterior` at candidate vs current `x`. That goes through `logpdf(base_prior, x)`, whose `logdetcov` term reloads `Q_prior` into the shared workspace and **factorizes it** — even though `log|Q_prior|` is constant in `x` and **cancels** in the `obj_candidate ≤ obj_current` comparison. (The workspace is otherwise held at `Q_post` for the Newton step, so each line search triggers a reload + full refactorization of `Q_prior`.)

## Change
Replace the line-search objective with `_line_search_energy` = the `x`-dependent part only: `0.5·(x−μ)'Q_prior(x−μ) − loglik(x)` (a matvec against the precision matrix; no factorization, no `logdetcov`). Accept/reject decisions are **bit-identical** — the dropped term is a constant shared by both sides.

This removes **one Q_prior factorization per Newton iteration**, in both the primal pass and the ForwardDiff primal-inside-Dual pass. Warm starts (1 iteration) save one; cold starts (K iterations) save K.

## Results — controlled A/B (single-file swap, same machine, `bel` min-of-N)

| n | regime | gradient before | gradient after | Δ |
|--:|:--|--:|--:|--:|
| 5041 | warm | 48.8 ms | 44.0 ms | −10% |
| 5041 | cold | 85.5 ms | **63.4 ms** | **−26%** |
| 10000 | warm | 110.6 ms | 101.0 ms | −9% |
| 10000 | cold | 188.5 ms | **144.9 ms** | **−23%** |

Primal evals drop even more (e.g. n=5041 cold 53.5 → 35.6 ms), since the line search runs in the primal too — so the AD/primal *ratio* rises slightly even though every absolute time falls.

## Correctness
Exact (logdet cancels in the comparison). The full workspace GA + `test_gmrf_workspace` suites pass (427 tests), and `benchmark/dual_gradient_bench.jl` reports `max|Δ|` vs FiniteDiff **unchanged** to the digit across all sizes.