### PR TITLE
Release 0.12.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GaussianMarkovRandomFields"
 uuid = "d5f06795-35bb-4323-9f0b-405ef76cfc5b"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Tim Weiland <hello@timwei.land> and contributors"]
 
 [deps]


### PR DESCRIPTION
Patch release (0.12.0 → 0.12.1) — bug fixes only, no API changes.

From #171 (multi-version testing on Julia 1.10/1.11/1.12):
- **`loghessian(::LinearlyTransformedLikelihood)`** no longer densifies the observation Hessian on Julia ≥1.11 (`Aᵀ·Diagonal·A` re-associated to `Aᵀ·(Diagonal·A)`), which also fixes a spurious workspace Newton-step pattern error.
- **`SymTridiagonal` constructor rrule** no longer throws `UndefVarError` on a zero/absent (`AbstractZero`) cotangent.

CI also now runs on Julia 1.10, 1.11, and the latest stable.

Merge to trigger registration of 0.12.1.