### PR TITLE
Fix evaluation_matrix P1 weight positivity under Ferrite 1.5

### DIFF
--- a/ext/GaussianMarkovRandomFieldsFEM/fem_discretization.jl
+++ b/ext/GaussianMarkovRandomFieldsFEM/fem_discretization.jl
@@ -146,6 +146,15 @@ function evaluation_matrix(f::FEMDiscretization, X::AbstractVector; field = :def
             Ferrite.reference_shape_value(f.interpolation, peh.local_coords[i], j) for
                 j in 1:getnbasefunctions(f.interpolation)
         ]
+        # Point location tolerates local coordinates slightly outside the
+        # reference cell (Ferrite ≥ 1.5 returns such coordinates for points
+        # exactly on cell boundaries), which puts affine shape values a
+        # roundoff outside [0, 1]. Clamp first-order Lagrange weights, for
+        # which [0, 1] is a true invariant; higher-order shape functions take
+        # legitimate values outside [0, 1] inside the cell and pass through.
+        if f.interpolation isa Lagrange{<:Any, 1}
+            vals = clamp.(vals, 0.0, 1.0)
+        end
         append!(Vs, vals)
     end
     return sparse(Is, Js, Vs, length(X), ndofs(f))

--- a/test/spdes/fem/test_fem_discretization.jl
+++ b/test/spdes/fem/test_fem_discretization.jl
@@ -30,6 +30,23 @@ using GaussianMarkovRandomFields, Ferrite, SparseArrays
     @test_throws ArgumentError evaluation_matrix(f, X_oob)
     @test_throws ArgumentError evaluation_matrix(f, [0.5 0.45; 5.0 5.0])
 
+    # Points exactly on cell boundaries: point location may return local
+    # coordinates a roundoff outside the reference cell (does so on
+    # Ferrite ≥ 1.5), and the affine weights must still land in [0, 1].
+    # This mesh has grid lines at multiples of 0.1.
+    X_edge = [Vec(0.5, 0.45), Vec(0.5, 0.5), Vec(-1.0, -1.0), Vec(0.3, 0.3)]
+    A_edge = evaluation_matrix(f, X_edge)
+    @test all(A_edge .>= 0)
+    @test all(A_edge .<= 1)
+    @test sum(A_edge, dims = 2) ≈ ones(length(X_edge))
+
+    # Quadratic shape functions legitimately take negative values inside a
+    # cell; the [0, 1] snap must not apply to them.
+    f2 = FEMDiscretization(grid, Lagrange{RefTriangle, 2}(), QuadratureRule{RefTriangle}(4))
+    A2 = evaluation_matrix(f2, [Vec(0.53, 0.415)])  # strictly inside a cell
+    @test minimum(A2) < -0.01
+    @test sum(A2, dims = 2) ≈ [1.0]
+
 
     node_idcs = [6, 13]
     B = node_selection_matrix(f, node_idcs)


### PR DESCRIPTION
Unblocks CI, which is red on every PR since the ecosystem moved to Ferrite 1.5.0 (main last ran green in June on 1.4.x).

## Problem

`test_fem_discretization.jl` asserts P1 evaluation weights lie in `[0, 1]`. Ferrite 1.5's rewritten point finder (Newton with line search) accepts local coordinates up to `√(residual_tolerance) = 1e-5` *outside* the reference cell, and for query points lying exactly on a cell boundary it now returns coordinates a roundoff outside it. Concretely, on the test's 20×20 grid the on-edge point `(0.5, 0.45)` yields a shape value of `-6.7e-16`, failing `all(A .>= 0)` on Julia 1.10/1.11/1 alike.

## Fix

`evaluation_matrix` clamps the shape values to `[0, 1]` for first-order Lagrange interpolations, where that is a true invariant of the exact weights — equivalent to projecting the located point back onto the cell it was assigned to, with error bounded by the location tolerance. Higher-order shape functions legitimately take values outside `[0, 1]` inside a cell, so they pass through untouched; a new test pins that down (quadratic weights at an interior point stay negative), alongside regression tests for points exactly on edges and vertices.
