### PR TITLE
Document support channels, governance, and how to cite

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,43 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+title: GaussianMarkovRandomFields.jl
+abstract: >-
+  A Julia package for flexible and efficient Bayesian inference with Gaussian
+  Markov random fields, including SPDE-based approximations to Gaussian process
+  priors, composable latent and observation models, and sparse automatic
+  differentiation.
+type: software
+authors:
+  - given-names: Tim
+    family-names: Weiland
+    email: hello@timwei.land
+    affiliation: University of Tübingen
+    orcid: "https://orcid.org/0009-0003-7636-5970"
+repository-code: "https://github.com/timweiland/GaussianMarkovRandomFields.jl"
+url: "https://timweiland.github.io/GaussianMarkovRandomFields.jl/stable"
+license: MIT
+doi: 10.5281/zenodo.18088214
+keywords:
+  - Julia
+  - Gaussian Markov random fields
+  - Bayesian inference
+  - spatial statistics
+  - sparse linear algebra
+  - stochastic partial differential equations
+# Once the JOSS paper is published, uncomment the block below (filling in the
+# DOI, volume, issue, pages and year) so that `preferred-citation` points at the
+# paper while the DOI above continues to archive the software itself.
+#
+# preferred-citation:
+#   type: article
+#   title: "GaussianMarkovRandomFields.jl: Flexible Latent Gaussian Modeling with Sparse Precision in Julia"
+#   authors:
+#     - given-names: Tim
+#       family-names: Weiland
+#       orcid: "https://orcid.org/0009-0003-7636-5970"
+#   journal: Journal of Open Source Software
+#   doi: TODO
+#   volume: TODO
+#   issue: TODO
+#   start: TODO
+#   year: TODO

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,26 @@ Thank you for your interest in contributing to **GaussianMarkovRandomFields.jl**
 We appreciate your help in improving and maintaining this package.
 The following guidelines will help you get started.
 
+If you are looking for help rather than looking to contribute, see
+[Getting Help](#getting-help) below.
+
+## Getting Help
+
+**Please use the [issue tracker](https://github.com/timweiland/GaussianMarkovRandomFields.jl/issues)
+for all questions and support requests.** We prefer this over private email so
+that answers remain searchable and benefit other users.
+
+- **Usage questions** ("how do I model X?", "which solver should I pick?"):
+  open an issue and label it `question`. Please include a short description of
+  what you are trying to model.
+- **Bug reports**: see [Reporting Issues](#reporting-issues) below.
+- **Feature requests**: open an issue describing your use case before writing
+  code, so we can discuss the design.
+
+Before opening an issue, it is worth skimming the
+[documentation](https://timweiland.github.io/GaussianMarkovRandomFields.jl/stable),
+which includes tutorials and a full API reference, and searching existing issues.
+
 ## Getting Started
 
 1. **Fork and Clone** the repository:
@@ -71,6 +91,32 @@ If you find a bug or have a feature request, please [open an issue](https://gith
 - Provide a **minimal reproducible example**.
 - Include Julia and GaussianMarkovRandomFields.jl version information.
 - Describe expected vs. actual behavior.
+
+## Support and Governance
+
+GaussianMarkovRandomFields.jl is maintained by
+[Tim Weiland](https://github.com/timweiland), with contributions from the
+community. All development happens in the open on GitHub.
+
+What you can expect:
+
+- Issues and pull requests are triaged on a best-effort basis. The package is
+  developed alongside other research commitments, so please allow a couple of
+  weeks for a response — and do feel free to bump a thread that has gone quiet.
+- Bug reports that affect correctness take priority over feature requests.
+- Breaking changes are signalled by the version number, following the Julia
+  ecosystem's semantic versioning conventions, and described in the
+  [release notes](https://github.com/timweiland/GaussianMarkovRandomFields.jl/releases).
+
+The maintainer has final say over the scope and design of the package. For
+anything substantial, please open an issue first so we can agree on an approach
+before you invest time in an implementation.
+
+## Citing
+
+If you use GaussianMarkovRandomFields.jl in your research, please cite it. See
+[Citing](./README.md#citing) in the README, or use the *Cite this repository*
+button on GitHub, which reads [`CITATION.cff`](./CITATION.cff).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 [![Coverage](https://codecov.io/gh/timweiland/GaussianMarkovRandomFields.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/timweiland/GaussianMarkovRandomFields.jl)
 [![Aqua](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 [![code style: runic](https://img.shields.io/badge/code_style-%E1%9A%B1%E1%9A%A2%E1%9A%BE%E1%9B%81%E1%9A%B2-black)](https://github.com/fredrikekre/Runic.jl)
-[![DOI](https://zenodo.org/badge/827801443.svg)](https://doi.org/10.5281/zenodo.18088215)
+[![DOI](https://zenodo.org/badge/827801443.svg)](https://doi.org/10.5281/zenodo.18088214)
 
 </div>
 
@@ -40,6 +40,8 @@ priors.
 
 - [Installation](#installation)
 - [Your first GMRF](#your-first-gmrf)
+- [Getting help](#getting-help)
+- [Citing](#citing)
 - [Contributing](#contributing)
 
 ## Installation
@@ -81,6 +83,40 @@ x_cond = gaussian_approximation(x, obs_likelihood)  # Posterior GMRF!
 ```
 
 Make sure to check the documentation for further examples!
+
+## Getting help
+
+Questions, bug reports and feature requests all belong in the
+[issue tracker](https://github.com/timweiland/GaussianMarkovRandomFields.jl/issues).
+Please open an issue rather than emailing the maintainer, so that answers stay
+searchable for everyone.
+
+See [Getting Help](./CONTRIBUTING.md#getting-help) for what to include, and
+[Support and Governance](./CONTRIBUTING.md#support-and-governance) for what to
+expect regarding response times and project scope.
+
+## Citing
+
+If you use GaussianMarkovRandomFields.jl in your research, please cite it via
+its Zenodo archive. The DOI below always resolves to the latest release; the
+Zenodo page additionally lets you cite a specific version and offers BibTeX and
+other export formats.
+
+> Tim Weiland. *GaussianMarkovRandomFields.jl*. Zenodo. <https://doi.org/10.5281/zenodo.18088214>
+
+```bibtex
+@software{weiland_gmrf_jl,
+  author    = {Weiland, Tim},
+  title     = {{GaussianMarkovRandomFields.jl}},
+  publisher = {Zenodo},
+  year      = {2025},
+  doi       = {10.5281/zenodo.18088214},
+  url       = {https://doi.org/10.5281/zenodo.18088214}
+}
+```
+
+GitHub's *Cite this repository* button exposes the same metadata, which lives in
+[`CITATION.cff`](./CITATION.cff).
 
 ## Contributing
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -49,3 +49,32 @@ using Pkg
 Pkg.add("GaussianMarkovRandomFields")
 using GaussianMarkovRandomFields
 ```
+
+## Getting Help
+
+Questions, bug reports and feature requests all belong in the
+[issue tracker](https://github.com/timweiland/GaussianMarkovRandomFields.jl/issues).
+Please open an issue rather than emailing the maintainer, so that answers stay
+searchable for everyone.
+
+The [contribution guidelines](https://github.com/timweiland/GaussianMarkovRandomFields.jl/blob/main/CONTRIBUTING.md)
+describe what to include in an issue, how to contribute code, and what to expect
+regarding response times and project scope.
+
+## Citing
+
+If you use GaussianMarkovRandomFields.jl in your research, please cite it via its
+[Zenodo archive](https://doi.org/10.5281/zenodo.18088214). That DOI always
+resolves to the latest release, and the Zenodo page offers BibTeX and other
+export formats as well as per-version DOIs.
+
+```bibtex
+@software{weiland_gmrf_jl,
+  author    = {Weiland, Tim},
+  title     = {{GaussianMarkovRandomFields.jl}},
+  publisher = {Zenodo},
+  year      = {2025},
+  doi       = {10.5281/zenodo.18088214},
+  url       = {https://doi.org/10.5281/zenodo.18088214}
+}
+```


### PR DESCRIPTION
First of the JOSS review PRs. Covers the community-guidelines and citation gaps, which are the parts of the review that touch JOSS's required checklist items rather than being suggestions.

## Motivation

JOSS requires community guidelines covering three things: how to contribute, how to report issues, and **how to seek support**. `CONTRIBUTING.md` covered the first two but never told users where to go for help, and stated no support or governance expectations. Separately, there was no machine-readable citation metadata and no statement anywhere of what to cite.

## Changes

- **`CONTRIBUTING.md`**: new `Getting Help` section pointing at the issue tracker as the preferred support channel, and a `Support and Governance` section covering triage expectations, prioritisation, how breaking changes are signalled, and who decides on scope.
- **`CITATION.cff`** (new): machine-readable citation metadata, which drives GitHub's *Cite this repository* button. Validates as CFF 1.2.0.
- **`README.md`**: `Getting help` and `Citing` sections, plus contents entries.
- **`docs/src/index.md`**: the same two sections. The docs site previously had no link to `CONTRIBUTING.md` at all.

## Drive-by fix

The DOI badge linked to `10.5281/zenodo.18088215`, which is the *version* DOI for v0.9.1 — it would have kept pointing at v0.9.1 forever. It now points at the concept DOI `10.5281/zenodo.18088214`, which always resolves to the latest release.

## Notes

- The `Support and Governance` section says to allow "a couple of weeks" for a response. That is a real commitment, so it is worth a second look before merge.
- `CITATION.cff` deliberately omits `version` / `date-released`, since those go stale on every tag and the concept DOI already covers all versions. Cost: GitHub's citation widget will not show a version number.
- A commented-out `preferred-citation` block sits at the bottom of `CITATION.cff`, ready to be filled in once the JOSS paper has a DOI. At that point the paper becomes the preferred citation and the Zenodo DOI remains as the software archive.

## Review items addressed

- #151, Documentation bullet 1 (support / governance expectations)
- Closes #93

Refs openjournals/joss-reviews#10509