### PR TITLE
Make MaternModel precision sparsity pattern range-invariant

### DIFF
--- a/ext/GaussianMarkovRandomFieldsFEM/barrier_model.jl
+++ b/ext/GaussianMarkovRandomFieldsFEM/barrier_model.jl
@@ -110,37 +110,6 @@ function _barrier_precision_only(fem, τ, range, range_fraction)
 end
 
 """
-    _pad_scaled_to_pattern(Q::SparseMatrixCSC, scale, pattern) -> SparseMatrixCSC
-
-Materialize `scale * Q` on the fixed sparsity `pattern` (a `(; colptr, rowval)`
-NamedTuple), keeping explicit zeros at pattern positions that `Q` does not
-store. All stored entries of `Q` must lie inside `pattern`.
-"""
-function _pad_scaled_to_pattern(Q::SparseMatrixCSC, scale, pattern)
-    nzval = zeros(typeof(zero(eltype(Q)) * scale), length(pattern.rowval))
-    rows = rowvals(Q)
-    vals = nonzeros(Q)
-    for col in 1:size(Q, 2)
-        ptr = pattern.colptr[col]
-        stop = pattern.colptr[col + 1] - 1
-        for k in nzrange(Q, col)
-            row = rows[k]
-            while ptr <= stop && pattern.rowval[ptr] < row
-                ptr += 1
-            end
-            (ptr <= stop && pattern.rowval[ptr] == row) || throw(
-                ArgumentError(
-                    "Q has an entry at ($row, $col) outside the structural pattern."
-                )
-            )
-            nzval[ptr] = scale * vals[k]
-            ptr += 1
-        end
-    end
-    return SparseMatrixCSC(Q.m, Q.n, copy(pattern.colptr), copy(pattern.rowval), nzval)
-end
-
-"""
     BarrierModel(disc::FEMDiscretization; barrier_cells = Int[], range_fraction = 0.1,
                  alg = CHOLMODFactorization(), constraint = nothing,
                  observation_points = nothing)

--- a/ext/GaussianMarkovRandomFieldsFEM/fem_utils.jl
+++ b/ext/GaussianMarkovRandomFieldsFEM/fem_utils.jl
@@ -277,3 +277,40 @@ function apply_soft_constraints!(
     end
     return
 end
+
+"""
+    _pad_scaled_to_pattern(Q::SparseMatrixCSC, scale, pattern) -> SparseMatrixCSC
+
+Materialize `scale * Q` on the fixed sparsity `pattern` (a `(; colptr, rowval)`
+NamedTuple), keeping explicit zeros at pattern positions that `Q` does not
+store. All stored entries of `Q` must lie inside `pattern`.
+
+Used to make model precision matrices sparsity-pattern-invariant across
+hyperparameters (issue #183): product fill entries whose true value is zero
+evaluate to exact 0.0 for some hyperparameters and to roundoff for others, and
+sparse scalar `*` drops the exact zeros. Folding the scaling into this scatter
+avoids that, so fixed-pattern workspaces can reuse one symbolic factorization.
+"""
+function _pad_scaled_to_pattern(Q::SparseMatrixCSC, scale, pattern)
+    nzval = zeros(typeof(zero(eltype(Q)) * scale), length(pattern.rowval))
+    rows = rowvals(Q)
+    vals = nonzeros(Q)
+    for col in 1:size(Q, 2)
+        ptr = pattern.colptr[col]
+        stop = pattern.colptr[col + 1] - 1
+        for k in nzrange(Q, col)
+            row = rows[k]
+            while ptr <= stop && pattern.rowval[ptr] < row
+                ptr += 1
+            end
+            (ptr <= stop && pattern.rowval[ptr] == row) || throw(
+                ArgumentError(
+                    "Q has an entry at ($row, $col) outside the structural pattern."
+                )
+            )
+            nzval[ptr] = scale * vals[k]
+            ptr += 1
+        end
+    end
+    return SparseMatrixCSC(Q.m, Q.n, copy(pattern.colptr), copy(pattern.rowval), nzval)
+end

--- a/ext/GaussianMarkovRandomFieldsFEM/matern_model.jl
+++ b/ext/GaussianMarkovRandomFieldsFEM/matern_model.jl
@@ -19,7 +19,14 @@ function MaternModel(discretization::F; smoothness::S, alg = CHOLMODFactorizatio
     processed_constraint = _process_constraint(constraint, n)
     # Assemble the κ-independent FEM matrices once; reused on every precision_matrix call.
     C, G = assemble_matern_C_G(discretization)
-    fem_matrices = (; C, G)
+    # Precompute the κ-invariant structural precision pattern (#183); every
+    # precision_matrix call is padded to it.
+    D = ndim(discretization)
+    α_val = Integer(smoothness_to_ν(smoothness, D) + D // 2)
+    Q_pattern = _matern_structural_pattern(
+        G, discretization.constraint_handler, discretization.constraint_noise, α_val
+    )
+    fem_matrices = (; C, G, Q_pattern)
     return MaternModel{F, S, typeof(alg), typeof(processed_constraint), typeof(observation_points), typeof(fem_matrices)}(discretization, smoothness, alg, processed_constraint, observation_points, fem_matrices)
 end
 
@@ -102,9 +109,13 @@ function precision_matrix(model::MaternModel{F, S}; τ::Real, range::Real, kwarg
     D = ndim(model.discretization)
     ν = smoothness_to_ν(model.smoothness, D)
     κ = range_to_κ(range, ν)
-    (; C, G) = model.fem_matrices
+    (; C, G, Q_pattern) = model.fem_matrices
     Q_unscaled = matern_precision_only(model.discretization, model.smoothness, κ, C, G)
-    return τ * Q_unscaled
+    # Scatter τ·Q into the fixed structural pattern instead of `τ * Q_unscaled`:
+    # sparse scalar `*` drops fill entries that cancel to exact 0.0 at the
+    # current range but not at others, which made the stored pattern
+    # range-dependent and broke fixed-pattern workspaces (#183).
+    return Symmetric(_pad_scaled_to_pattern(parent(Q_unscaled), τ, Q_pattern))
 end
 
 function mean(model::MaternModel; kwargs...)

--- a/ext/GaussianMarkovRandomFieldsFEM/matern_spde.jl
+++ b/ext/GaussianMarkovRandomFieldsFEM/matern_spde.jl
@@ -231,6 +231,40 @@ function _matern_precision_only(
 end
 
 """
+    _matern_structural_pattern(G::SparseMatrixCSC, ch, constraint_noise, α::Integer)
+
+κ-invariant structural sparsity pattern of the precision produced by
+[`_matern_precision_only`](@ref), as a `(; colptr, rowval)` NamedTuple.
+
+Runs the α-recursion's product chain once with all-ones matrices: every
+structurally reachable entry stays strictly positive, so sparse arithmetic
+cannot drop any of them, and the numeric precision's stored pattern at any κ
+is a subset of this pattern (issue #183). `K = κ²C + G` carries the pattern
+`diag ∪ G` at every κ (`C` is lumped/diagonal); constraint handling can insert
+entries for affine constraints, so it is mirrored on the ones matrix and
+unioned with the unconstrained pattern (the inner recursion multiplies
+unconstrained `K`s).
+"""
+function _matern_structural_pattern(G::SparseMatrixCSC, ch, constraint_noise, α::Integer)
+    n = size(G, 1)
+    S = spdiagm(0 => ones(n)) + _ones_pattern(G)
+    if ch !== nothing && !isempty(ch.prescribed_dofs)
+        S_con = copy(S)
+        apply_soft_constraints!(ch, constraint_noise; K = S_con)
+        S = _ones_pattern(S) + _ones_pattern(S_con)
+    end
+    P = _pattern_product_recursion(S, α)
+    return (colptr = P.colptr, rowval = P.rowval)
+end
+
+# Pattern of the α-recursion products: α=1 → K, α=2 → Kᵀ·diag·K, α≥3 → Kᵀ·P_{α-2}·K.
+function _pattern_product_recursion(S::SparseMatrixCSC, α::Integer)
+    α == 1 && return S
+    α == 2 && return S' * S
+    return S' * _pattern_product_recursion(S, α - 2) * S
+end
+
+"""
     assemble_matern_C_G(disc::FEMDiscretization{D}) where {D}
 
 Assemble the κ-independent FEM matrices for a Matérn discretization: the lumped

--- a/test/latent_models/test_matern.jl
+++ b/test/latent_models/test_matern.jl
@@ -1,5 +1,6 @@
 using GaussianMarkovRandomFields
 using LinearAlgebra
+using SparseArrays
 using Ferrite
 
 @testset "MaternModel" begin
@@ -326,6 +327,52 @@ using Ferrite
                 Q_fresh = τ * GaussianMarkovRandomFields.matern_precision_only(disc, smoothness, κ)
                 @test Matrix(Q_cached) == Matrix(Q_fresh)  # bit-identical
             end
+        end
+    end
+
+    @testset "sparsity pattern is range-invariant (#183)" begin
+        # Same phantom-fill mechanism as BarrierModel (#183): fill entries of
+        # the precision products whose true value is zero evaluate to exact
+        # 0.0 for some ranges (then dropped by sparse scalar `*`) and to
+        # roundoff for others (then kept). On this mesh the stored nnz used to
+        # flip between 10315 and 10317 across the ranges below. The precision
+        # is now padded to a precomputed structural pattern.
+        grid = generate_grid(Triangle, (24, 24))
+        disc = FEMDiscretization(grid, Lagrange{RefTriangle, 1}(), QuadratureRule{RefTriangle}(2))
+        ranges = [0.05, 0.1, 0.2, 0.3, 0.5, 0.8, 1.3, 2.0]
+        for smoothness in [0, 1]
+            model = MaternModel(disc; smoothness = smoothness)
+            Qs = [sparse(precision_matrix(model; τ = τ, range = r)) for τ in (0.3, 1.0) for r in ranges]
+            @test all(Q.colptr == Qs[1].colptr for Q in Qs)
+            @test all(Q.rowval == Qs[1].rowval for Q in Qs)
+
+            # The crash path: a workspace fixes its pattern at θ_ref and must
+            # accept the precision produced at every other θ.
+            ws = make_workspace(model; τ = 1.0, range = 0.3)
+            for r in ranges
+                x = model(ws; τ = 1.0, range = r)
+                @test x isa GaussianMarkovRandomFields.AbstractGMRF
+            end
+        end
+
+        # Constrained discretizations stay pattern-invariant too, including
+        # the affine-constraint path (which inserts entries into K).
+        grid_1d = generate_grid(Line, (20,))
+        ip_1d = Lagrange{RefLine, 1}()
+        qr_1d = QuadratureRule{RefLine}(2)
+        disc_dbc = FEMDiscretization(
+            grid_1d, ip_1d, qr_1d, ((:u, nothing),),
+            ((_get_dirichlet_constraint(grid_1d, 0.0, 0.0), 1.0e-4),),
+        )
+        disc_per = FEMDiscretization(
+            grid_1d, ip_1d, qr_1d, ((:u, nothing),),
+            ((_get_periodic_constraint(grid_1d), 1.0e-4),),
+        )
+        for (disc_c, smoothness) in [(disc_dbc, 0), (disc_dbc, 1), (disc_per, 1)]
+            model = MaternModel(disc_c; smoothness = smoothness)
+            Qs = [sparse(precision_matrix(model; τ = 1.0, range = r)) for r in ranges]
+            @test all(Q.colptr == Qs[1].colptr for Q in Qs)
+            @test all(Q.rowval == Qs[1].rowval for Q in Qs)
         end
     end
 

--- a/test/spdes/fem/test_barrier_model.jl
+++ b/test/spdes/fem/test_barrier_model.jl
@@ -47,11 +47,10 @@ using ForwardDiff
         Q = sparse(precision_matrix(bm; τ = 1.0, range = 0.5))
         Qm = sparse(precision_matrix(mm; τ = 1.0, range = 0.5))
         @test cholesky(Symmetric(Q)) isa SparseArrays.CHOLMOD.Factor
-        # Barrier keeps the stationary Matérn sparsity/cost and is far from
-        # dense. Its stored pattern is the full structural pattern of
-        # Aᵀ C̃⁻¹ A (padded for range-invariance, #183), which sits a few
-        # percent above Matérn's value-pruned nnz.
-        @test abs(nnz(Q) - nnz(Qm)) < 0.1 * nnz(Qm)
+        # Barrier and stationary Matérn are both padded to the structural
+        # pattern of the same product (#183), so their stored patterns — and
+        # hence sparsity/cost — coincide exactly. Far from dense.
+        @test nnz(Q) == nnz(Qm)
         @test nnz(Q) < 0.05 * length(Q)
         x = bm(τ = 1.0, range = 0.5)
         @test x isa GaussianMarkovRandomFields.AbstractGMRF


### PR DESCRIPTION
Stacked on #184; applies the same fix to `MaternModel`.

## Problem

`MaternModel` has the same bug class as #183: fill entries of the precision products whose true value is zero evaluate to exact `0.0` for some ranges (then dropped by the `τ` scalar multiply) and to roundoff for others (then kept). Probing a structured 24×24 mesh shows the stored nnz flipping across ranges for every smoothness level (α = 2: 10315 ↔ 10317, α = 3: 19427 ↔ 19435, α = 4: 30997 ↔ 31001), so a fixed-pattern workspace built at θ_ref can reject the precision from another θ — it just hadn't been triggered in the wild yet.

## Fix

- `MaternModel` construction precomputes the κ-invariant structural pattern of the α-recursion's product chain (`_matern_structural_pattern`), running it once with all-ones matrices so nothing can cancel. Constraint handling is mirrored on the ones matrix, since affine constraints insert entries into `K`, and unioned with the unconstrained pattern (the inner recursion multiplies unconstrained `K`s).
- `precision_matrix(::MaternModel)` scatters the result into that fixed pattern as the final step with the `τ` scaling folded in, instead of `τ * Q_unscaled`. `matern_precision_only` and the `discretize(::MaternSPDE)` path are unchanged.
- `_pad_scaled_to_pattern` moved from `barrier_model.jl` to `fem_utils.jl` since both models now use it.

## Verification

On the 24×24 mesh, the new pipeline is pattern-invariant across a τ × range sweep for smoothness 0/1/2, with values **bit-identical** to the old pipeline (the pad applies the same `τ * v` per entry, so the existing bit-identity regression test for #145 still passes). Workspaces built at one θ accept the whole sweep with factorizations forced. Constrained discretizations (1D Dirichlet at α = 1 and 2, and 1D periodic exercising the affine-insertion path) are pattern-invariant and bit-identical too. ForwardDiff through `range` matches finite differences at every smoothness. Per-eval cost is unchanged (0.86 → 0.87 ms at α = 2, 2.21 → 2.42 ms at α = 3 on 4225 dofs); construction gains a one-time symbolic product comparable to one precision evaluation.

Since barrier and stationary Matérn now pad to the structural pattern of the same product, their stored patterns coincide exactly — the barrier test's nnz comparison is tightened to equality. New regression tests cover pattern equality across range sweeps (which fail on the old code) plus the workspace crash path, for both unconstrained and constrained discretizations.
