### PR TITLE
Motivate the ecosystem claim and complete the AD story in the paper

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -248,3 +248,69 @@
   address = {London},
   doi = {10.1201/b19708},
 }
+
+@article{skaug2006automatic,
+  title = {Automatic Approximation of the Marginal Likelihood in Non-{Gaussian} Hierarchical Models},
+  author = {Skaug, Hans J. and Fournier, David A.},
+  year = {2006},
+  journal = {Computational Statistics \& Data Analysis},
+  volume = {51},
+  number = {2},
+  pages = {699--709},
+  doi = {10.1016/j.csda.2006.03.005},
+}
+
+@article{nielsen2014sam,
+  title = {Estimation of Time-Varying Selectivity in Stock Assessments Using State-Space Models},
+  author = {Nielsen, Anders and Berg, Casper W.},
+  year = {2014},
+  journal = {Fisheries Research},
+  volume = {158},
+  pages = {96--101},
+  doi = {10.1016/j.fishres.2014.01.014},
+}
+
+@article{hoffman2014nuts,
+  title = {The No-{U}-Turn Sampler: Adaptively Setting Path Lengths in {Hamiltonian} {Monte} {Carlo}},
+  author = {Hoffman, Matthew D. and Gelman, Andrew},
+  year = {2014},
+  journal = {Journal of Machine Learning Research},
+  volume = {15},
+  number = {47},
+  pages = {1593--1623},
+  url = {https://jmlr.org/papers/v15/hoffman14a.html},
+}
+
+@misc{innes2018zygote,
+  title = {Don't Unroll Adjoint: Differentiating {SSA}-Form Programs},
+  author = {Innes, Michael},
+  year = {2018},
+  eprint = {1810.07951},
+  archiveprefix = {arXiv},
+  primaryclass = {cs.PL},
+  doi = {10.48550/arXiv.1810.07951},
+}
+
+@misc{dalle2025differentiationinterface,
+  title = {A Common Interface for Automatic Differentiation},
+  author = {Dalle, Guillaume and Hill, Adrian},
+  year = {2025},
+  eprint = {2505.05542},
+  archiveprefix = {arXiv},
+  primaryclass = {cs.MS},
+  doi = {10.48550/arXiv.2505.05542},
+}
+
+@software{tebbutt2024mooncake,
+  title = {{Mooncake}: Towards a Differentiable General-Purpose Language},
+  author = {Tebbutt, Will and Ge, Hong},
+  year = {2024},
+  url = {https://github.com/chalk-lab/Mooncake.jl},
+}
+
+@software{weiland2026latte,
+  title = {{Latte.jl}},
+  author = {Weiland, Tim and {Latte.jl contributors}},
+  year = {2026},
+  url = {https://github.com/timweiland/Latte.jl},
+}

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -42,10 +42,11 @@ For users requiring continuous spatial domains, the SPDE approach is implemented
 As an alternative to SPDE-based constructions, the package also implements KL-minimizing sparse Cholesky approximations [@schaeferSparseCholeskyKL2021], which construct sparse precision matrices directly from covariance specifications and are particularly effective for covariance functions with strong screening effects.
 
 The package extends beyond Gaussian observations through Gaussian approximation methods.
-When working with non-Gaussian data such as counts or binary outcomes, the package seamlessly handles exponential family likelihoods and custom likelihood functions, exploiting sparsity structure through automatic differentiation to maintain computational efficiency even for complex observation models.
+When working with non-Gaussian data such as counts or binary outcomes, the package seamlessly handles exponential family likelihoods.
+Users may also specify custom likelihood functions, for which the package exploits sparsity structure through automatic differentiation to maintain computational efficiency even for complex observation models, an approach established by Skaug and Fournier [@skaug2006automatic] and popularised by TMB [@kristensen2016tmb].
 For large-scale applications, the package provides efficient marginal variance computation methods [@lin2011selinv; @rueMarginalVariancesGaussian2005a; @sidenEfficientCovarianceApproximations2018a].
 \autoref{fig:bernoulli} demonstrates this capability on a spatial binary classification task.
-Automatic differentiation support via ForwardDiff.jl [@revels2016forward] and Enzyme.jl [@moses2020enzyme] enables gradient-based optimization and inference methods, making the package compatible with modern probabilistic programming frameworks including Turing.jl [@ge2018turing].
+Automatic differentiation support via ForwardDiff.jl [@revels2016forward], Enzyme.jl [@moses2020enzyme], Zygote.jl [@innes2018zygote], Mooncake.jl [@tebbutt2024mooncake] and DifferentiationInterface.jl [@dalle2025differentiationinterface] enable gradient-based optimization and inference methods, making the package compatible with modern probabilistic programming frameworks including Turing.jl [@ge2018turing].
 
 ![Spatial binary classification of tree species in the Lansing Woods dataset [@gerrard1969lansing; @baddeley2015spatstat] using a Matérn latent field with Bernoulli observations. Points show observed trees: \textcolor{red}{hickory (circles)} and \textcolor{blue}{other species (diamonds)}. The heatmap shows predicted probabilities, demonstrating the package's support for non-Gaussian likelihoods through efficient Gaussian approximation.\label{fig:bernoulli}](bernoulli_classification.pdf){ width=80% }
 
@@ -58,10 +59,13 @@ The rSPDE package [@bolin2025rspde] supports fractional SPDE models with non-int
 Template Model Builder (TMB) [@kristensen2016tmb] supports Laplace approximation and gradient-based inference over latent Gaussian models via C++ templates, but requires users to write C++ for their models.
 In Python, general-purpose probabilistic programming frameworks such as PyMC [@abril2023pymc] expose some GMRF primitives but lack specialized machinery.
 
-Across these packages, GMRFs appear as implementation details of a specific inference algorithm, buried in C or C++ code and not exposed as first-class objects that users can extend.
-`GaussianMarkovRandomFields.jl` instead treats GMRFs as the primary abstraction and exposes a high-level interface that is straightforward for practitioners to use, extend, and compose with existing tools.
-It combines the computational efficiency that sparse-precision Gaussian inference demands with the flexibility required for methodological research.
-The design leverages Julia's multiple dispatch to integrate directly with LinearSolve.jl, Ferrite.jl, ForwardDiff.jl [@revels2016forward], Enzyme.jl [@moses2020enzyme], and the broader SciML stack, a combination that no existing GMRF package offers.
+Across these packages, GMRFs appear as implementation details of a particular inference algorithm, buried in C or C++ code and not exposed as first-class objects that users can extend.
+`GaussianMarkovRandomFields.jl` instead treats the GMRF as the primary abstraction, exposed through a high-level interface, which enables workflows that are impractical elsewhere.
+
+Neither the observation likelihood nor the latent prior need come from a fixed catalogue: both may be ordinary Julia functions, and the sparsity of their Hessians is discovered automatically.
+A latent field whose own dynamics are nonlinear (e.g., a state-space model of the kind routinely written in C++ for TMB [@nielsen2014sam]) is therefore expressed directly, and the iterated Laplace approximation such a model requires follows from the same machinery.
+Because a GMRF is itself a distribution with automatic differentiation rules attached, it composes directly with probabilistic programming languages: gradient-based samplers such as NUTS [@hoffman2014nuts] target the latent field and its hyperparameters jointly, giving fully Bayesian inference [@ge2018turing].
+SPDE discretizations are delegated to a general finite element library [@carlsson2025ferrite], putting custom differential operators, meshes, and boundary conditions within reach; the capability underlying [@weiland2025gmrfpde].
 
 # Software Design
 
@@ -73,7 +77,7 @@ Provided models include autoregressive processes AR(p), random walks, IID, fixed
 A formula interface built on StatsModels.jl offers the familiar R-style syntax for combined models.
 
 Linear solves are delegated to LinearSolve.jl, so users can swap CHOLMOD, Pardiso, LDLt factorizations, or preconditioned conjugate gradient without touching model code.
-Automatic differentiation is provided through package extensions for ForwardDiff.jl, Zygote.jl/ChainRulesCore.jl, and Enzyme.jl, with chain rules written at the GMRF-construction level so gradients flow through composed models.
+Automatic differentiation is provided through package extensions for ForwardDiff.jl, Zygote.jl/ChainRulesCore.jl, Enzyme.jl and Mooncake.jl, with chain rules written at the GMRF-construction level so gradients flow through composed models.
 This split (abstract core, composable solver backends, AD via extensions) keeps the package's load-time cost small while preserving extensibility.
 
 # Research Impact Statement
@@ -83,6 +87,7 @@ Near-term impact is rooted in the package's scope: `GaussianMarkovRandomFields.j
 
 Integrated Nested Laplace Approximation (INLA) [@rueApproximateBayesianInference2009] and Template Model Builder (TMB) [@kristensen2016tmb], with HMC extensions such as tmbstan [@monnahan2018tmbstan], are widely used in ecology, epidemiology, and environmental statistics, but have been available only in R or as C++ templates.
 The sparse-linear-algebra, automatic-differentiation, and latent-model abstractions provided here are the prerequisite machinery for Julia implementations of these methods.
+`Latte.jl` [@weiland2026latte], a probabilistic programming language for latent Gaussian models built by the author on these abstractions, provides INLA, TMB-style Laplace approximation, and HMC-Laplace behind a model-specification syntax --- evidence that the machinery described here is sufficient for that purpose, not merely intended for it.
 Integration with Turing.jl [@ge2018turing] additionally enables full MCMC over GMRF hyperparameters, combining GMRF sub-models with arbitrary non-Gaussian components in a probabilistic program.
 
 The package targets researchers and practitioners working in spatial statistics, epidemiology, environmental science, and related fields, and can serve both as a turnkey toolkit and as a substrate for methodological development in Julia's AD- and SciML-aware ecosystem.


### PR DESCRIPTION
Sixth and final JOSS review PR, covering the paper's substantive claims.

## State of the Field

The section closed by listing the Julia packages this one integrates with, which asserts a benefit without saying what it buys anyone — as raised in #151. It now names the workflows the design enables instead:

- Likelihoods **and latent priors** are ordinary Julia functions whose Hessian sparsity is discovered automatically, so nonlinear state-space models of the kind usually written in C++ for TMB can be expressed directly.
- A GMRF is itself a distribution with AD rules attached, so it composes with probabilistic programming languages and gradient-based samplers reach the latent field and its hyperparameters together.
- SPDE discretizations are delegated to a general finite element library, putting custom differential operators, meshes and boundary conditions within reach.

## Statement of Need and Research Impact

The AD sentence named only ForwardDiff and Enzyme (#133); it now names all four backends and DifferentiationInterface. The custom-likelihood claim is attributed to Skaug and Fournier, who established AD-based Laplace approximation a decade before TMB, with TMB credited for popularising it.

Research Impact argued that this package supplies the prerequisite machinery for Julia implementations of INLA and TMB without pointing at anything built on it. It now cites Latte.jl, which provides exactly those methods on these abstractions. Authorship is stated in the text, so it reads as evidence that the abstractions suffice rather than as third-party adoption.

## References

Seven new entries: Skaug & Fournier, Nielsen & Berg, Hoffman & Gelman, Zygote, Mooncake, DifferentiationInterface, Latte.jl. Fields come from CrossRef, DataCite, and the projects' own citation metadata — Mooncake's `CITATION.cff` asks for two authors and a title neither of which I would have guessed.

Every cited key resolves, no entry is unused, no duplicates, braces balanced, file remains pure ASCII.

Latte.jl has no DOI yet, so its entry carries a URL. Adding the DOI later is a one-line change.

## Review items addressed

- #151 — Statement of Need novelty framing; State of the Field motivation
- #133 items 1, 2, 3 — AD backends named and cited

Refs openjournals/joss-reviews#10509