### PR TITLE
Support Zygote hyperparameter gradients through the workspace reuse path

### DIFF
--- a/docs/src/reference/autodiff.md
+++ b/docs/src/reference/autodiff.md
@@ -102,6 +102,14 @@ Zygote works through the package's ChainRules rules, which cover `logdetcov`,
 `logpdf` and `gaussian_approximation` for every GMRF type in the table. Each one
 uses a selected inverse rather than differentiating the sparse factorization.
 
+The workspace reuse path — `make_workspace(model; θ...)` once, then
+`model(ws; θ...)` inside the differentiated function — also works under Zygote.
+The callable carries an rrule that reruns the model's `mean` and
+`precision_matrix` construction in reverse mode while keeping the workspace
+itself (including its `update_precision!` mutation) out of the trace.
+`SeparableModel` is the exception: its Kronecker-product construction is not
+yet reverse-mode differentiable, so use ForwardDiff for separable models.
+
 `var` and `std` raise an `ArgumentError`. Their tangent needs entries of the
 covariance *outside* the precision's sparsity pattern, which selected inversion
 does not compute, so there is no cheap rule to write and one built on `selinv`

--- a/docs/src/reference/workspaces.md
+++ b/docs/src/reference/workspaces.md
@@ -182,6 +182,7 @@ CliqueTreesBackend
 - [Latent Models](@ref) — the `LatentModel` interface that factory hooks
   dispatch on.
 - [Automatic Differentiation Reference](@ref) — `WorkspaceGMRF` supports Zygote
-  rrules for `logpdf` and `gaussian_approximation`, and ForwardDiff
-  through the unconstrained constructor.
+  rrules for `logpdf`, `logdetcov`, `gaussian_approximation`, and the
+  `model(ws; θ...)` reuse path, and ForwardDiff through the unconstrained
+  constructor.
 - Tutorial: [Reusing factorizations across hyperparameters](@ref).

--- a/src/autodiff/constructors.jl
+++ b/src/autodiff/constructors.jl
@@ -38,6 +38,32 @@ function ChainRulesCore.rrule(::Type{GMRF}, μ::AbstractVector, Q::Union{Abstrac
 end
 
 """
+    ChainRulesCore.rrule(::typeof(_ensure_sparse), A::SymTridiagonal)
+
+Structural pullback for the SymTridiagonal → SparseMatrixCSC conversion used
+by latent-model precision matrices (AR1, RW1). Generic AD lacks a usable rule
+for `sparse(::SymTridiagonal)`; here the cotangent is read off directly:
+`dv̄[i] = Q̄[i,i]` and `ev̄[i] = Q̄[i,i+1] + Q̄[i+1,i]` (each `ev[i]` is written
+to both symmetric positions, so its adjoint sums both).
+"""
+function ChainRulesCore.rrule(::typeof(_ensure_sparse), A::SymTridiagonal)
+    Q = _ensure_sparse(A)
+
+    function _ensure_sparse_symtridiagonal_pullback(Q̄)
+        Q̄ = unthunk(Q̄)
+        Q̄ isa AbstractZero && return NoTangent(), ZeroTangent()
+
+        n = size(A, 1)
+        dv̄ = [Q̄[i, i] for i in 1:n]
+        ev̄ = [Q̄[i, i + 1] + Q̄[i + 1, i] for i in 1:(n - 1)]
+        Ā = Tangent{typeof(A)}(; dv = dv̄, ev = ev̄)
+        return NoTangent(), Ā
+    end
+
+    return Q, _ensure_sparse_symtridiagonal_pullback
+end
+
+"""
     ChainRulesCore.rrule(::Type{GMRF}, μ::AbstractVector, Q::Union{AbstractMatrix, LinearMaps.LinearMap})
 
 Automatic differentiation rule for GMRF constructor with default algorithm.

--- a/src/autodiff/gaussian_approximation.jl
+++ b/src/autodiff/gaussian_approximation.jl
@@ -306,6 +306,11 @@ function ChainRulesCore.rrule(
         else
             _, hess_pullback = rrule_via_ad(config, loghessian, x_star, obs_lik)
             _, x̄_from_Q, obs_lik_tangent_from_Q = hess_pullback(-Q̄)
+            # rrule_via_ad may hand back Thunks (e.g. from ChainRules' sparse
+            # A*x rule when obs_lik carries a design matrix); `collect` and
+            # `_add_namedtuples` below need materialized tangents.
+            x̄_from_Q = unthunk(x̄_from_Q)
+            obs_lik_tangent_from_Q = unthunk(obs_lik_tangent_from_Q)
         end
 
         # μ̄ path: μ_post = x*, so μ̄ flows directly to x*
@@ -319,6 +324,10 @@ function ChainRulesCore.rrule(
         base_prior = _base_gmrf(prior_gmrf)
         _, ∇_pullback = rrule_via_ad(config, ∇ₓ_neg_log_posterior, base_prior, obs_lik, x_star)
         _, base_prior_tangent, obs_lik_tangent, _ = ∇_pullback(-λ)
+        # A Thunk here would silently fail the `isa Tangent` checks downstream
+        # and drop gradient terms, so materialize defensively.
+        base_prior_tangent = unthunk(base_prior_tangent)
+        obs_lik_tangent = unthunk(obs_lik_tangent)
 
         # Add contribution from ȳ.precision to base prior tangent
         if !_is_zero_tangent(Q̄)

--- a/src/latent_models/separable.jl
+++ b/src/latent_models/separable.jl
@@ -287,7 +287,13 @@ function _component_param_keymap(model::SeparableModel, kwarg_keys)
     return keymap
 end
 
-ChainRulesCore.@non_differentiable _component_param_keymap(::SeparableModel, ::Any)
+# Hand-written rather than `@non_differentiable`: the macro also emits a
+# kwargs-forwarding `Core.kwcall` branch, which JET flags as a method error
+# because `_component_param_keymap` has no kwarg method.
+function ChainRulesCore.rrule(::typeof(_component_param_keymap), model::SeparableModel, kwarg_keys)
+    _component_param_keymap_pullback(::Any) = (NoTangent(), NoTangent(), NoTangent())
+    return _component_param_keymap(model, kwarg_keys), _component_param_keymap_pullback
+end
 
 """
     _extract_component_kwargs(model::SeparableModel, kwargs)

--- a/src/latent_models/separable.jl
+++ b/src/latent_models/separable.jl
@@ -1,6 +1,7 @@
 using LinearAlgebra
 using SparseArrays
 using LinearMaps
+using ChainRulesCore
 
 export SeparableModel
 
@@ -244,17 +245,19 @@ function constraints(model::SeparableModel; kwargs...)
 end
 
 """
-    _extract_component_kwargs(model::SeparableModel, kwargs)
+    _component_param_keymap(model::SeparableModel, kwarg_keys)
 
-Extract hyperparameters for each component from the combined kwargs.
-
-Returns a vector of NamedTuples, one per component.
+Per component, the pair `(local param names, suffixed keys in the combined
+kwargs)`, keeping only keys present in `kwarg_keys`. Pure Symbol bookkeeping —
+marked non-differentiable so that reverse-mode AD only has to trace the value
+extraction in [`_extract_component_kwargs`](@ref), not the `Dict`/`push!`
+bookkeeping here.
 """
-function _extract_component_kwargs(model::SeparableModel, kwargs)
+function _component_param_keymap(model::SeparableModel, kwarg_keys)
     # Track counts of each model name
     name_counts = Dict{Symbol, Int}()
 
-    comp_kwargs = NamedTuple[]
+    keymap = Tuple{Tuple{Vararg{Symbol}}, Tuple{Vararg{Symbol}}}[]
 
     for component in model.components
         comp_model_name = model_name(component)
@@ -264,21 +267,42 @@ function _extract_component_kwargs(model::SeparableModel, kwargs)
         count = get(name_counts, comp_model_name, 0) + 1
         name_counts[comp_model_name] = count
 
-        # Extract parameters for this component
         suffix = count == 1 ? "" : "_$count"
-        comp_kw = NamedTuple()
+        local_names = Symbol[]
+        full_keys = Symbol[]
 
         for param_name in keys(comp_params_template)
             # Look for {param}_{modelname}{suffix} in kwargs
             full_key = Symbol("$(param_name)_$(comp_model_name)$(suffix)")
 
-            if haskey(kwargs, full_key)
-                comp_kw = merge(comp_kw, NamedTuple{(param_name,)}((kwargs[full_key],)))
+            if full_key in kwarg_keys
+                push!(local_names, param_name)
+                push!(full_keys, full_key)
             end
         end
 
-        push!(comp_kwargs, comp_kw)
+        push!(keymap, (Tuple(local_names), Tuple(full_keys)))
     end
 
-    return comp_kwargs
+    return keymap
+end
+
+ChainRulesCore.@non_differentiable _component_param_keymap(::SeparableModel, ::Any)
+
+"""
+    _extract_component_kwargs(model::SeparableModel, kwargs)
+
+Extract hyperparameters for each component from the combined kwargs.
+
+Returns a vector of NamedTuples, one per component. Implemented without
+mutation on the value path so reverse-mode AD (Zygote) can differentiate
+hyperparameters through it.
+"""
+function _extract_component_kwargs(model::SeparableModel, kwargs)
+    keymap = _component_param_keymap(model, keys(kwargs))
+    # `map` (not a typed comprehension, which lowers to `setindex!`) so that
+    # Zygote can differentiate the value extraction.
+    return map(keymap) do (local_names, full_keys)
+        NamedTuple{local_names}(map(k -> kwargs[k], full_keys))
+    end
 end

--- a/src/workspace/autodiff.jl
+++ b/src/workspace/autodiff.jl
@@ -161,6 +161,11 @@ function ChainRulesCore.rrule(
         else
             _, hess_pullback = rrule_via_ad(config, loghessian, x_star, obs_lik)
             _, x_tangent_from_hess, obs_lik_tangent_from_Q̄ = hess_pullback(-Q̄)
+            # rrule_via_ad may hand back Thunks (e.g. from ChainRules' sparse
+            # A*x rule when obs_lik carries a design matrix); `collect` and
+            # `_add_namedtuples` below need materialized tangents.
+            x_tangent_from_hess = unthunk(x_tangent_from_hess)
+            obs_lik_tangent_from_Q̄ = unthunk(obs_lik_tangent_from_Q̄)
         end
 
         ensure_loaded!(posterior)
@@ -179,6 +184,10 @@ function ChainRulesCore.rrule(
             config, ∇ₓ_neg_log_posterior, base_prior, obs_lik, x_star
         )
         _, prior_tangent, obs_lik_tangent, _ = ∇_pullback(-λ)
+        # A Thunk here would silently fail the `isa Tangent` checks downstream
+        # and drop gradient terms, so materialize defensively.
+        prior_tangent = unthunk(prior_tangent)
+        obs_lik_tangent = unthunk(obs_lik_tangent)
 
         if !_is_zero_tangent(Q̄)
             prior_tangent = _workspace_add_precision_tangent(prior_tangent, prior_gmrf, Q̄)
@@ -190,6 +199,74 @@ function ChainRulesCore.rrule(
     end
 
     return posterior, workspace_ga_pullback
+end
+
+# --- rrule shield for the LatentModel-on-workspace callable ---
+
+# Positional θ-wrappers for rrule_via_ad: ChainRules treats kwargs as
+# non-differentiable, so the hyperparameters are re-exposed as a NamedTuple
+# positional argument that reverse-mode AD can produce tangents for.
+_model_mean_from_θ(model::LatentModel, θ::NamedTuple) = mean(model; θ...)
+_model_precision_from_θ(model::LatentModel, θ::NamedTuple) =
+    _ensure_sparse(precision_matrix(model; θ...))
+
+# Accumulate two tangents where either may be a zero-like tangent.
+_accum_tangent(a, b) = _is_zero_tangent(a) ? b : (_is_zero_tangent(b) ? a : a + b)
+
+"""
+    ChainRulesCore.rrule(config, ::typeof(_evaluate_with_workspace), model, ws, θ)
+
+Shield the `(model::LatentModel)(ws::GMRFWorkspace; θ...)` fast path from
+reverse-mode AD: the primal runs as-is (including the `update_precision!`
+mutation, which Zygote cannot trace), and the pullback routes the
+`WorkspaceGMRF` tangent's `mean`/`precision` components through
+`rrule_via_ad` of `mean(model; θ...)` / `precision_matrix(model; θ...)`.
+
+The workspace itself is non-differentiable state. Constraint quantities
+(`ȳ.constraints`) are ignored, matching the constrained `WorkspaceGMRF`
+constructor rrule above: the constrained-logpdf correction terms already
+arrive folded into `ȳ.mean`/`ȳ.precision`.
+
+`Q̄` may live on the workspace's (possibly obs-padded) sparsity pattern; the
+padded positions hold structural zeros of the model's precision, so the
+pullback of the model's own construction correctly ignores them.
+"""
+function ChainRulesCore.rrule(
+        config::RuleConfig{>:HasReverseMode},
+        ::typeof(_evaluate_with_workspace),
+        model::LatentModel, ws::GMRFWorkspace, θ::NamedTuple
+    )
+    gmrf = _evaluate_with_workspace(model, ws, θ)
+
+    function _evaluate_with_workspace_pullback(ȳ)
+        ȳ = unthunk(ȳ)
+        if ȳ isa AbstractZero
+            return NoTangent(), NoTangent(), NoTangent(), NoTangent()
+        end
+        μ̄ = unthunk(ȳ.mean)
+        Q̄ = unthunk(ȳ.precision)
+
+        model_tangent = NoTangent()
+        θ̄ = NoTangent()
+
+        if !_is_zero_tangent(μ̄)
+            _, mean_pb = rrule_via_ad(config, _model_mean_from_θ, model, θ)
+            _, m̄_mean, θ̄_mean = mean_pb(collect(μ̄))
+            model_tangent = _accum_tangent(model_tangent, unthunk(m̄_mean))
+            θ̄ = _accum_tangent(θ̄, unthunk(θ̄_mean))
+        end
+
+        if !_is_zero_tangent(Q̄)
+            _, prec_pb = rrule_via_ad(config, _model_precision_from_θ, model, θ)
+            _, m̄_prec, θ̄_prec = prec_pb(Q̄)
+            model_tangent = _accum_tangent(model_tangent, unthunk(m̄_prec))
+            θ̄ = _accum_tangent(θ̄, unthunk(θ̄_prec))
+        end
+
+        return NoTangent(), model_tangent, NoTangent(), θ̄
+    end
+
+    return gmrf, _evaluate_with_workspace_pullback
 end
 
 # --- Helper: add Q̄ to prior tangent for WorkspaceGMRF ---

--- a/src/workspace/latent_model_integration.jl
+++ b/src/workspace/latent_model_integration.jl
@@ -149,10 +149,18 @@ prior = model(ws; τ=2.0, ρ=0.3)  # WorkspaceGMRF, numeric-only refactorization
 ```
 """
 function (model::LatentModel)(ws::GMRFWorkspace; kwargs...)
-    μ = mean(model; kwargs...)
-    Q = precision_matrix(model; kwargs...)
+    # Delegate to a positional function so that reverse-mode AD can attach an
+    # rrule (see workspace/autodiff.jl). An rrule on this kwargs callable
+    # itself would be useless for hyperparameter gradients: ChainRules treats
+    # kwargs as non-differentiable, so Zygote would silently drop θ tangents.
+    return _evaluate_with_workspace(model, ws, values(kwargs))
+end
+
+function _evaluate_with_workspace(model::LatentModel, ws::GMRFWorkspace, θ::NamedTuple)
+    μ = mean(model; θ...)
+    Q = precision_matrix(model; θ...)
     Q_sparse = _ensure_sparse(Q)
-    constraint_info = constraints(model; kwargs...)
+    constraint_info = constraints(model; θ...)
 
     # Pad Q's values into the workspace's sparsity pattern with zeros at
     # observation-Hessian-only positions. Allows the joint-pattern workspace

--- a/test/workspace/test_workspace_autodiff.jl
+++ b/test/workspace/test_workspace_autodiff.jl
@@ -1,5 +1,5 @@
 using GaussianMarkovRandomFields
-using Distributions: logpdf, Normal, Poisson
+using Distributions: logpdf, logdetcov, Normal, Poisson
 using SparseArrays
 using LinearAlgebra
 using Random
@@ -146,9 +146,8 @@ end
     # built once outside the differentiated function so its factorization
     # survives across calls.
     #
-    # Note: ForwardDiff-only for now. Zygote on the LatentModel-callable
-    # reuse path requires an rrule on the callable itself (separate gap;
-    # tracked as future work).
+    # The Zygote counterpart (via the `_evaluate_with_workspace` rrule) is
+    # covered in the "Zygote WorkspaceGMRF reuse path" testset below.
     Random.seed!(42)
     fd_backend = AutoFiniteDiff()
 
@@ -252,5 +251,127 @@ end
         rel_error = abs_error ./ (abs.(grad_fd) .+ 1.0e-10)
         @test maximum(abs_error) < 1.0e-3
         @test maximum(rel_error) < 5.0e-2
+    end
+end
+
+@testset "Zygote WorkspaceGMRF reuse path" begin
+    # Reverse-mode counterpart of the reuse-path tests above, enabled by the
+    # rrule shield on `_evaluate_with_workspace` (the positional core of
+    # `(model::LatentModel)(ws; θ...)`). One backward sweep covers any dim(θ),
+    # which is the shape downstream hyperparameter inference runs.
+    Random.seed!(42)
+    fd_backend = AutoFiniteDiff()
+
+    @testset "Unconstrained logpdf gradient" begin
+        k = 10
+        θ = [0.5, 0.1]
+        z = randn(k)
+        model = AR1Model(k)
+        ws = make_workspace(model; τ = 1.0, ρ = 0.3)
+
+        pipeline = θ -> logpdf(model(ws; τ = exp(θ[1]), ρ = tanh(θ[2])), z)
+
+        grad_zy = DifferentiationInterface.gradient(pipeline, AutoZygote(), θ)
+        grad_fwd = DifferentiationInterface.gradient(pipeline, AutoForwardDiff(), θ)
+        grad_fd = DifferentiationInterface.gradient(pipeline, fd_backend, θ)
+
+        @test maximum(abs.(grad_zy - grad_fd)) < 1.0e-4
+        # Both AD paths are exact up to floating point; pin them together.
+        @test grad_zy ≈ grad_fwd rtol = 1.0e-8
+    end
+
+    @testset "Unconstrained gaussian_approximation gradient" begin
+        k = 8
+        θ = [0.5, 0.0]
+        y = [2, 1, 3, 0, 4, 1, 2, 3]
+        x = zeros(k)
+        model = AR1Model(k)
+        ws = make_workspace(model; τ = 1.0, ρ = 0.3)
+        obs_lik = ExponentialFamily(Poisson)(PoissonObservations(y))
+
+        function pipeline(θ)
+            prior = model(ws; τ = exp(θ[1]), ρ = tanh(θ[2]))
+            posterior = gaussian_approximation(prior, obs_lik)
+            return logpdf(posterior, x)
+        end
+
+        grad_zy = DifferentiationInterface.gradient(pipeline, AutoZygote(), θ)
+        grad_fd = DifferentiationInterface.gradient(pipeline, fd_backend, θ)
+
+        abs_error = abs.(grad_zy - grad_fd)
+        rel_error = abs_error ./ (abs.(grad_fd) .+ 1.0e-10)
+        @test maximum(abs_error) < 2.0e-2
+        @test maximum(rel_error) < 5.0e-2
+    end
+
+    @testset "Constrained RW1 logpdf gradient" begin
+        k = 10
+        z = randn(k)
+        z .-= sum(z) / k
+        model = RW1Model(k)
+        ws = make_workspace(model; τ = 1.0)
+
+        pipeline = θ -> logpdf(model(ws; τ = exp(θ[1])), z)
+
+        θ = [0.3]
+        grad_zy = DifferentiationInterface.gradient(pipeline, AutoZygote(), θ)
+        grad_fd = DifferentiationInterface.gradient(pipeline, fd_backend, θ)
+
+        abs_error = abs.(grad_zy - grad_fd)
+        rel_error = abs_error ./ (abs.(grad_fd) .+ 1.0e-10)
+        @test maximum(abs_error) < 1.0e-4
+        @test maximum(rel_error) < 1.0e-2
+    end
+
+    @testset "Sparse design matrix GA" begin
+        # Exercises the obs-padded workspace pattern inside the callable's
+        # rrule (Q̄ arrives on a strictly larger pattern than the model's Q),
+        # and the sparse-A loghessian pullback inside workspace_ga_pullback —
+        # the path where thunked cotangents from ChainRules' sparse rules can
+        # reach `collect`, guarded by the explicit `unthunk`s there.
+        n = 8
+        m_obs = 10
+        Random.seed!(123)
+        A = sprand(m_obs, n, 0.6)
+        model = AR1Model(n)
+        ltom = LinearlyTransformedObservationModel(ExponentialFamily(Normal), A)
+        y_obs = randn(m_obs)
+        obs_lik = ltom(y_obs; σ = 0.5)
+        ws = GMRFWorkspace(model, obs_lik; τ = 1.0, ρ = 0.5)
+        x_eval = 0.1 .* randn(n)
+
+        function pipeline(θ)
+            prior = model(ws; τ = exp(θ[1]), ρ = tanh(θ[2]))
+            posterior = gaussian_approximation(prior, obs_lik)
+            return logpdf(posterior, x_eval)
+        end
+
+        θ = [0.5, 0.1]
+        grad_zy = DifferentiationInterface.gradient(pipeline, AutoZygote(), θ)
+        grad_fd = DifferentiationInterface.gradient(pipeline, fd_backend, θ)
+
+        abs_error = abs.(grad_zy - grad_fd)
+        rel_error = abs_error ./ (abs.(grad_fd) .+ 1.0e-10)
+        @test maximum(abs_error) < 2.0e-2
+        @test maximum(rel_error) < 5.0e-2
+    end
+
+    @testset "logdetcov gradient" begin
+        # The Laplace marginal-likelihood objective consumes the reuse path
+        # through logdetcov as well; only the precision tangent is nonzero.
+        k = 10
+        model = AR1Model(k)
+        ws = make_workspace(model; τ = 1.0, ρ = 0.3)
+
+        pipeline = θ -> logdetcov(model(ws; τ = exp(θ[1]), ρ = tanh(θ[2])))
+
+        θ = [0.5, 0.1]
+        grad_zy = DifferentiationInterface.gradient(pipeline, AutoZygote(), θ)
+        grad_fd = DifferentiationInterface.gradient(pipeline, fd_backend, θ)
+
+        abs_error = abs.(grad_zy - grad_fd)
+        rel_error = abs_error ./ (abs.(grad_fd) .+ 1.0e-10)
+        @test maximum(abs_error) < 1.0e-4
+        @test maximum(rel_error) < 1.0e-2
     end
 end


### PR DESCRIPTION
## Summary

Reverse-mode (Zygote) hyperparameter gradients now work through the workspace reuse path: build `ws = make_workspace(model)` once, then differentiate `θ -> logpdf(model(ws; θ...), z)` — as well as `gaussian_approximation` and `logdetcov` pipelines — with a single backward sweep. This path was previously ForwardDiff-only, which made reverse mode unavailable exactly where it pays off: one sweep covers any `dim(θ)`.

## Changes

- `(model::LatentModel)(ws::GMRFWorkspace; θ...)` now delegates to a positional `_evaluate_with_workspace(model, ws, θ::NamedTuple)` that carries an rrule. The rrule keeps the primal (including the `update_precision!` mutation) out of the trace and routes the mean/precision cotangents through `rrule_via_ad` of the model's `mean` / `precision_matrix`. The delegation is load-bearing: ChainRules treats kwargs as non-differentiable, so an rrule on the kwargs callable itself would silently zero all θ gradients.
- New structural rrule for `_ensure_sparse(::SymTridiagonal)`, needed because AR1/RW1 precisions are `SymTridiagonal` and generic AD has no usable pullback for the sparse conversion.
- The `gaussian_approximation` pullbacks (workspace and non-workspace) now `unthunk` the cotangents returned by `rrule_via_ad`. Thunked cotangents — e.g. from ChainRules' sparse `A*x` rule when the likelihood carries a design matrix — crashed the `collect` on the IFT path, and worse, silently failed the `isa Tangent` checks downstream, dropping gradient terms.
- `SeparableModel`'s `_extract_component_kwargs` no longer mutates on the value path (Symbol bookkeeping moved into a non-differentiable keymap), removing the first reverse-mode blockers there. Full `SeparableModel` support still requires reverse-mode rules for its Kronecker construction; the docs point to ForwardDiff for separable models in the meantime.

## Tests

New "Zygote WorkspaceGMRF reuse path" testset covering AR1 `logpdf` (additionally pinned against ForwardDiff at `rtol = 1e-8`), Poisson `gaussian_approximation`, constrained RW1, a sparse design-matrix GA exercising the obs-padded workspace pattern, and `logdetcov` — all validated against finite differences.