### PR TITLE
Make BarrierModel precision sparsity pattern range-invariant

### DIFF
--- a/ext/GaussianMarkovRandomFieldsFEM.jl
+++ b/ext/GaussianMarkovRandomFieldsFEM.jl
@@ -15,7 +15,7 @@ using GaussianMarkovRandomFields:
     precision_map, to_matrix, make_chunks,
     SymmetricBlockTridiagonalMap, SSMBidiagonalMap, ZeroMap,
     temporal_block_gauss_seidel,
-    _process_constraint
+    _process_constraint, _ones_pattern
 
 import GaussianMarkovRandomFields:
     ndim, evaluation_matrix, node_selection_matrix,

--- a/ext/GaussianMarkovRandomFieldsFEM/barrier_model.jl
+++ b/ext/GaussianMarkovRandomFieldsFEM/barrier_model.jl
@@ -29,6 +29,8 @@ whose ids are in `barrier_cells`). Returns a `NamedTuple`:
 - `G_regions = (G_normal, G_barrier)`: stiffness `∫_{Ω_k} ∇φ_i·∇φ_j` per region
   (`G_normal + G_barrier =` full stiffness).
 - `c_regions = (c_normal, c_barrier)`: lumped mass `∫_{Ω_k} φ_i` per region.
+- `Q_pattern = (; colptr, rowval)`: the range-invariant structural sparsity
+  pattern of the precision `Aᵀ C̃⁻¹ A`; every assembly is padded to it.
 """
 function assemble_barrier_fem(disc::FEMDiscretization{D}, barrier_cells) where {D}
     D == 2 || throw(ArgumentError("BarrierModel currently supports 2D discretizations only"))
@@ -71,19 +73,71 @@ function assemble_barrier_fem(disc::FEMDiscretization{D}, barrier_cells) where {
     c_normal = Vector{Tv}(vec(sum(M_normal, dims = 2)))
     c_barrier = Vector{Tv}(vec(sum(M_barrier, dims = 2)))
     C = c_normal .+ c_barrier
-    return (; C = C, G_regions = (G_normal, G_barrier), c_regions = (c_normal, c_barrier))
+
+    # Range-invariant structural pattern of Aᵀ C̃⁻¹ A, where A carries the union
+    # pattern diag ∪ G_normal ∪ G_barrier at every range. All-ones values keep
+    # every structurally reachable entry of the product strictly positive, so
+    # sparse arithmetic cannot drop any of them as numerical zeros; the numeric
+    # product's stored pattern at any range is a subset of this pattern.
+    S = spdiagm(0 => ones(Tv, length(C))) + _ones_pattern(G_normal) + _ones_pattern(G_barrier)
+    P = S' * S
+    Q_pattern = (colptr = P.colptr, rowval = P.rowval)
+
+    return (;
+        C = C, G_regions = (G_normal, G_barrier),
+        c_regions = (c_normal, c_barrier), Q_pattern = Q_pattern,
+    )
 end
 
-# Factorization-free barrier precision (unscaled by τ). Supports ForwardDiff.Dual
-# `range` since it never factorizes.
-function _barrier_precision_only(fem, range, range_fraction)
-    (; C, G_regions, c_regions) = fem
+# Factorization-free barrier precision (scaled by τ). Supports ForwardDiff.Dual
+# τ/range since it never factorizes.
+#
+# The product's fill entries between second-order mesh neighbors can cancel to
+# zero, and whether a given entry evaluates to exact 0.0 or to roundoff depends
+# on the range. Sparse scalar `*` drops exact-zero stored entries, so scaling a
+# raw sparse result makes the stored pattern range-dependent, which breaks
+# fixed-pattern workspaces (issue #183). Instead, the result is scattered into
+# the precomputed structural pattern with the τ·2/π scaling folded into the
+# scatter, so the stored pattern is identical for every θ.
+function _barrier_precision_only(fem, τ, range, range_fraction)
+    (; C, G_regions, c_regions, Q_pattern) = fem
     r1 = range
     r2 = range_fraction * range
     Cdiag = r1^2 .* c_regions[1] .+ r2^2 .* c_regions[2]
     Cinv = spdiagm(0 => inv.(Cdiag))
     A = spdiagm(0 => C) + (r1^2 / 8) * G_regions[1] + (r2^2 / 8) * G_regions[2]
-    return Symmetric((2 / π) * (A' * Cinv * A))
+    return Symmetric(_pad_scaled_to_pattern(A' * Cinv * A, τ * (2 / π), Q_pattern))
+end
+
+"""
+    _pad_scaled_to_pattern(Q::SparseMatrixCSC, scale, pattern) -> SparseMatrixCSC
+
+Materialize `scale * Q` on the fixed sparsity `pattern` (a `(; colptr, rowval)`
+NamedTuple), keeping explicit zeros at pattern positions that `Q` does not
+store. All stored entries of `Q` must lie inside `pattern`.
+"""
+function _pad_scaled_to_pattern(Q::SparseMatrixCSC, scale, pattern)
+    nzval = zeros(typeof(zero(eltype(Q)) * scale), length(pattern.rowval))
+    rows = rowvals(Q)
+    vals = nonzeros(Q)
+    for col in 1:size(Q, 2)
+        ptr = pattern.colptr[col]
+        stop = pattern.colptr[col + 1] - 1
+        for k in nzrange(Q, col)
+            row = rows[k]
+            while ptr <= stop && pattern.rowval[ptr] < row
+                ptr += 1
+            end
+            (ptr <= stop && pattern.rowval[ptr] == row) || throw(
+                ArgumentError(
+                    "Q has an entry at ($row, $col) outside the structural pattern."
+                )
+            )
+            nzval[ptr] = scale * vals[k]
+            ptr += 1
+        end
+    end
+    return SparseMatrixCSC(Q.m, Q.n, copy(pattern.colptr), copy(pattern.rowval), nzval)
 end
 
 """
@@ -138,8 +192,7 @@ end
 
 function precision_matrix(model::BarrierModel; τ::Real, range::Real, kwargs...)
     _validate_barrier_parameters(; τ = τ, range = range)
-    Q_unscaled = _barrier_precision_only(model.fem_matrices, range, model.range_fraction)
-    return τ * Q_unscaled
+    return _barrier_precision_only(model.fem_matrices, τ, range, model.range_fraction)
 end
 
 mean(model::BarrierModel; kwargs...) = zeros(length(model))

--- a/src/fem/types.jl
+++ b/src/fem/types.jl
@@ -231,7 +231,9 @@ across them — useful for e.g. coastlines/islands blocking a marine field.
 
 The precision keeps the same sparsity and cost as the stationary model and is
 assembled per region. With no barrier triangles it reduces exactly to
-`MaternModel(disc; smoothness = 0)` (the stationary ν = 1 Matérn).
+`MaternModel(disc; smoothness = 0)` (the stationary ν = 1 Matérn). Its sparsity
+pattern is padded to a precomputed structural pattern, so it is identical for
+all hyperparameter values — as required by fixed-pattern workspaces.
 
 Validated user-facing constructors live in the `GaussianMarkovRandomFieldsFEM`
 extension. The range-independent per-region FEM matrices are assembled once at

--- a/src/workspace/latent_model_integration.jl
+++ b/src/workspace/latent_model_integration.jl
@@ -122,9 +122,11 @@ function GMRFWorkspace(model::LatentModel, obs_lik::ObservationLikelihood; kwarg
     H = loghessian(x_dummy, obs_lik)
     H_sparse = _ensure_sparse_hessian(H, n)
 
-    # Joint pattern: Q_prior + |H| (using absolute values to get the union pattern)
-    # Then copy Q_prior's actual values into the joint pattern
-    Q_joint_pattern = Q_prior + _abs_pattern(H_sparse)
+    # Joint pattern: structural union of Q_prior and H, built from all-ones
+    # copies so that sparse `+` (which drops exact-zero results, including
+    # stored zeros of the operands) cannot lose any position of either pattern.
+    # Then copy Q_prior's actual values into the joint pattern.
+    Q_joint_pattern = _ones_pattern(Q_prior) + _ones_pattern(H_sparse)
     # Reset values to Q_prior (the observation entries become zero)
     _copy_values_into!(Q_joint_pattern, Q_prior)
 
@@ -177,9 +179,10 @@ _ensure_sparse_hessian(H::Diagonal, n::Int) = sparse(H)
 _ensure_sparse_hessian(H::SparseMatrixCSC, ::Int) = H
 _ensure_sparse_hessian(H::AbstractMatrix, ::Int) = sparse(H)
 
-"""Create a sparse matrix with absolute values of nonzeros (for pattern union)."""
-function _abs_pattern(H::SparseMatrixCSC{T}) where {T}
-    return SparseMatrixCSC(H.m, H.n, H.colptr, H.rowval, abs.(H.nzval))
+"""Create a sparse matrix with `A`'s stored pattern and all-ones values.
+Used for cancellation-free pattern unions and structural pattern products."""
+function _ones_pattern(A::SparseMatrixCSC)
+    return SparseMatrixCSC(A.m, A.n, A.colptr, A.rowval, ones(length(A.rowval)))
 end
 
 """

--- a/test/spdes/fem/test_barrier_model.jl
+++ b/test/spdes/fem/test_barrier_model.jl
@@ -47,9 +47,11 @@ using ForwardDiff
         Q = sparse(precision_matrix(bm; τ = 1.0, range = 0.5))
         Qm = sparse(precision_matrix(mm; τ = 1.0, range = 0.5))
         @test cholesky(Symmetric(Q)) isa SparseArrays.CHOLMOD.Factor
-        # Barrier keeps the stationary Matérn sparsity/cost (same pattern up to
-        # Adjoint/Symmetric bookkeeping) and is far from dense.
-        @test abs(nnz(Q) - nnz(Qm)) < 0.01 * nnz(Qm)
+        # Barrier keeps the stationary Matérn sparsity/cost and is far from
+        # dense. Its stored pattern is the full structural pattern of
+        # Aᵀ C̃⁻¹ A (padded for range-invariance, #183), which sits a few
+        # percent above Matérn's value-pruned nnz.
+        @test abs(nnz(Q) - nnz(Qm)) < 0.1 * nnz(Qm)
         @test nnz(Q) < 0.05 * length(Q)
         x = bm(τ = 1.0, range = 0.5)
         @test x isa GaussianMarkovRandomFields.AbstractGMRF
@@ -88,6 +90,29 @@ using ForwardDiff
         @test a_b < 0.2 * w_b          # barrier: across strongly suppressed vs within
         @test a_s > 0.5 * w_s          # stationary: across ≈ within (same distance)
         @test a_b < 0.2 * a_s          # barrier suppresses across vs stationary
+    end
+
+    @testset "sparsity pattern is range-invariant (#183)" begin
+        bcells = barrier_triangles(disc, strip)
+        bm = BarrierModel(disc; barrier_cells = bcells, range_fraction = 0.1)
+        # Fill entries of Aᵀ C̃⁻¹ A whose true value is zero evaluate to exact
+        # 0.0 for some ranges (then dropped by sparse scalar `*`) and to
+        # roundoff for others (then kept), so the stored pattern used to be
+        # range-dependent — on this mesh e.g. ranges 0.2 and 0.3 differed by
+        # 6 stored entries. The precision is now padded to the precomputed
+        # structural pattern, which must make all patterns identical.
+        ranges = [0.05, 0.1, 0.2, 0.3, 0.5, 0.8, 1.3, 2.0]
+        Qs = [sparse(precision_matrix(bm; τ = τ, range = r)) for τ in (0.3, 1.0) for r in ranges]
+        @test all(Q.colptr == Qs[1].colptr for Q in Qs)
+        @test all(Q.rowval == Qs[1].rowval for Q in Qs)
+
+        # The crash path from #183: a workspace fixes its pattern at θ_ref and
+        # must accept the precision produced at every other θ.
+        ws = make_workspace(bm; τ = 1.0, range = 0.3)
+        for r in ranges
+            x = bm(ws; τ = 1.0, range = r)
+            @test x isa GaussianMarkovRandomFields.AbstractGMRF
+        end
     end
 
     @testset "argument validation" begin


### PR DESCRIPTION
Stacked on #186, which unblocks CI (Ferrite 1.5 broke an unrelated `evaluation_matrix` test on every PR).

Fixes #183.

## Root cause

`AᵀC̃⁻¹A` stores every structural fill entry, including ones whose true value is zero — sparse matmul does not value-prune. The pruning happens afterwards: **sparse scalar `*` drops stored entries that are exactly `0.0`** (as does sparse `+`), on every Julia version 1.10–1.12. Whether a given fill entry cancels to exact `0.0` or leaves roundoff (`~1e-32`) depends on the range, so `τ * (2/π) * (AᵀC̃⁻¹A)` had a range-dependent stored pattern, and a workspace whose pattern was fixed at θ_ref rejected `Q`s from other θ.

## Fix

- `assemble_barrier_fem` now precomputes the structural pattern of `AᵀC̃⁻¹A` once, via the same product with all-ones values — every structurally reachable entry stays strictly positive, so nothing can be dropped, and the numeric product's stored pattern at any θ is a subset of it.
- Each precision assembly is scattered into that fixed pattern as the final step, with the `τ·2/π` scaling folded into the scatter (so no sparse scalar `*` runs afterwards). Every θ — Float64 or Dual — now produces the identical stored pattern.
- The joint prior + observation-Hessian workspace pattern (`GMRFWorkspace(model, obs_lik)`) is now built from all-ones copies of both patterns instead of `Q_prior + |H|`, so the union can't lose the padded stored zeros either.

## Verification

On structured meshes (625 and 1681 dofs) the old pipeline's nnz demonstrably varied across ranges (e.g. 10311 ↔ 10317); the new one is pattern-invariant across a τ × range sweep, with values matching the old pipeline to ~2e-16. A workspace built at one θ now accepts the whole sweep with factorizations forced. The no-barrier reduction to the stationary Matérn (~4e-16) and ForwardDiff through `range`/`τ` are unchanged. Assembly is not slower (pad replaces two allocating scalar multiplies; 0.71 ms vs 0.82 ms at 4225 dofs).

The stored pattern is now the full structural pattern, ~5% more entries than the value-pruned nnz — the pattern-vs-Matérn test tolerance is updated accordingly. Includes a regression test that fails on the old code (pattern equality across a range sweep + the workspace crash path).

## Note

The same probe shows `MaternModel`'s stored pattern also varies with range (10315 ↔ 10317 on the same mesh) — same bug class, just never triggered yet. Left out of scope here since its fix has to thread through the α-recursion and constraint handling; happy to follow up separately.

