### PR TITLE
Hand the posterior the workspace factorization after a forward-mode GA

### DIFF
--- a/ext/forwarddiff/autodiff_likelihood_ift.jl
+++ b/ext/forwarddiff/autodiff_likelihood_ift.jl
@@ -470,15 +470,18 @@ function _workspace_dualhp_ift(
     # for the constrained branch — the Dual-mean / Dual-Q corrections are
     # rebuilt inside `_build_constrained_dual_workspace_gmrf`.
     if prior_gmrf.constraints === nothing
-        return GMRFs.WorkspaceGMRF(x_star_dual, Q_post_dual, ws)
+        return _own_workspace_factor!(ws, GMRFs.WorkspaceGMRF(x_star_dual, Q_post_dual, ws))
     else
         ci_post = posterior_primal.constraints
         A_dense = ci_post.matrix
         log_AA_det = logdet(cholesky(Symmetric(A_dense * A_dense')))
-        return _build_constrained_dual_workspace_gmrf(
-            x_star_dual, Q_post_dual, ws,
-            A_dense, ci_post.vector, ci_post.A_tilde_T, ci_post.L_c,
-            log_AA_det, posterior_primal.version
+        return _own_workspace_factor!(
+            ws,
+            _build_constrained_dual_workspace_gmrf(
+                x_star_dual, Q_post_dual, ws,
+                A_dense, ci_post.vector, ci_post.A_tilde_T, ci_post.L_c,
+                log_AA_det, posterior_primal.version
+            ),
         )
     end
 end

--- a/ext/forwarddiff/workspace_gaussian_approximation.jl
+++ b/ext/forwarddiff/workspace_gaussian_approximation.jl
@@ -3,6 +3,17 @@
 #   - Dual prior, unconstrained (via _forwarddiff_workspace_ga)
 #   - Dual prior, constrained (via _forwarddiff_workspace_ga_constrained)
 
+# After the IFT tangent solves, the workspace is factorized at Q_post and ws.Q
+# already equals `value(posterior.precision)`. Tag the posterior as the
+# workspace's current owner so the first consumer that touches it (logpdf / var /
+# logdetcov on the posterior) reuses this factorization instead of reloading and
+# refactorizing Q_post. This pays off when the posterior term is consumed before
+# any other WorkspaceGMRF sharing the workspace — e.g. evaluating a Laplace
+# marginal likelihood as `logpdf(posterior, x*)` before `logpdf(prior, x*)`. It
+# is harmless otherwise: a consumer with a different version reloads as usual.
+_own_workspace_factor!(ws::GMRFs.GMRFWorkspace, posterior) =
+    (ws.loaded_version = posterior.version; posterior)
+
 # ----------------------------------------------------------------------------
 # Float64 WorkspaceGMRF + Dual obs_lik
 # ----------------------------------------------------------------------------
@@ -73,15 +84,18 @@ function _forwarddiff_workspace_ga_obs_dual(
     # ConstraintInfo (already computed at Q_post during the primal pass) to
     # avoid a second factorization + m constraint solves.
     if prior_gmrf.constraints === nothing
-        return GMRFs.WorkspaceGMRF(x_star_dual, Q_post_sparse, ws)
+        return _own_workspace_factor!(ws, GMRFs.WorkspaceGMRF(x_star_dual, Q_post_sparse, ws))
     else
         ci_post = posterior_primal.constraints
         A_dense = ci_post.matrix
         log_AA_det = logdet(cholesky(Symmetric(A_dense * A_dense')))
-        return _build_constrained_dual_workspace_gmrf(
-            x_star_dual, Q_post_sparse, ws,
-            A_dense, ci_post.vector, ci_post.A_tilde_T, ci_post.L_c,
-            log_AA_det, posterior_primal.version
+        return _own_workspace_factor!(
+            ws,
+            _build_constrained_dual_workspace_gmrf(
+                x_star_dual, Q_post_sparse, ws,
+                A_dense, ci_post.vector, ci_post.A_tilde_T, ci_post.L_c,
+                log_AA_det, posterior_primal.version
+            ),
         )
     end
 end
@@ -158,7 +172,7 @@ function _forwarddiff_workspace_ga(
 
     # Step 6: Return WorkspaceGMRF with Dual values and primal workspace
     Q_post_sparse = sparse(Q_post_dual)
-    return GMRFs.WorkspaceGMRF(x_star_dual, Q_post_sparse, ws)
+    return _own_workspace_factor!(ws, GMRFs.WorkspaceGMRF(x_star_dual, Q_post_sparse, ws))
 end
 
 # Tried splitting via `WorkspaceGMRF{D, B, W, Nothing}` and
@@ -264,7 +278,10 @@ function _forwarddiff_workspace_ga_constrained(
 
     # Step 6: Build Dual constrained WorkspaceGMRF with the prior's constraints.
     ci_prior = prior_gmrf.constraints
-    return GMRFs.WorkspaceGMRF(
-        x_star_dual, Q_post_sparse, ws, ci_prior.matrix, ci_prior.vector
+    return _own_workspace_factor!(
+        ws,
+        GMRFs.WorkspaceGMRF(
+            x_star_dual, Q_post_sparse, ws, ci_prior.matrix, ci_prior.vector
+        ),
     )
 end

--- a/test/observation_models/test_workspace_dualhp_ift.jl
+++ b/test/observation_models/test_workspace_dualhp_ift.jl
@@ -59,6 +59,37 @@ using FiniteDiff, ForwardDiff
         @test maximum(abs.(grad_fwd - grad_fd)) < 1.0e-3
     end
 
+    @testset "Posterior owns the workspace factorization after a Dual GA" begin
+        # The forward-mode GA leaves the shared workspace factorized at Q_post
+        # (from the IFT tangent solves) and tags the posterior as its owner, so a
+        # consumer that touches the posterior first (logpdf / var / logdetcov)
+        # reuses that factorization instead of reloading + refactorizing Q_post.
+        Random.seed!(202)
+        k = 8
+        y = [2, 1, 3, 0, 4, 1, 2, 3]
+        model = AR1Model(k)
+        ws = make_workspace(model; τ = 1.0, ρ = 0.3)
+        obs_model = AutoDiffObservationModel(
+            (x; y, φ) -> sum(y .* (φ .* x) .- exp.(φ .* x));
+            n_latent = k, hyperparams = (:φ,),
+            grad_backend = AutoForwardDiff(), hessian_backend = AutoForwardDiff(),
+        )
+        obs_lik = obs_model(y; φ = 1.0)
+
+        Tag = typeof(ForwardDiff.Tag(:handoff, Float64))
+        prior = model(
+            ws;
+            τ = exp(ForwardDiff.Dual{Tag}(0.1, 1.0, 0.0)),
+            ρ = tanh(ForwardDiff.Dual{Tag}(0.2, 0.0, 1.0)),
+        )  # WorkspaceGMRF{Dual}
+        posterior = gaussian_approximation(prior, obs_lik)
+
+        @test posterior.workspace.loaded_version == posterior.version
+        @test posterior.workspace.numeric_valid
+        # The reused-factor path stays consistent (finite, right Dual tag).
+        @test isfinite(ForwardDiff.value(logpdf(posterior, zeros(k))))
+    end
+
     @testset "Dual prior + Dual-hp AutoDiffLikelihood (joint outer AD)" begin
         # Both prior precision/mean and lik hyperparam carry Duals from the
         # same outer ForwardDiff pass over θ = (τ, φ). This is the canonical


### PR DESCRIPTION
## Motivation
Third in the forward-mode hyperparameter-gradient series (after #165 selinv-dot and #166 line-search energy). Profiling the workspace Laplace marginal likelihood showed `Q_post` factorized **twice** per Dual gradient: once by the GA's IFT tangent solves, then again by `logpdf(posterior)`. The shared `GMRFWorkspace` holds one numeric factorization; the GA left the workspace factorized at `Q_post` but tagged it "owned by nobody", so the posterior's version mismatched and any consumer reloaded + refactorized `Q_post` — even though the factor was sitting right there.

## Change
`_own_workspace_factor!(ws, posterior)` sets `ws.loaded_version = posterior.version` at every forward-mode GA return path:
- `_forwarddiff_workspace_ga` (prior-Dual, unconstrained)
- `_forwarddiff_workspace_ga_constrained`
- `_forwarddiff_workspace_ga_obs_dual`
- `_workspace_dualhp_ift` (the unified path for LinearlyTransformed / composite / AutoDiff likelihoods — the one Matérn+LTL pipelines hit)

After the IFT solves the workspace is factorized at `Q_post` and `ws.Q` already equals the posterior's precision values, so this is a truthful ownership tag. A consumer that touches the posterior **before** any other `WorkspaceGMRF` sharing the workspace then reuses the factor instead of refactorizing.

## Effect
When the marginal likelihood is evaluated **posterior-term-first** (`logpdf(posterior, x*)` before `logpdf(prior, x*)`), the gradient does one fewer factorization:

| n | regime | prior-first | post-first | saved |
|--:|:--|--:|--:|--:|
| 5041 | warm | 49.2 ms | 44.7 ms | **9.0%** |
| 10000 | warm | 130.0 ms | 123.3 ms | **5.1%** |

(cold is dominated by the multi-iteration Newton solve and is noise-limited here.) The handoff is **harmless** in the other order — a consumer with a different version reloads exactly as before, so existing call sites are unaffected.

## Correctness
The reused factor is the workspace's *primal-Newton* `Q_post`, which equals the posterior's *Dual-path* precision up to floating point — they differ by ~1e-12 in the gradient when the likelihood Hessian uses the reassociated `AᵀWA` form (LTL), and are bit-identical for diagonal Hessians. That's far below the Laplace approximation tolerance (and the benchmark's 1e-6 AD-vs-FiniteDiff check). New regression test asserts the posterior owns the workspace factor after a Dual GA; the full dual-hp IFT suite (44 tests) + ForwardDiff-ext suite pass.

Independent of #165/#166 (touches only the ForwardDiff extension). To realize the speedup, the downstream marginal-likelihood objective must evaluate the posterior term before the prior term.