### PR TITLE
Label the tutorial plots and write out the models they fit

### DIFF
--- a/docs/src/literate-tutorials/autoregressive_models.jl
+++ b/docs/src/literate-tutorials/autoregressive_models.jl
@@ -7,7 +7,7 @@
 #
 # ```math
 # x_0 \sim \mathcal{N}(\mu_0, \Lambda_0), \\
-# x_{t+1} = \phi x_t + \varepsilon_t, \quad \varepsilon \sim \mathcal{N}(0, \Lambda).
+# x_{t+1} = \phi x_t + \varepsilon_t, \quad \varepsilon_t \sim \mathcal{N}(0, \Lambda).
 # ```
 #
 # The latter equation is equivalent to the likelihood
@@ -74,7 +74,10 @@ x = GMRF(μ, Q, LinearSolve.LDLtFactorization())
 # `Distributions.jl`. We can get its mean, marginal standard deviation, and
 # draw samples as follows:
 using Plots, Distributions
-plot(xs, mean(x), ribbon = 1.96 * std(x), label = "Mean + std")
+plot(
+    xs, mean(x), ribbon = 1.96 * std(x), label = "Mean ± 1.96 std",
+    xlabel = "t", ylabel = "x", title = "AR(1) prior"
+)
 for i in 1:3
     plot!(xs, rand(x), fillalpha = 0.3, linestyle = :dash, label = "Sample")
 end
@@ -104,7 +107,10 @@ obs_lik = obs_model(y; σ = 0.001) # Concrete likelihood
 x_cond = gaussian_approximation(x, obs_lik)
 
 # Indeed, our model now conforms to these observations:
-plot(xs, mean(x_cond), ribbon = 1.96 * std(x_cond), label = "Mean + std")
+plot(
+    xs, mean(x_cond), ribbon = 1.96 * std(x_cond), label = "Mean ± 1.96 std",
+    xlabel = "t", ylabel = "x", title = "AR(1) posterior given observations"
+)
 for i in 1:3
     plot!(xs, rand(x_cond), fillalpha = 0.3, linestyle = :dash, label = "Sample")
 end
@@ -154,7 +160,10 @@ end
 x_car = generate_car_model(W, 0.99; μ = μ, σ = 0.001)
 
 # Let's take our CAR for a test drive:
-plot(xs, mean(x_car), ribbon = 1.96 * std(x_car), label = "Mean + std")
+plot(
+    xs, mean(x_car), ribbon = 1.96 * std(x_car), label = "Mean ± 1.96 std",
+    xlabel = "t", ylabel = "x", title = "CAR prior"
+)
 for i in 1:3
     plot!(xs, rand(x_car), fillalpha = 0.3, linestyle = :dash, label = "Sample")
 end
@@ -167,7 +176,10 @@ obs_model = ExponentialFamily(Distributions.Normal, indices = [1, 26, 76])
 y = [1.0, 0.85, 0.71]
 obs_lik = obs_model(y; σ = 0.001)
 x_car_cond = gaussian_approximation(x_car, obs_lik)
-plot(xs, mean(x_car_cond), ribbon = 1.96 * std(x_car_cond), label = "Mean + std")
+plot(
+    xs, mean(x_car_cond), ribbon = 1.96 * std(x_car_cond), label = "Mean ± 1.96 std",
+    xlabel = "t", ylabel = "x", title = "CAR posterior given observations"
+)
 for i in 1:3
     plot!(xs, rand(x_car_cond), fillalpha = 0.3, linestyle = :dash, label = "Sample")
 end

--- a/docs/src/literate-tutorials/bernoulli_spatial_classification.jl
+++ b/docs/src/literate-tutorials/bernoulli_spatial_classification.jl
@@ -11,6 +11,21 @@
 # - perform a fast Gaussian approximation to the posterior, and
 # - make and visualize spatial probability predictions on a grid.
 #
+# Written out, the model is
+# ```math
+# u \sim \mathcal{GP}\big(0, k_\nu(\cdot, \cdot)\big), \quad
+# y_i \mid u \sim \mathrm{Bernoulli}\big(p(s_i)\big), \quad
+# \mathrm{logit}\, p(s_i) = u(s_i),
+# ```
+# where $u$ is a Matérn field with smoothness $\nu$, approximated by a GMRF
+# through its SPDE representation, and $s_i$ are the observed locations. The
+# logit link keeps $p(s_i) \in (0, 1)$ without constraining $u$.
+#
+# The posterior $p(u \mid y)$ is not Gaussian, because the Bernoulli likelihood
+# is not conjugate to the prior. We approximate it by the Gaussian centred at the
+# posterior mode with matching curvature — the Laplace approximation — which
+# `gaussian_approximation` computes.
+#
 # We use the well-known Lansing Woods dataset (tree locations with species marks).
 # The dataset here provides three columns: `x`, `y`, `is_hickory` (0/1). We try a
 # local file first so the tutorial works offline; otherwise we download a small RDA

--- a/docs/src/literate-tutorials/boundary_conditions.jl
+++ b/docs/src/literate-tutorials/boundary_conditions.jl
@@ -55,7 +55,12 @@ x = discretize(matern_spde, disc)
 # the variance vanishes at the boundary:
 using CairoMakie
 CairoMakie.activate!()
-plot(x, disc)
+plot(
+    x, disc; axis = (;
+        xlabel = "x", ylabel = "u(x)",
+        title = "Homogeneous Neumann boundary",
+    )
+)
 
 # ### Periodic boundary
 # We can also define a periodic boundary condition in terms of an affine
@@ -85,7 +90,12 @@ x_periodic = discretize(matern_spde, disc_periodic)
 
 # Verify for yourself that the values at the left and right boundary match
 # for all samples:
-plot(x_periodic, disc)
+plot(
+    x_periodic, disc; axis = (;
+        xlabel = "x", ylabel = "u(x)",
+        title = "Periodic boundary",
+    )
+)
 
 # ## Spatiotemporal example: Advection-Diffusion SPDE
 # This works just as well in the spatiotemporal case.
@@ -115,19 +125,19 @@ x_adv_diff_dirichlet = linear_condition(x_adv_diff_dirichlet; A = A_ic, Q_ϵ = 1
 x_adv_diff_periodic = linear_condition(x_adv_diff_periodic; A = A_ic, Q_ϵ = 1.0e8, y = ys_ic)
 
 # First, check the initial observations:
-plot(x_adv_diff_dirichlet, 1)
+plot(x_adv_diff_dirichlet, 1; axis = (; xlabel = "x", ylabel = "u(x)", title = "Dirichlet, t = 0"))
 
 # Now, let's see how the process evolves over time:
-plot(x_adv_diff_dirichlet, N_t ÷ 2)
+plot(x_adv_diff_dirichlet, N_t ÷ 2; axis = (; xlabel = "x", ylabel = "u(x)", title = "Dirichlet, t = T/2"))
 
 #
-plot(x_adv_diff_dirichlet, N_t)
+plot(x_adv_diff_dirichlet, N_t; axis = (; xlabel = "x", ylabel = "u(x)", title = "Dirichlet, t = T"))
 
 # Compare to this to the periodic case:
-plot(x_adv_diff_periodic, N_t ÷ 2)
+plot(x_adv_diff_periodic, N_t ÷ 2; axis = (; xlabel = "x", ylabel = "u(x)", title = "Periodic, t = T/2"))
 
 #
-plot(x_adv_diff_periodic, N_t)
+plot(x_adv_diff_periodic, N_t; axis = (; xlabel = "x", ylabel = "u(x)", title = "Periodic, t = T"))
 
 # ## Conclusion
 # We have seen how to specify more complex boundary conditions for GMRFs.

--- a/docs/src/literate-tutorials/bym_scotland_lip_cancer.jl
+++ b/docs/src/literate-tutorials/bym_scotland_lip_cancer.jl
@@ -11,6 +11,26 @@
 # - A BYM latent field = Besag (structured spatial) + IID (unstructured spatial).
 # - Fixed effects (intercept + one covariate).
 #
+# In symbols, for district $i$ with observed count $y_i$ and expected count $E_i$,
+# ```math
+# y_i \mid \eta_i \sim \mathrm{Poisson}\big(E_i \exp(\eta_i)\big), \quad
+# \eta_i = \beta_0 + \beta_1 \mathrm{AFF}_i + u_i + v_i,
+# ```
+# so $\exp(\eta_i)$ is the relative risk and the offset $\log E_i$ enters the
+# linear predictor with a fixed coefficient of one. The two random effects split
+# the residual variation by whether it respects the map:
+# ```math
+# u_i \mid u_{-i} \sim \mathcal{N}\!\left(\frac{1}{n_i}\sum_{j \sim i} u_j,\;
+# \frac{1}{\tau_u n_i}\right), \qquad
+# v_i \sim \mathcal{N}(0, \tau_v^{-1}),
+# ```
+# where $j \sim i$ denotes the neighbours of district $i$ and $n_i$ their number.
+# The Besag component $u$ borrows strength from adjacent districts; the IID
+# component $v$ absorbs district-specific over-dispersion that has no spatial
+# pattern. The Besag precision is singular — it constrains only differences
+# between neighbours, not the overall level — so it carries a sum-to-zero
+# constraint, which the intercept $\beta_0$ then supplies.
+#
 # What you’ll learn:
 # - Build a polygon contiguity adjacency matrix directly from a shapefile.
 # - Compose a BYM + fixed‑effects model via the formula interface.

--- a/docs/src/literate-tutorials/spatial_modelling_spdes.jl
+++ b/docs/src/literate-tutorials/spatial_modelling_spdes.jl
@@ -20,7 +20,11 @@ using Plots
 x = convert(Vector{Float64}, df[:, :x])
 y = convert(Vector{Float64}, df[:, :y])
 zinc = df[:, :zinc]
-scatter(x, y, zcolor = zinc)
+scatter(
+    x, y, zcolor = zinc, xlabel = "x coordinate", ylabel = "y coordinate",
+    title = "Zinc concentration near the Meuse", label = false,
+    colorbar_title = "zinc (ppm)"
+)
 
 # Finally, in classic machine learning fashion, we split the data into a training
 # and a test set. We use about 85% of the data for training and the remaining 15%
@@ -41,7 +45,7 @@ size(X_train, 1), size(X_test, 1)
 # Unfortunately, without using any further tricks, GPs have a cubic runtime
 # complexity. As the size of the dataset grows, this quickly becomes
 # prohibitively expensive.
-# In the tutorial on Autoregressive models, we learned that GMRFs enable highly
+# In [Building autoregressive models](@ref), we learned that GMRFs enable highly
 # efficient Gaussian inference through sparse precision matrices.
 # Can we combine the modelling power of GPs with the efficiency of GMRFs?
 #

--- a/docs/src/literate-tutorials/spatiotemporal_modelling.jl
+++ b/docs/src/literate-tutorials/spatiotemporal_modelling.jl
@@ -94,16 +94,16 @@ x_st_kron_posterior = linear_condition(x_st_kron; A = A_all, Q_ϵ = Q_noise, y =
 # Let's look at the dynamics of this posterior.
 using CairoMakie
 CairoMakie.activate!()
-plot(x_st_kron_posterior, t_initial_idx)
+plot(x_st_kron_posterior, t_initial_idx; axis = (; xlabel = "x", ylabel = "concentration", title = "Separable prior, t = 0"))
 
 #
-plot(x_st_kron_posterior, Nₜ ÷ 3)
+plot(x_st_kron_posterior, Nₜ ÷ 3; axis = (; xlabel = "x", ylabel = "concentration", title = "Separable prior, t = T/3"))
 
 #
-plot(x_st_kron_posterior, 2 * Nₜ ÷ 3)
+plot(x_st_kron_posterior, 2 * Nₜ ÷ 3; axis = (; xlabel = "x", ylabel = "concentration", title = "Separable prior, t = 2T/3"))
 
 #
-plot(x_st_kron_posterior, Nₜ)
+plot(x_st_kron_posterior, Nₜ; axis = (; xlabel = "x", ylabel = "concentration", title = "Separable prior, t = T"))
 
 # We see that the effect of our observations effectively just "dies off" over
 # time.
@@ -139,16 +139,16 @@ x_adv_diff = discretize(adv_diff_spde, disc, ts)
 x_adv_diff_posterior = linear_condition(x_adv_diff; A = A_all, Q_ϵ = Q_noise, y = ys_all)
 
 # Let's look at the dynamics of this posterior.
-plot(x_adv_diff_posterior, t_initial_idx)
+plot(x_adv_diff_posterior, t_initial_idx; axis = (; xlabel = "x", ylabel = "concentration", title = "Advection-diffusion, t = 0"))
 
 #
-plot(x_adv_diff_posterior, Nₜ ÷ 3)
+plot(x_adv_diff_posterior, Nₜ ÷ 3; axis = (; xlabel = "x", ylabel = "concentration", title = "Advection-diffusion, t = T/3"))
 
 #
-plot(x_adv_diff_posterior, 2 * Nₜ ÷ 3)
+plot(x_adv_diff_posterior, 2 * Nₜ ÷ 3; axis = (; xlabel = "x", ylabel = "concentration", title = "Advection-diffusion, t = 2T/3"))
 
 #
-plot(x_adv_diff_posterior, Nₜ)
+plot(x_adv_diff_posterior, Nₜ; axis = (; xlabel = "x", ylabel = "concentration", title = "Advection-diffusion, t = T"))
 
 # This looks much more reasonable!
 # We see that the pollutant is transported downstream over time, and the


### PR DESCRIPTION
Fourth JOSS review PR: tutorial polish. Independent of #195, which touches only the AD reference and AD tutorial.

## Plot labels

Fourteen plots across four tutorials had no axis labels. Two different plotting stacks are involved: the autoregressive and Meuse tutorials use Plots.jl, so they take `xlabel`/`ylabel`/`title`; the boundary-condition and spatiotemporal tutorials use this package's Makie recipes, where labels go through `axis = (; ...)`.

The Makie ones mattered most. Both tutorials draw a sequence of snapshots — `plot(x_adv_diff_dirichlet, N_t ÷ 2)` and so on — which rendered as runs of near-identical unlabelled curves with nothing indicating which boundary condition or which time step you were looking at. They now carry titles like "Dirichlet, t = T/2". Verified against the built output rather than assumed, since a recipe could have ignored the keyword silently.

## Model equations

The Bernoulli and disease-mapping tutorials described their models only in prose.

- **Bernoulli**: adds the GP / logit / Bernoulli specification, plus a sentence on why the posterior is not Gaussian — which is what motivates the Laplace approximation the tutorial then uses.
- **BYM**: adds the Poisson-with-offset likelihood, the conditional form of the Besag and IID components, and why the Besag precision is singular and therefore carries a sum-to-zero constraint that the intercept supplies.

## Two smaller fixes

The AR tutorial wrote its noise term as `\varepsilon_t` in the recursion and `\varepsilon` in the distribution on the adjacent line.

The Meuse tutorial referred to the autoregressive tutorial in prose without linking to it.

## One item not done, deliberately

Review #132 item 5 suggests combining the two SPDE tutorials, or at least moving "Spatial Modelling with SPDEs" after the spatiotemporal one. The cross-references make the current order the only coherent one: the spatiotemporal tutorial closes by pointing at `[Spatial Modelling with SPDEs](@ref)` for the general-mesh treatment, and the spatial tutorial builds on the autoregressive one. Moving spatial later would leave a tutorial depending on one that comes after it. The AR dependency is now an actual link rather than plain prose, so the progression is visible instead of implied.

## Review items addressed

- #132 items 3, 4 and 7
- #132 item 5 — see above

Refs openjournals/joss-reviews#10509