### PR TITLE
Complete the AD support story across the docs

### DIFF
--- a/docs/src/literate-tutorials/automatic_differentiation.jl
+++ b/docs/src/literate-tutorials/automatic_differentiation.jl
@@ -7,11 +7,23 @@
 # gradients through GMRF operations to optimize hyperparameters like precision parameters,
 # mean field values, and other model parameters.
 #
-# We currently support AD via Zygote, Enzyme, and ForwardDiff.
+# Four backends have hand-written rules in this package: ForwardDiff, Zygote,
+# Enzyme and Mooncake. Which of them works depends on the operation and on the
+# GMRF type -- differentiating through a sparse Cholesky factorization is not
+# something a general-purpose AD system can do unaided, so each supported
+# combination rests on a rule written for it. ForwardDiff is the only backend
+# that covers every type and every operation, and it is what we use below.
 #
-# !!! note "AD may break"
-#     Our current AD rules cover the most common workflows with GMRFs.
-#     Less common operations may or may not work.
+# The [Automatic Differentiation Reference](@ref) has the full support matrix,
+# checked against finite differences. Combinations without a rule raise an
+# explicit error rather than returning a wrong number.
+#
+# !!! note "A different question: your own likelihoods"
+#     The matrix above is about differentiating *through* the package's own
+#     linear algebra. When you supply your own log-likelihood to
+#     `AutoDiffObservationModel`, the package differentiates your function
+#     through [DifferentiationInterface.jl](https://github.com/JuliaDiff/DifferentiationInterface.jl)
+#     instead, and any DI-compatible backend works there -- no rule needed.
 #     If one of these backends breaks for your use case, please open an issue.
 
 # ## Basic Setup

--- a/docs/src/reference/autodiff.md
+++ b/docs/src/reference/autodiff.md
@@ -5,6 +5,36 @@ through several AD backends. Which backend to reach for depends on **both** the
 operation and the GMRF type — support is not uniform, and the differences are
 large enough to matter in practice.
 
+## Two kinds of differentiation
+
+It is worth separating two things that both get called "AD support", because the
+answer is different for each.
+
+**Differentiating through GMRF internals** — `logpdf`, `logdetcov`, `var` and
+`gaussian_approximation`, with respect to hyperparameters — runs through a sparse
+Cholesky factorization. No general-purpose AD system can traverse that: CHOLMOD is
+a C library reached through opaque pointers, and even the pure-Julia multifrontal
+factorization behind `ChordalGMRF` is walked incorrectly by backends that try. So
+every supported combination here rests on a **hand-written rule**, and the support
+matrix below records exactly which ones exist. This is the part where the choice of
+backend genuinely constrains what you can do.
+
+**Differentiating your own likelihood** — through
+[`AutoDiffObservationModel`](@ref) and [`AutoDiffLatentPrior`](@ref) — is a
+different situation. There the package differentiates *your* Julia function, not
+its own linear algebra, and it does so through
+[DifferentiationInterface.jl](https://github.com/JuliaDiff/DifferentiationInterface.jl).
+Any DI-compatible backend can be passed as `grad_backend`; the package does not
+need a rule for it. The default picks the first of Enzyme, Mooncake, Zygote or
+ForwardDiff that is loaded, and you can override it:
+
+```julia
+using DifferentiationInterface, Enzyme
+obs_model = AutoDiffObservationModel(my_loglik; n_latent = n, grad_backend = AutoEnzyme())
+```
+
+The support matrix constrains the first kind, not the second.
+
 ## Choosing a backend
 
 **Start with ForwardDiff.jl.** It is the only backend that currently handles every
@@ -24,31 +54,42 @@ forward mode's per-parameter cost dominates:
 
 ## Support matrix
 
-Checked against finite differences with a precision matrix whose Cholesky factor
-has genuine fill-in — the Enzyme column on Julia 1.10.10, 1.11.9 and 1.12.6, the
-other columns on 1.12.6. The fill-in matters: a tridiagonal AR(1) precision has
-none, and several of the failures below are invisible with one.
+Every cell below was checked against finite differences on Julia 1.10.10, 1.11.9
+and 1.12.6, using a precision matrix whose Cholesky factor has genuine fill-in.
+The fill-in matters: a tridiagonal AR(1) precision has none, and several of these
+failures are invisible with one.
 
-Mooncake is not in the table; it supports `ChordalGMRF` and refuses the
-CHOLMOD-backed types, so a column would be mostly ❌. See the Mooncake section
-below.
-
-| Operation | ForwardDiff | Zygote | Enzyme |
-|---|---|---|---|
-| `logdetcov(::GMRF)` | ✅ | ✅ | ✅ |
-| `logpdf(::GMRF, z)` | ✅ | ✅ | ✅ |
-| `gaussian_approximation` (`GMRF`) | ✅ | ✅ | ✅ |
-| `logdetcov(::ChordalGMRF)` | ✅ | ✅ | ⚠️ unreliable |
-| `logpdf(::ChordalGMRF, z)` | ✅ | ✅ | ⚠️ unreliable |
-| `gaussian_approximation` (`ChordalGMRF`) | ✅ | ✅ | ⚠️ unreliable |
-| `logdetcov(::WorkspaceGMRF)` | ✅ | ✅ | ✅ |
-| `logpdf(::WorkspaceGMRF, z)` | ✅ | ✅ | ✅ |
-| `gaussian_approximation` (`WorkspaceGMRF`) | ✅ | ✅ | ✅ |
-| `logpdf(::ConstrainedGMRF, z)` | ✅ | ✅ | Julia 1.12 only |
-| `gaussian_approximation` (`ConstrainedGMRF`) | ✅ | ✅ | Julia 1.12 only |
-| `var` / `std` (any type) | ✅ | ❌ raises | ❌ raises |
+| Operation | ForwardDiff | Zygote | Enzyme | Mooncake |
+|---|---|---|---|---|
+| `logdetcov(::GMRF)` | ✅ | ✅ | ✅ | ❌ raises |
+| `logpdf(::GMRF, z)` | ✅ | ✅ | ✅ | ❌ raises |
+| `gaussian_approximation` (`GMRF`) | ✅ | ✅ | ✅ | ❌ raises |
+| `logdetcov(::ChordalGMRF)` | ✅ | ✅ | ⚠️ unreliable | ✅ |
+| `logpdf(::ChordalGMRF, z)` | ✅ | ✅ | ⚠️ unreliable | ✅ |
+| `gaussian_approximation` (`ChordalGMRF`) | ✅ | ✅ | ⚠️ unreliable | ✅ |
+| `logdetcov(::WorkspaceGMRF)` | ✅ | ✅ | ✅ | ❌ raises |
+| `logpdf(::WorkspaceGMRF, z)` | ✅ | ✅ | ✅ | ❌ raises |
+| `gaussian_approximation` (`WorkspaceGMRF`) | ✅ | ✅ | ✅ | ❌ raises |
+| `logpdf(::ConstrainedGMRF, z)` | ✅ | ✅ | Julia 1.12 only | ❌ raises |
+| `gaussian_approximation` (`ConstrainedGMRF`) | ✅ | ✅ | Julia 1.12 only | ❌ raises |
+| `var` / `std` (`GMRF`, `WorkspaceGMRF`) | ✅ | ❌ raises | ❌ raises | ❌ raises |
+| `var` / `std` (`ChordalGMRF`) | ✅ | ❌ raises | ❌ raises | ⚠️ wrong, see below |
 
 ✅ matches finite differences · ❌ raises an error · ⚠️ see the note for that row
+
+The Enzyme `ChordalGMRF` rows depend on the Julia version *and* the CPU
+architecture; see the note under [Enzyme](#Enzyme) below. The verification above
+ran on aarch64.
+
+The single ⚠️ is `var`/`std` on a `ChordalGMRF` under Mooncake, whose gradient is
+currently around 1% off. The cause sits upstream of this package, in the
+selected-inversion rule for the chordal factorization, and a fix is expected. Use
+ForwardDiff for marginal-variance gradients in the meantime.
+
+Everything else that is not ✅ raises an explicit, actionable error. Combinations
+that cannot be supported refuse rather than falling back to differentiating a
+sparse factorization, because doing the latter produces wrong gradients that no
+test without a finite-difference reference would catch.
 
 Every ❌ in this table is an explicit, actionable error. Combinations that cannot
 be supported raise rather than falling back to differentiating a sparse


### PR DESCRIPTION
Third JOSS review PR. The backend correctness fixes (#192, #193, #194) are in; this makes the documentation match them, and closes the AD-related review items.

## Changes

**Mooncake is in the support matrix.** It was previously omitted on the grounds that its column would be mostly negative — but that left exactly the ambiguity sethaxen raised: Mooncake appeared on the observation-models page and nowhere else, so a reader could not tell whether it was supported, untested, or forgotten. It now has a column like every other backend.

**Every cell re-verified** against finite differences on Julia 1.10.10, 1.11.9 and 1.12.6, after the fixes, using a precision matrix with genuine Cholesky fill-in. 13 operations across 4 GMRF types and 4 backends. No segfaults, and every unsupported combination raises an explicit error — the claim the page makes, now checked rather than asserted.

**The `var` row is split by GMRF type**, since `ChordalGMRF` and the CHOLMOD-backed types now differ. The one remaining wrong-answer cell (Mooncake `var` on `ChordalGMRF`, ~1% off, upstream in the chordal selected-inversion rule) is called out rather than left silent.

**The tutorial claimed three of the four backends** — "We currently support AD via Zygote, Enzyme, and ForwardDiff", written before Mooncake existed here. Fixed, and pointed at the matrix.

**Distinguished the two things that both get called "AD support".** Differentiating *through* the package's own factorizations needs a hand-written rule per backend, which is what the matrix constrains. Differentiating a *user-supplied* likelihood via `AutoDiffObservationModel` goes through DifferentiationInterface, where any DI-compatible backend works and no rule is needed. Conflating these is why "which backends are supported?" had no single answer — and it is the honest version of the "you support any DI backend" point raised in review.

## Note on the Enzyme rows

I initially sharpened Enzyme's `ChordalGMRF` rows from "unreliable" to specific Julia versions, based on measurement. The Enzyme section already documents that support depends on CPU architecture as well — the same Julia 1.12.6 succeeds on aarch64 and fails on x86-64. The verification here ran on aarch64 only, and CI runs x86-64, so the version-specific claim would have been wrong for most users. Those rows stay "unreliable", with the architecture caveat noted under the table.

## Review items addressed

- #132 item 8 (Mooncake missing from the AD docs; DI framing)
- #151, Documentation bullet 4 (Mooncake's status inconsistent across three pages)
- #133 items 3 and 4 (Mooncake omitted; per-backend guidance)

Paper-side AD changes (L48/L64/L76 and the Zygote/Mooncake/DI citations) are deliberately left for the paper PR.

Refs openjournals/joss-reviews#10509