### PR TITLE
AutoDiffLatentPrior: support a GMRFWorkspace on the IFT θ-gradient path (closes #174)

### DIFF
--- a/ext/forwarddiff/autodiff_latent_prior_ift.jl
+++ b/ext/forwarddiff/autodiff_latent_prior_ift.jl
@@ -23,13 +23,6 @@
 function GMRFs._nongaussian_dualhp_ift(
         prior::GMRFs.AutoDiffLatentPrior, obs_lik, θ_full::NamedTuple, ws; kwargs...
     )
-    ws === nothing || throw(
-        ArgumentError(
-            "θ-gradients for AutoDiffLatentPrior with a GMRFWorkspace are not supported " *
-                "yet; omit `ws` for the hyperparameter-gradient pass."
-        )
-    )
-
     Tag, N = _outer_tag_and_npartials(θ_full)
     V = Float64
     DualT = ForwardDiff.Dual{Tag, V, N}
@@ -38,7 +31,13 @@ function GMRFs._nongaussian_dualhp_ift(
     # Step 1: primal Newton on stripped θ + stripped obs_lik.
     θ_primal = GMRFs._strip_ad_partials_hyperparams(θ_full)
     primal_obs = _primal_obs_lik(obs_lik)
-    posterior_primal = GMRFs.gaussian_approximation(prior, primal_obs; θ = θ_primal, kwargs...)
+    # Forward the workspace (#174): the primal Newton then reuses ws's symbolic factorization
+    # (one symbolic factor across the whole θ-grid), and its converged Q_post factor backs the
+    # IFT solves below. With ws === nothing this is the original fresh-cache path. Returns a
+    # WorkspaceGMRF when ws is supplied, a (Constrained)GMRF otherwise.
+    posterior_primal = GMRFs.gaussian_approximation(
+        prior, primal_obs; θ = θ_primal, ws = ws, kwargs...
+    )
     x_star = GMRFs.mean(posterior_primal)
     n = length(x_star)
 
@@ -55,18 +54,37 @@ function GMRFs._nongaussian_dualhp_ift(
     g_lik = GMRFs.loggrad(x_star, obs_lik)   # Float64 for a primal obs_lik; Dual if it carries θ
     neg_grad_dual = (-g_prior_dual) .- g_lik
 
-    # Step 3: IFT solves, reusing the primal posterior factorization.
-    cache = GMRFs.linsolve_cache(GMRFs._base_gmrf(posterior_primal))
-    b_saved = copy(cache.b)
+    # Step 3: IFT solves Q_post · dx[:, j] = -∂(neg_score)/∂θ_j, reusing the primal
+    # factorization. `alg` (for the Dual posterior in Step 6) comes from that same factor source.
     dx = Matrix{V}(undef, n, N)
-    for j in 1:N
-        for i in 1:n
-            cache.b[i] = -ForwardDiff.partials(neg_grad_dual[i], j)
+    alg = if ws === nothing
+        cache = GMRFs.linsolve_cache(GMRFs._base_gmrf(posterior_primal))
+        b_saved = copy(cache.b)
+        for j in 1:N
+            for i in 1:n
+                cache.b[i] = -ForwardDiff.partials(neg_grad_dual[i], j)
+            end
+            step = copy(solve!(cache).u)
+            dx[:, j] .= GMRFs._constrain_step(step, cache, constraints_nt)
         end
-        step = copy(solve!(cache).u)
-        dx[:, j] .= GMRFs._constrain_step(step, cache, constraints_nt)
+        cache.b .= b_saved
+        cache.alg
+    else
+        # Reuse the workspace's Q_post factorization. The primal build leaves it
+        # unfactorized (by design — #167), so the first `workspace_solve` refactorizes once
+        # and the remaining N-1 partials (plus the constraint Schur solves) reuse that factor.
+        rhs = Vector{V}(undef, n)
+        for j in 1:N
+            for i in 1:n
+                rhs[i] = -ForwardDiff.partials(neg_grad_dual[i], j)
+            end
+            step = GMRFs.workspace_solve(ws, rhs)
+            dx[:, j] .= GMRFs._workspace_constrain_step(step, ws, constraints_nt)
+        end
+        # The workspace's CHOLMOD factor is Float64-only, so build the Dual posterior with the
+        # default solver — which is what the no-ws path's `alg` resolves to anyway.
+        nothing
     end
-    cache.b .= b_saved
 
     # Step 4: Dual x* carrying dx*/dθ.
     x_star_dual = [
@@ -85,8 +103,7 @@ function GMRFs._nongaussian_dualhp_ift(
     H_lik_dual = GMRFs.loghessian(x_star_dual, obs_lik)
     Q_post_dual = (-H_prior_dual) - H_lik_dual
 
-    # Step 6: result.
-    alg = GMRFs.linsolve_cache(GMRFs._base_gmrf(posterior_primal)).alg
+    # Step 6: result. `alg` was taken from the primal factor source in Step 3.
     base = GMRF(x_star_dual, Q_post_dual, alg)
     return constraints_nt === nothing ? base :
         GMRFs.ConstrainedGMRF(base, constraints_nt.A, constraints_nt.e)

--- a/test/latent_models/test_autodiff_latent_prior.jl
+++ b/test/latent_models/test_autodiff_latent_prior.jl
@@ -238,4 +238,47 @@ _qd_logp_kw(x; τ, a) = _qd_logp(x, τ, a)
         end
         @test J_ad ≈ J_fd rtol = 1.0e-4
     end
+
+    @testset "θ-gradients via IFT reuse a GMRFWorkspace and match the no-ws path (#174)" begin
+        # The IFT hyperparameter-gradient path accepts a seeded workspace: the primal Newton
+        # reuses ws's symbolic factorisation and its converged Q_post factor backs the IFT
+        # solves, so one workspace serves the whole θ-grid instead of re-running the symbolic
+        # analysis every gradient evaluation. The result must match the fresh-cache no-ws path.
+        Random.seed!(11)
+        n = 4; σ = 0.5
+        y = [0.4, 0.7, 1.0, 1.1]
+        prior = AutoDiffLatentPrior(_qd_logp_kw; n = n, hyperparams = (:τ, :a))
+        obs_lik = ExponentialFamily(Normal)(y; σ = σ)
+        ws = make_workspace(prior; τ = 2.0, a = 0.5)
+
+        ml_ws(θ) = marginal_loglikelihood(
+            prior, obs_lik,
+            gaussian_approximation(prior, obs_lik; τ = θ[1], a = θ[2], ws = ws);
+            τ = θ[1], a = θ[2],
+        )
+        ml_nows(θ) = marginal_loglikelihood(
+            prior, obs_lik,
+            gaussian_approximation(prior, obs_lik; τ = θ[1], a = θ[2]);
+            τ = θ[1], a = θ[2],
+        )
+
+        θ0 = [2.0, 0.5]
+        g_ws = ForwardDiff.gradient(ml_ws, θ0)      # previously threw: ws unsupported on the IFT path
+        @test g_ws ≈ ForwardDiff.gradient(ml_nows, θ0) rtol = 1.0e-6
+
+        # ...and still matches central differences of the (workspace) marginal likelihood.
+        h = 1.0e-6
+        g_fd = similar(θ0)
+        for i in 1:2
+            θp = copy(θ0); θp[i] += h
+            θm = copy(θ0); θm[i] -= h
+            g_fd[i] = (ml_ws(θp) - ml_ws(θm)) / (2h)
+        end
+        @test g_ws ≈ g_fd rtol = 1.0e-4
+
+        # One seeded workspace is reusable across the θ-grid: a gradient at a second θ also
+        # matches no-ws (sequential reuse is valid — the structural pattern is θ-independent).
+        θ1 = [3.0, 0.3]
+        @test ForwardDiff.gradient(ml_ws, θ1) ≈ ForwardDiff.gradient(ml_nows, θ1) rtol = 1.0e-6
+    end
 end


### PR DESCRIPTION
Closes #174.

`gaussian_approximation(prior::NonGaussianLatentPrior, obs_lik; θ, ws)` previously **threw** when `θ` carried `ForwardDiff.Dual` partials *and* a `ws::GMRFWorkspace` was supplied — so a workspace and exact θ-gradients were mutually exclusive. Differentiating the Laplace marginal likelihood forced the no-`ws` branch, which `deepcopy`s a fresh `linsolve_cache` and **recomputes the symbolic factorization on every gradient evaluation** (the dominant cost, and exactly what the workspace exists to avoid).

## Fix

`_nongaussian_dualhp_ift` now accepts the workspace (`ext/forwarddiff/autodiff_latent_prior_ift.jl`):

1. The primal Newton runs **with** `ws` (forwarded into the primal `gaussian_approximation`), returning a `WorkspaceGMRF` that reuses one symbolic factor.
2. The IFT linear solves come from that workspace factor (`workspace_solve` + `_workspace_constrain_step`) instead of a fresh `linsolve_cache`. The workspace's `Q_post` is refactorized once on the first solve and reused across all θ-partials.

The Dual result stays a plain `GMRF{Dual}` (the workspace is only for the primal solve + factor reuse). The no-`ws` path is unchanged.

**Why it's sound:** the structural sparsity pattern is θ-independent — the property the workspace already relies on to reuse one symbolic factor across Newton iterates — so reusing a single workspace across the θ-grid is valid. The primal Newton refreshes the numeric factor at each θ before the IFT solves run there.

## Tests

- New testset in `test_autodiff_latent_prior.jl`: θ-gradient via IFT **with a seeded `ws`** matches (a) the no-`ws` path (consistency — bit-identical locally), and (b) central differences; plus a grid-reuse check (one `ws`, two θ values).

Verified green on the full 1.10 suite locally; CI runs 1.10/1.11/1.12.