### PR TITLE
Propagate ForwardDiff partials through marginal variances

### DIFF
--- a/ext/GaussianMarkovRandomFieldsForwardDiff.jl
+++ b/ext/GaussianMarkovRandomFieldsForwardDiff.jl
@@ -6,9 +6,10 @@ module GaussianMarkovRandomFieldsForwardDiff
 
 import GaussianMarkovRandomFields as GMRFs
 import GaussianMarkovRandomFields: GMRF, ADJacobianMap
-import Distributions: logdetcov
+import Distributions: logdetcov, var
 import DifferentiationInterface as DI
 
+using CliqueTrees.Multifrontal: ChordalCholesky, selinv as mselinv
 using ForwardDiff
 using LinearAlgebra
 using LinearMaps
@@ -29,6 +30,7 @@ include("forwarddiff/workspace_constructors.jl")
 include("forwarddiff/constrained_workspace.jl")
 include("forwarddiff/workspace_gaussian_approximation.jl")
 include("forwarddiff/logdetcov.jl")
+include("forwarddiff/var.jl")
 include("forwarddiff/autodiff_likelihood_dual.jl")
 include("forwarddiff/autodiff_likelihood_ift.jl")
 include("forwarddiff/autodiff_latent_prior_ift.jl")

--- a/ext/forwarddiff/constrained_gmrf.jl
+++ b/ext/forwarddiff/constrained_gmrf.jl
@@ -3,19 +3,25 @@
 # `log_constraint_correction` is captured correctly) and dispatch hooks
 # for Dual-prior and Float64-prior + Dual-obs cases.
 
-# Override for Dual `base_gmrf`: ConstrainedGMRF's inner constructor stores
-# `A_tilde_T` and `L_c` as Float64, so the default `_constraint_info` drops
-# Q-path partials through `log_constraint_correction`. Here we rebuild
-# `A_tilde_T` as a Dual matrix via implicit differentiation
-# (Q * Ã^T = A'  ⇒  Q_v * Ã^T_p = -Q_p * Ã^T_v per partial direction),
-# then form a Dual `L_c` by dense Cholesky of A * A_tilde_T_dual. The
-# resulting constrained_mean and log_constraint_correction carry correct
-# μ- and Q-path partials.
-function GMRFs._constraint_info(
+"""
+    _dual_constraint_factors(base_gmrf, A_dense, A_tilde_T_v)
+        -> (A_tilde_T_dual, L_c_dual)
+
+Rebuild `Ã^T = Q⁻¹Aᵀ` and `L_c = chol(A Ã^T)` as Dual-valued quantities.
+
+`ConstrainedGMRF` stores both as `Float64` — they fall out of the primal
+factorization — so every consumer that reads the stored fields directly loses
+the Q-path partials. Implicit differentiation of `Q Ã^T = Aᵀ` recovers them:
+
+    Q_v * Ã^T_p = -Q_p * Ã^T_v    (one primal solve per constraint row and
+                                   partial direction)
+
+Shared by `_constraint_info` (for `log_constraint_correction`) and `var`.
+"""
+function _dual_constraint_factors(
         base_gmrf::GMRFs.GMRF{D},
-        A_dense::AbstractMatrix, e_vec::AbstractVector,
+        A_dense::AbstractMatrix,
         A_tilde_T_v::Matrix{Float64},
-        L_c_v::LinearAlgebra.Cholesky{Float64, Matrix{Float64}}
     ) where {D <: ForwardDiff.Dual}
     Tag = ForwardDiff.tagtype(D)
     V = ForwardDiff.valtype(D)
@@ -52,8 +58,20 @@ function GMRFs._constraint_info(
     end
 
     # Dual L_c via dense m×m Cholesky.
-    AAtt_dual = A_dense * A_tilde_T_dual
-    L_c_dual = cholesky(Symmetric(AAtt_dual))
+    L_c_dual = cholesky(Symmetric(A_dense * A_tilde_T_dual))
+
+    return A_tilde_T_dual, L_c_dual
+end
+
+function GMRFs._constraint_info(
+        base_gmrf::GMRFs.GMRF{D},
+        A_dense::AbstractMatrix, e_vec::AbstractVector,
+        A_tilde_T_v::Matrix{Float64},
+        L_c_v::LinearAlgebra.Cholesky{Float64, Matrix{Float64}}
+    ) where {D <: ForwardDiff.Dual}
+    m = size(A_dense, 1)
+    A_tilde_T_dual, L_c_dual =
+        _dual_constraint_factors(base_gmrf, A_dense, A_tilde_T_v)
 
     μ_base = GMRFs.mean(base_gmrf)
     residual = A_dense * μ_base - e_vec

--- a/ext/forwarddiff/var.jl
+++ b/ext/forwarddiff/var.jl
@@ -1,0 +1,99 @@
+# Dual-valued `var` for `GMRF`, `WorkspaceGMRF` and `ConstrainedGMRF`.
+#
+# These types deliberately hold a *primal* factorization — CHOLMOD and friends
+# cannot store Duals — so the Float64 path's `selinv_diag` hands back plain
+# `Float64`s and every partial is dropped. Without the methods below `var`
+# reports a zero gradient rather than failing.
+#
+# `logdetcov` works around the primal cache with an IFT correction (see
+# `logdetcov.jl`), but `var` has no such shortcut: `d(diag(Q⁻¹)) = -diag(Q⁻¹ Q̇ Q⁻¹)`
+# reaches entries of `Q⁻¹` outside the selected-inverse pattern. Redoing the
+# selected inversion in Dual arithmetic *is* cheap, though — the Takahashi
+# recursion is closed over the fill-in pattern, so its tangent stays in-pattern
+# too. `ChordalCholesky` is generic Julia and propagates partials exactly, which
+# is why `ChordalGMRF` never had this bug; these methods route `GMRF` through the
+# same machinery. The cost is a fresh Dual factorization per call, since the
+# cached primal one cannot be reused.
+
+function var(d::GMRF{<:ForwardDiff.Dual})
+    return _dual_var_impl(d, GMRFs.supports_selinv(d.linsolve_cache.alg))
+end
+
+function _dual_var_impl(d::GMRF{<:ForwardDiff.Dual}, ::Val{true})
+    return _dual_selinv_diag(GMRFs.precision_matrix(d))
+end
+
+# The Float64 fallback for solvers without selected inversion is `RBMCStrategy`,
+# a Monte Carlo estimator whose solves go through the primal cache. Its partials
+# would be dropped exactly like the ones this file exists to fix, so refuse
+# rather than hand back another silent zero.
+function _dual_var_impl(d::GMRF{<:ForwardDiff.Dual}, ::Val{false})
+    throw(
+        ArgumentError(
+            "Cannot differentiate `var(::GMRF)` with algorithm $(typeof(d.linsolve_cache.alg)): " *
+                "it does not support selected inversion, so `var` falls back to the stochastic " *
+                "`RBMCStrategy` estimator, which cannot propagate ForwardDiff partials. " *
+                "Construct the GMRF with a selected-inversion-capable solver — e.g. " *
+                "`GMRF(mean, precision, LinearSolve.CHOLMODFactorization())` — to differentiate `var`."
+        )
+    )
+end
+
+# `WorkspaceGMRF` keeps the same split — Dual `precision` field, primal workspace —
+# so `selinv_diag(d.workspace)` drops partials exactly like the `GMRF` case.
+function var(d::GMRFs.WorkspaceGMRF{<:ForwardDiff.Dual})
+    if d.constraints !== nothing
+        throw(
+            ArgumentError(
+                "Cannot differentiate `var` through a constrained `WorkspaceGMRF`: the " *
+                    "stored `ConstraintInfo` is built from the primal factorization, so the " *
+                    "constraint correction would contribute no partials."
+            )
+        )
+    end
+    return _dual_selinv_diag(d.precision)
+end
+
+# `var(::ConstrainedGMRF)` subtracts a correction built from the *stored* `L_c`
+# and `A_tilde_T`, both Float64. Differentiating only the base term would give a
+# gradient that looks reasonable but is simply the unconstrained one, so rebuild
+# the constraint factors as Duals first.
+function var(d::GMRFs.ConstrainedGMRF{<:ForwardDiff.Dual})
+    return _dual_constrained_var(d, d.base_gmrf)
+end
+
+function _dual_constrained_var(
+        d::GMRFs.ConstrainedGMRF, base_gmrf::GMRF{<:ForwardDiff.Dual}
+    )
+    σ_base = var(base_gmrf)
+    A_tilde_T_dual, L_c_dual =
+        _dual_constraint_factors(base_gmrf, d.constraint_matrix, d.A_tilde_T)
+
+    # σ_c = σ - diag(Ã^T (AÃ^T)⁻¹ Ã) = σ - colsums((L_c.L \ Ã^Tᵀ).^2)
+    B_T = L_c_dual.L \ A_tilde_T_dual'
+    σ = σ_base .- vec(sum(abs2, B_T, dims = 1))
+    # Match the Float64 path, which clamps away tiny negative round-off.
+    return max.(σ, zero(eltype(σ)))
+end
+
+function _dual_constrained_var(d::GMRFs.ConstrainedGMRF, base_gmrf)
+    throw(
+        ArgumentError(
+            "Cannot differentiate `var(::ConstrainedGMRF)` with a base GMRF of type " *
+                "$(typeof(base_gmrf)): rebuilding the constraint factors under Dual " *
+                "arithmetic is only implemented for a `GMRF` base."
+        )
+    )
+end
+
+# Diagonal precision inverts elementwise; no factorization needed.
+_dual_selinv_diag(Q::Diagonal) = inv.(Q.diag)
+
+function _dual_selinv_diag(Q::AbstractMatrix)
+    H = Hermitian(SparseArrays.sparse(Q), :L)
+    Σ = mselinv(H, cholesky!(ChordalCholesky(H)))
+    # `diag` of a sparse matrix is a `SparseVector`; the Float64 path returns a
+    # dense `Vector`, and `ForwardDiff.jacobian` cannot extract partials from a
+    # sparse result. Marginal variances are dense anyway.
+    return Vector(diag(Σ))
+end

--- a/src/chordal_gmrf.jl
+++ b/src/chordal_gmrf.jl
@@ -35,14 +35,31 @@ struct ChordalGMRF{T <: Real, Hrm <: Hermitian, Fac <: ChordalCholesky, Mea <: A
     F::Fac
 end
 
+# `AbstractGMRF{T, L}` requires `L <: AbstractMatrix{T}`, so the mean and the
+# precision must share an element type. Promoting here is what lets a Float64
+# mean be combined with a Dual precision (the shape ForwardDiff produces when
+# only hyperparameters carry partials); without it the struct's type bound
+# rejects the pair outright.
+function _chordal_promote(μ::AbstractVector, Q::SparseMatrixCSC)
+    T = promote_type(eltype(μ), eltype(Q))
+    μ_T = eltype(μ) === T ? μ : convert(AbstractVector{T}, μ)
+    # Rebuild rather than `convert` so the stored sparsity pattern is preserved
+    # exactly, including any structural zeros.
+    Q_T = eltype(Q) === T ? Q :
+        SparseMatrixCSC(Q.m, Q.n, Q.colptr, Q.rowval, convert(Vector{T}, Q.nzval))
+    return μ_T, Q_T
+end
+
 function ChordalGMRF(μ::AbstractVector, Q::SparseMatrixCSC, F::ChordalCholesky)
-    return ChordalGMRF(μ, Hermitian(Q, :L), F)
+    μ_T, Q_T = _chordal_promote(μ, Q)
+    return ChordalGMRF(μ_T, Hermitian(Q_T, :L), F)
 end
 
 function ChordalGMRF(μ::AbstractVector, Q::SparseMatrixCSC; kw...)
-    H = Hermitian(Q, :L)
+    μ_T, Q_T = _chordal_promote(μ, Q)
+    H = Hermitian(Q_T, :L)
     F = cholesky!(ChordalCholesky(H; kw...))
-    return ChordalGMRF(μ, H, F)
+    return ChordalGMRF(μ_T, H, F)
 end
 
 function Base.length(d::ChordalGMRF)
@@ -76,7 +93,9 @@ end
 
 function var(d::ChordalGMRF)
     Σ = mselinv(d.Q, d.F)
-    return diag(Σ)
+    # `diag` of a sparse matrix is a `SparseVector`, but every marginal variance
+    # is stored anyway and a sparse result breaks `ForwardDiff.jacobian`.
+    return Vector(diag(Σ))
 end
 
 function _rand!(rng::AbstractRNG, d::ChordalGMRF{T}, x::AbstractVector) where {T}

--- a/src/gmrf.jl
+++ b/src/gmrf.jl
@@ -295,13 +295,35 @@ function _rand_impl!(rng::AbstractRNG, d::GMRF, x::AbstractVector, ::Val{false})
     return x
 end
 
+"""
+    var(d::GMRF)
+
+Marginal variances `diag(Q⁻¹)`, as a dense `Vector`.
+
+How they are obtained depends on the GMRF's linear solver:
+
+- Solvers that support selected inversion (`CHOLMODFactorization`,
+  `CholeskyFactorization`, `LDLtFactorization`, `DiagonalFactorization`,
+  `PardisoJL`, and the default solver whenever it resolves to one of these)
+  give **exact** variances.
+- Any other solver falls back to [`RBMCStrategy`](@ref), a **stochastic** Monte
+  Carlo estimator. Repeated calls then return slightly different numbers, and
+  finite-difference checks against them are meaningless.
+
+Only the exact path is differentiable: differentiating `var` through a solver
+without selected inversion throws rather than silently returning a zero
+gradient. Pass a selinv-capable solver explicitly if you need gradients, e.g.
+`GMRF(mean, precision, LinearSolve.CHOLMODFactorization())`.
+"""
 function var(d::GMRF)
     return _var_impl(d, supports_selinv(d.linsolve_cache.alg))
 end
 
 function _var_impl(d::GMRF, ::Val{true})
-    # Use selected inversion
-    return selinv_diag(d.linsolve_cache)
+    # Use selected inversion. `selinv_diag` hands back a `SparseVector` whose
+    # every entry is stored — marginal variances are structurally dense — and a
+    # sparse result breaks `ForwardDiff.jacobian`, so densify.
+    return Vector(selinv_diag(d.linsolve_cache))
 end
 
 function _var_impl(d::GMRF, ::Val{false})

--- a/test/autodiff/runtests.jl
+++ b/test/autodiff/runtests.jl
@@ -1,5 +1,6 @@
 include("test_helper_functions.jl")
 include("test_forwarddiff_extension.jl")
+include("test_forwarddiff_var.jl")
 include("test_logpdf.jl")
 include("test_constructors.jl")
 include("test_gaussian_approximation.jl")

--- a/test/autodiff/test_forwarddiff_var.jl
+++ b/test/autodiff/test_forwarddiff_var.jl
@@ -1,0 +1,164 @@
+using GaussianMarkovRandomFields
+using Distributions
+using SparseArrays
+using LinearAlgebra
+using LinearSolve
+using Statistics
+
+using DifferentiationInterface
+using FiniteDiff, ForwardDiff
+using ReTest: @testset, @test, @test_throws
+
+# GMRF types that carry Dual numbers deliberately keep a *primal* factorization —
+# CHOLMOD cannot hold Duals — so anything that reads marginal variances straight
+# out of that factorization silently drops its partials and reports a zero
+# gradient. These tests pin `var`/`std` to dense references that share no code
+# with the selected-inversion path.
+#
+# The precision below is a 2D grid Laplacian: its Cholesky factor has fill-in, so
+# entries of Q⁻¹ outside the selected-inverse pattern genuinely matter. A
+# tridiagonal AR(1) precision has no fill-in and cannot detect this class of bug.
+function _fd_var_grid_laplacian(m)
+    I_, J_ = Int[], Int[]
+    for j in 1:m, i in 1:m
+        idx = (j - 1) * m + i
+        i < m && (push!(I_, idx); push!(J_, idx + 1))
+        j < m && (push!(I_, idx); push!(J_, idx + m))
+    end
+    W = sparse([I_; J_], [J_; I_], 1.0, m * m, m * m)
+    return spdiagm(0 => vec(sum(W, dims = 2))) - W
+end
+
+@testset "ForwardDiff var/std" begin
+    L = _fd_var_grid_laplacian(8)
+    N = size(L, 1)
+    Qof(θ) = sparse(exp(θ[1]) * (L + exp(θ[2]) * I))
+    θ0 = [log(2.0), 0.3]
+
+    # Dense marginal variances — no GMRF machinery, no selected inversion.
+    dense_var(θ) = diag(inv(Matrix(Qof(θ))))
+
+    # Guard the premise: without fill-in this suite cannot see the bug it targets.
+    @testset "test precision has Cholesky fill-in" begin
+        Q = Qof(θ0)
+        @test nnz(sparse(cholesky(Symmetric(Q)).L)) > nnz(tril(Q))
+    end
+
+    @testset "var returns a dense Vector" begin
+        # `selinv_diag` yields a structurally dense `SparseVector`, which
+        # `ForwardDiff.jacobian` cannot extract partials from.
+        Q = Qof(θ0)
+        @test var(GMRF(zeros(N), Q, LinearSolve.CHOLMODFactorization())) isa Vector
+        @test var(GMRF(zeros(N), Q)) isa Vector
+        @test var(ChordalGMRF(zeros(N), Q)) isa Vector
+        @test var(WorkspaceGMRF(zeros(N), Q)) isa Vector
+    end
+
+    @testset "gradient of sum(var)" begin
+        ref = ForwardDiff.gradient(θ -> sum(dense_var(θ)), θ0)
+        @test ref ≉ zeros(2)  # the reference must be non-trivial
+
+        # `GMRF(μ, Q)` resolves to CHOLMOD for sparse SPD precisions, so the
+        # default constructor must be differentiable too — not just the
+        # explicitly-configured one.
+        gmrf_sum(θ) = sum(var(GMRF(zeros(N), Qof(θ), LinearSolve.CHOLMODFactorization())))
+        default_sum(θ) = sum(var(GMRF(zeros(N), Qof(θ))))
+        chordal_sum(θ) = sum(var(ChordalGMRF(zeros(N), Qof(θ))))
+        workspace_sum(θ) = sum(var(WorkspaceGMRF(zeros(N), Qof(θ))))
+
+        @test ForwardDiff.gradient(gmrf_sum, θ0) ≈ ref rtol = 1.0e-8
+        @test ForwardDiff.gradient(default_sum, θ0) ≈ ref rtol = 1.0e-8
+        @test ForwardDiff.gradient(chordal_sum, θ0) ≈ ref rtol = 1.0e-8
+        @test ForwardDiff.gradient(workspace_sum, θ0) ≈ ref rtol = 1.0e-8
+
+        # Independent check that the dense reference itself is right.
+        @test FiniteDiff.finite_difference_gradient(gmrf_sum, θ0) ≈ ref rtol = 1.0e-5
+    end
+
+    @testset "full Jacobian of var" begin
+        # A sum can hide per-element sign errors; pin every marginal variance.
+        ref = ForwardDiff.jacobian(dense_var, θ0)
+
+        gmrf_var(θ) = var(GMRF(zeros(N), Qof(θ), LinearSolve.CHOLMODFactorization()))
+        chordal_var(θ) = var(ChordalGMRF(zeros(N), Qof(θ)))
+        workspace_var(θ) = var(WorkspaceGMRF(zeros(N), Qof(θ)))
+
+        @test ForwardDiff.jacobian(gmrf_var, θ0) ≈ ref rtol = 1.0e-8
+        @test ForwardDiff.jacobian(chordal_var, θ0) ≈ ref rtol = 1.0e-8
+        @test ForwardDiff.jacobian(workspace_var, θ0) ≈ ref rtol = 1.0e-8
+    end
+
+    @testset "std differentiates through var" begin
+        ref = ForwardDiff.gradient(θ -> sum(sqrt.(dense_var(θ))), θ0)
+        gmrf_std(θ) = sum(std(GMRF(zeros(N), Qof(θ), LinearSolve.CHOLMODFactorization())))
+        @test ForwardDiff.gradient(gmrf_std, θ0) ≈ ref rtol = 1.0e-8
+    end
+
+    @testset "ConstrainedGMRF constraint correction is differentiated" begin
+        A = zeros(2, N)
+        A[1, 1] = 1.0
+        A[1, 2] = 1.0
+        A[2, 5] = 1.0
+        A[2, 9] = -2.0
+        e = zeros(2)
+
+        # Σ_c = Σ - ΣAᵀ(AΣAᵀ)⁻¹AΣ, computed densely.
+        function dense_constrained_var(θ)
+            Σ = inv(Matrix(Qof(θ)))
+            M = Σ * A'
+            return diag(Σ - M * ((A * M) \ M'))
+        end
+
+        constrained_sum(θ) = sum(
+            var(
+                ConstrainedGMRF(
+                    GMRF(zeros(N), Qof(θ), LinearSolve.CHOLMODFactorization()), A, e
+                )
+            )
+        )
+
+        ref = ForwardDiff.gradient(θ -> sum(dense_constrained_var(θ)), θ0)
+        @test constrained_sum(θ0) ≈ sum(dense_constrained_var(θ0)) rtol = 1.0e-10
+        @test ForwardDiff.gradient(constrained_sum, θ0) ≈ ref rtol = 1.0e-8
+
+        # Regression guard: differentiating only the base term yields the
+        # *unconstrained* gradient, which is wrong but looks plausible.
+        unconstrained_ref = ForwardDiff.gradient(θ -> sum(dense_var(θ)), θ0)
+        @test ref ≉ unconstrained_ref
+    end
+
+    @testset "ChordalGMRF promotes a Float64 mean against a Dual precision" begin
+        # `AbstractGMRF{T, L}` requires `L <: AbstractMatrix{T}`; without
+        # promotion this construction throws a TypeError.
+        g = ChordalGMRF(zeros(N), Qof(ForwardDiff.Dual.(θ0, (1.0, 0.0), (0.0, 1.0))))
+        @test eltype(mean(g)) <: ForwardDiff.Dual
+        @test length(var(g)) == N
+    end
+
+    @testset "diagonal precision" begin
+        θd = [1.0, 2.0, 3.0]
+        diag_sum(θ) = sum(var(GMRF(zeros(3), Diagonal(θ), LinearSolve.DiagonalFactorization())))
+        @test ForwardDiff.gradient(diag_sum, θd) ≈ -1 ./ θd .^ 2 rtol = 1.0e-10
+    end
+
+    @testset "constant precision gives a zero gradient" begin
+        # Differentiating only through the mean: `var` really is constant here, so
+        # zero is the right answer rather than a dropped-partials artifact.
+        Q0 = Qof(θ0)
+        mean_only(θ) = sum(var(GMRF(θ[1] * ones(N), Q0, LinearSolve.CHOLMODFactorization())))
+        @test ForwardDiff.gradient(mean_only, [1.0]) ≈ [0.0] atol = 1.0e-12
+    end
+
+    @testset "non-selinv solver throws rather than returning zeros" begin
+        krylov_sum(θ) = sum(var(GMRF(zeros(N), Qof(θ), LinearSolve.KrylovJL_CG())))
+        @test_throws ArgumentError ForwardDiff.gradient(krylov_sum, θ0)
+    end
+
+    @testset "primal values are unchanged" begin
+        ref = sum(dense_var(θ0))
+        Q = Qof(θ0)
+        @test sum(var(GMRF(zeros(N), Q, LinearSolve.CHOLMODFactorization()))) ≈ ref rtol = 1.0e-10
+        @test sum(var(ChordalGMRF(zeros(N), Q))) ≈ ref rtol = 1.0e-10
+        @test sum(var(WorkspaceGMRF(zeros(N), Q))) ≈ ref rtol = 1.0e-10
+    end
+end


### PR DESCRIPTION
Differentiating `var` on a GMRF returned a zero gradient instead of failing, so gradient-based hyperparameter optimisation would stall silently rather than error.

```julia
f(θ) = sum(var(GMRF(zeros(N), Qof(θ), LinearSolve.CHOLMODFactorization())))

FiniteDiff.finite_difference_gradient(f, θ0)   # [-8.2461584, -3.7793075]
ForwardDiff.gradient(f, θ0)                    # [0.0, 0.0]
```

## Cause

GMRF types carrying `Dual` numbers deliberately hold a **primal** factorization, because CHOLMOD cannot store `Dual`s. `var` read its marginal variances straight out of that factorization, so every partial was dropped. `logdetcov` had escaped this because it carries an explicit IFT correction; `var` had no `Dual` method at all.

There is no equivalent shortcut for `var`: `d(diag(Q⁻¹)) = -diag(Q⁻¹ Q̇ Q⁻¹)` reaches entries of `Q⁻¹` outside the selected-inverse pattern, so it cannot be recovered from the primal selected inverse.

Redoing the selected inversion in `Dual` arithmetic *is* cheap, though — the Takahashi recursion is closed over the fill-in pattern, so its tangent stays in-pattern and costs `O(nnz(L))` per partial. `ChordalCholesky` is generic Julia and propagates partials exactly, which is precisely why `ChordalGMRF` never had this bug. `GMRF` and `WorkspaceGMRF` now route through the same machinery.

This adds exactly one CliqueTrees call site, inside the ForwardDiff extension, reachable only from `{<:Dual}` dispatches. **SelectedInversion keeps the entire `Float64` path** — the only selinv-related change in `src/` wraps the existing call in `Vector(...)`.

## What changed

| path | before | after |
| --- | --- | --- |
| `GMRF`, selinv solvers | `[0, 0]` | exact (relerr ~5e-17) |
| `WorkspaceGMRF` | `[0, 0]` | exact |
| `ConstrainedGMRF` | `[0, 0]` | exact (~2e-11 vs finite differences) |
| `ChordalGMRF`, Float64 mean + Dual precision | `TypeError` | exact |
| solvers without selected inversion | `[0, 0]` | throws `ArgumentError` |

Three points worth a reviewer's attention:

**The default constructor was affected too.** `GMRF(μ, Q)` resolves to CHOLMOD for sparse SPD precisions, so it takes the *exact* selected-inversion path rather than the stochastic `RBMCStrategy` fallback. It was equally broken, and it is the form most users write. `var` now documents that the RBMC fallback is stochastic when it does trigger.

**`ConstrainedGMRF` needed more than its base term.** It stores `L_c` and `A_tilde_T` as `Float64`, so fixing only the base would have produced the *unconstrained* gradient — wrong, but plausible enough to escape notice, which is worse than the zero it replaced. This reuses the implicit differentiation `_constraint_info` already performs, factored out as `_dual_constraint_factors`. A test asserts the constrained gradient differs from the unconstrained one so that specific regression cannot return quietly.

**`var` now returns a dense `Vector`.** It previously returned a `SparseVector` whose every entry was stored anyway (`nnz == N`), and a sparse result makes `ForwardDiff.jacobian` fail outright — for every GMRF type, including on the `Float64` path. No existing test depended on the sparse type.

## Known gaps

Both throw a clear `ArgumentError` rather than returning a wrong answer, and both are narrow — the repo's own constrained constructions (`rw.jl`, `besag.jl`, `latent_model.jl`) all use `GMRF` bases, and the `Dual` `WorkspaceGMRF` constructors always produce unconstrained instances.

- Constrained `WorkspaceGMRF`: `ConstraintInfo` declares `A_tilde_T` and `L_c` as `Float64` in the struct, so they cannot hold `Dual`s.
- `ConstrainedGMRF` over a non-`GMRF` base: `_dual_constraint_factors` reaches the solver through `linsolve_cache`, which only a `GMRF` has.

Both need the same follow-up: a solve-backend-agnostic version of `_dual_constraint_factors`.

## Testing

Full suite passes (5610 tests, including Aqua and JET). New regression file passes 26/26 on both Julia 1.12.6 and 1.10.10.

The new tests use a 2D grid Laplacian and assert that it has Cholesky fill-in — a tridiagonal AR(1) precision has none and cannot detect this class of bug at all. They pin the full Jacobian rather than just `sum(var(...))`, since a sum can hide per-element sign errors, and check against a dense reference that shares no code with the selected-inversion path.
