### PR TITLE
Test on Julia 1.11 & 1.12 in CI + fix the incompatibilities it surfaced

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.10'
+          - '1.10'   # LTS + declared compat floor
+          - '1.11'
+          - '1'       # latest stable (1.12 today; auto-tracks future releases)
         os:
           - ubuntu-latest
         arch:

--- a/src/arithmetic/condition/gaussian_approximation.jl
+++ b/src/arithmetic/condition/gaussian_approximation.jl
@@ -185,6 +185,11 @@ function gaussian_approximation(
         if adaptive_stepsize
             obj_current = neg_log_posterior(base_gmrf, obs_lik, x_k)
             accept = false
+            # Pre-initialize so `x_new` is provably defined for static analysis: the loop
+            # assigns it only on the accept branch, coupled to the `accept` flag in a way
+            # JET cannot track. Always overwritten below — by the loop on acceptance, or by
+            # the `!accept` fallback (which uses the backtracked α, so this is a dead store).
+            x_new = x_k - α * step
 
             for ls_iter in 1:max_linesearch_iter
                 candidate = x_k - α * step

--- a/src/autodiff/precision_gradient.jl
+++ b/src/autodiff/precision_gradient.jl
@@ -51,6 +51,12 @@ function ChainRulesCore.rrule(::Type{SymTridiagonal}, dv::AbstractVector, ev::Ab
     function pullback(ȳ)
         ȳ = unthunk(ȳ)
 
+        # A zero/absent cotangent (e.g. the constructed matrix is unused) maps to
+        # zero tangents for both fields.
+        if ȳ isa AbstractZero
+            return (NoTangent(), ȳ, ȳ)
+        end
+
         # If we’re given a SymTridiagonal as the cotangent, just read its fields.
         if ȳ isa SymTridiagonal
             dd = ȳ.dv
@@ -63,6 +69,9 @@ function ChainRulesCore.rrule(::Type{SymTridiagonal}, dv::AbstractVector, ev::Ab
             # so the adjoint is the sum of those two entries.
             dd = diag(ȳ)
             de = diag(ȳ, 1) + diag(ȳ, -1)
+        else
+            # Unknown cotangent type: treat as zero rather than reading undefined locals.
+            return (NoTangent(), ZeroTangent(), ZeroTangent())
         end
 
         return (NoTangent(), project_d(dd), project_e(de))

--- a/src/latent_models/besag.jl
+++ b/src/latent_models/besag.jl
@@ -45,13 +45,18 @@ model = BesagModel(W, alg=LDLtFactorization())
 gmrf = model(τ=1.0)
 ```
 """
-struct BesagModel{M <: AbstractMatrix, NF, QT <: AbstractMatrix, PT, Alg, C} <: LatentModel
+struct BesagModel{M <: AbstractMatrix, NF, QT <: AbstractMatrix, Alg, C} <: LatentModel
     adjacency::M
     regularization::Float64
     connected_components::Vector{Vector{Int}}
     normalization_factor::NF
     Q::QT
-    singleton_policy::PT
+    # Declared as the concrete two-member union rather than a dependent type parameter
+    # `PT`: with `PT`, `new` lowers to `convert(typeof(x), x)` over an inferred union and
+    # Julia ≥1.11 union-splits the type-param × value cross-product, manufacturing
+    # type-impossible `convert(Val{:degenerate}, ::Val{:gaussian})` pairs (a JET no-method).
+    # A fixed union field is a plain identity-convert with no cross-product.
+    singleton_policy::Union{Val{:gaussian}, Val{:degenerate}}
     alg::Alg
     additional_constraints::C
 
@@ -103,7 +108,7 @@ struct BesagModel{M <: AbstractMatrix, NF, QT <: AbstractMatrix, PT, Alg, C} <: 
         _enforce_singleton_policy_on_Q!(Q, comps, singleton_policy)
 
         normalization_factor = _compute_normalization(Q, comps, normalize_var, singleton_policy)
-        return new{typeof(adj), typeof(normalization_factor), typeof(Q), typeof(singleton_policy), typeof(alg), typeof(processed_additional)}(adj, regularization, comps, normalization_factor, Q, singleton_policy, alg, processed_additional)
+        return new{typeof(adj), typeof(normalization_factor), typeof(Q), typeof(alg), typeof(processed_additional)}(adj, regularization, comps, normalization_factor, Q, singleton_policy, alg, processed_additional)
     end
 end
 

--- a/src/linear_maps/cholesky_sqrt.jl
+++ b/src/linear_maps/cholesky_sqrt.jl
@@ -9,7 +9,12 @@ function sparse_cho_sqrt(cho::SparseArrays.CHOLMOD.Factor)
     if Bool(s.is_ll)
         return sparse(cho.L)[p⁻¹, :]
     end
-    LD = sparse(cho.LD)
+    # `sparse(::FactorComponent{_,:LD})` is inferred as a non-concrete union
+    # (`Union{SparseMatrixCSC, Symmetric}` — CHOLMOD's `sparse` can't be type-stable across
+    # `stype`), but an :LD component always has `stype == 0`, so it is concretely a
+    # `SparseMatrixCSC`. Assert that so `getLd!` (which has only a `::SparseMatrixCSC`
+    # method) resolves without a union-split (a no-method JET flags on Julia ≥1.11).
+    LD = sparse(cho.LD)::SparseMatrixCSC
     L, d = SparseArrays.CHOLMOD.getLd!(LD)
     return (L .* sqrt.(d)')[p⁻¹, :]
 end

--- a/src/observation_models/linearly_transformed.jl
+++ b/src/observation_models/linearly_transformed.jl
@@ -326,10 +326,17 @@ function loghessian(x_full, ltlik::LinearlyTransformedLikelihood)
     hess_η = loghessian(η, ltlik.base_likelihood)
     A = ltlik.design_matrix
 
-    # Chain rule: A^T * hess_η * A. η = A·x + b is affine in x, so the additive
-    # offset leaves ∂η/∂x = A and the Hessian structure unchanged (it only shifts the
-    # point η at which the base Hessian is evaluated).
-    return Symmetric(A' * hess_η * A)
+    # Chain rule: H = Aᵀ·hess_η·A. η = A·x + b is affine in x, so the additive offset
+    # leaves ∂η/∂x = A and the Hessian structure unchanged (it only shifts the point η at
+    # which the base Hessian is evaluated).
+    #
+    # Parenthesize as Aᵀ·(hess_η·A), NOT (Aᵀ·hess_η)·A. On Julia ≥1.11 the left-associated
+    # `Aᵀ·hess_η` dispatches to `Adjoint{SparseMatrixCSC}·Diagonal`, which materializes a
+    # *fully dense* structural pattern of explicit zeros (a diagonal A blows up to n²
+    # stored entries — O(n²) memory/compute, and the spurious zeros trip the workspace
+    # Newton step's `pattern(H) ⊆ pattern(Q)` check). Evaluating `hess_η·A` first keeps
+    # every factor a genuine sparse product, so H carries only true nonzeros.
+    return Symmetric(A' * (hess_η * A))
 end
 
 """

--- a/src/workspace/gaussian_approximation.jl
+++ b/src/workspace/gaussian_approximation.jl
@@ -238,6 +238,10 @@ function gaussian_approximation(
         if adaptive_stepsize
             obj_current = _line_search_energy(base_prior, obs_lik, x_k)
             step_accepted = false
+            # Pre-initialize so `μ_new` is provably defined for static analysis (the loop
+            # assigns it only on the accept branch); always overwritten below. See the
+            # matching note in the non-workspace `gaussian_approximation`.
+            μ_new = x_k - α * step
 
             for ls_iter in 1:max_linesearch_iter
                 candidate = x_k - α * step

--- a/test/autodiff/test_constructors.jl
+++ b/test/autodiff/test_constructors.jl
@@ -9,6 +9,7 @@ using Enzyme, FiniteDiff, Zygote, ForwardDiff
 using Distributions
 using Test
 using ReTest
+import ChainRulesCore
 
 # Helper to create precision matrix
 function ar_precision(ρ, k)
@@ -215,4 +216,36 @@ if get(ENV, "GMRF_TEST_ENZYME", "false") == "true"
     @testset "Enzyme GMRF constructor autodiff tests (SymTridiagonal)" begin
         @run_symtridiagonal_tests(AutoEnzyme(; function_annotation = Enzyme.Const))
     end
+end
+
+# Regression (PR #171): the SymTridiagonal constructor rrule pullback read undefined
+# `dd`/`de` when handed a zero/absent cotangent — an `AbstractZero` (`ZeroTangent` or
+# `NoTangent`), which routinely flows through AD when the constructed matrix's gradient is
+# structurally zero — because the `if/elseif` branch chain had no fallback → `UndefVarError`
+# (JET surfaced this on Julia ≥1.11).
+@testset "SymTridiagonal rrule pullback handles zero/absent cotangents" begin
+    dv = [2.0, 2.0, 2.0]
+    ev = [-1.0, -1.0]
+    y, pb = ChainRulesCore.rrule(SymTridiagonal, dv, ev)
+    @test y == SymTridiagonal(dv, ev)
+
+    # Dense cotangent → field adjoints (dv from the diagonal, ev from the two off-diagonals).
+    c, gd, ge = pb(Matrix(1.0I, 3, 3))
+    @test c isa ChainRulesCore.NoTangent
+    @test gd == [1.0, 1.0, 1.0]
+    @test ge == [0.0, 0.0]
+
+    # Zero/absent cotangents must return zero tangents rather than throwing.
+    for z in (ChainRulesCore.ZeroTangent(), ChainRulesCore.NoTangent())
+        cz, gdz, gez = pb(z)
+        @test cz isa ChainRulesCore.NoTangent
+        @test gdz isa ChainRulesCore.AbstractZero
+        @test gez isa ChainRulesCore.AbstractZero
+    end
+
+    # An unrecognized cotangent falls back to zero instead of reading undefined locals.
+    cs, gds, ges = pb(2.0)
+    @test cs isa ChainRulesCore.NoTangent
+    @test gds isa ChainRulesCore.AbstractZero
+    @test ges isa ChainRulesCore.AbstractZero
 end


### PR DESCRIPTION
CI previously ran **Julia 1.10 only**. Running the suite locally on 1.11 and 1.12 surfaced two genuine bugs and three static-analysis smells; this PR fixes them and expands the CI matrix so they stay caught.

## Bugs fixed

- **`loghessian(::LinearlyTransformedLikelihood)` densified the Hessian on Julia ≥1.11.** The chain rule `Aᵀ·hess_η·A` left-associates to `(Aᵀ·hess_η)·A`, and on ≥1.11 `Adjoint{SparseMatrixCSC}·Diagonal` returns a *fully dense* structural pattern of stored zeros — a diagonal `A` blows up to `n²` entries (O(n²) memory/compute), and the spurious zeros trip the workspace Newton step's `pattern(H) ⊆ pattern(Q)` check (an `ArgumentError`). Fixed by evaluating `Aᵀ·(hess_η·A)`, which keeps every factor a genuine sparse product.
- **`SymTridiagonal` rrule pullback errored on a zero cotangent.** `dd`/`de` were assigned only inside an `if/elseif/elseif` with no `else`; an `AbstractZero` cotangent (`ZeroTangent`/`NoTangent`, which routinely flows through AD when a constructed matrix's gradient is structurally zero) matched no branch → `UndefVarError`. This was latent on **all** versions; JET only flagged it on ≥1.11. Fixed with an `AbstractZero` short-circuit + a zero `else`-fallback.

## Static-analysis smells cleaned

- `gaussian_approximation` (both paths): pre-initialize `x_new`/`μ_new` (always overwritten) so they're provably defined.
- `cholesky_sqrt`: `sparse(cho.LD)::SparseMatrixCSC` so `getLd!` resolves without a union-split (the `stype==0` invariant always holds for an `:LD` component).
- `BesagModel`: store `singleton_policy` as a concrete `Union{Val{:gaussian},Val{:degenerate}}` field instead of a dependent type parameter, avoiding a spurious `convert` union-split.

## CI

Matrix expanded from `1.10` to `['1.10', '1.11', '1']` — LTS (+ declared compat floor) + 1.11 + latest stable (`'1'` auto-tracks future releases). `fail-fast` already false.

Full suite verified green locally on **1.10, 1.11, and 1.12**.