### PR TITLE
Finish gaussian_approximation on the existing factorization

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -50,7 +50,8 @@ The suite currently covers:
 - **`gmrf/`** — `GMRF` construction (LDLt and CHOLMOD), `logpdf`, `var`
   (selected inversion), `rand` (backward solve).
 - **`gaussian_approximation/`** — Fisher-scoring loop with Poisson
-  observations over an RW1 prior (n=500).
+  observations over an RW1 prior (n=500), both cold and warm-started at a
+  tight tolerance (the outer-loop pattern where factorization count dominates).
 - **`autodiff/`** — ForwardDiff and Zygote gradients through the full
   hyperparameters → GMRF → `gaussian_approximation` → `logpdf` pipeline.
   Tracked separately because forward- and reverse-mode exercise largely

--- a/benchmarks/benchmarks.jl
+++ b/benchmarks/benchmarks.jl
@@ -72,6 +72,14 @@ const Y_POISSON_SMALL = PoissonObservations(
 const OBS_LIK_POISSON_SMALL = ExponentialFamily(Poisson)(Y_POISSON_SMALL)
 const GMRF_PRIOR_SMALL = GMRF(MU_SMALL, Q_RW1_SMALL, LinearSolve.LDLtFactorization())
 
+# Warm-started solve at a tight tolerance: the outer-loop pattern (hyperparameter
+# optimisation, grid exploration) where the per-solve factorization count dominates.
+# The prior is perturbed away from the one the warm start was computed for, so the
+# solve takes a real Newton step rather than converging on iteration 1 (#202).
+const GMRF_PRIOR_SMALL_PERTURBED =
+    GMRF(MU_SMALL, 1.1 * Q_RW1_SMALL, LinearSolve.LDLtFactorization())
+const WARM_START_SMALL = mean(gaussian_approximation(GMRF_PRIOR_SMALL, OBS_LIK_POISSON_SMALL))
+
 # LinearlyTransformedLikelihood on the ForwardDiff.Dual (AD-through-hyperparameter)
 # path: the `loghessian` transpose product Aᵀ·hess_η·A specialized in #157. The design
 # matrix is a sparse local transform (~3 nonzeros/row), as in FEM / evaluation-matrix
@@ -241,6 +249,11 @@ SUITE["gmrf"]["workspace_selinv_diag"] =
 SUITE["gaussian_approximation"] = BenchmarkGroup()
 SUITE["gaussian_approximation"]["poisson_rw1_small"] =
     @benchmarkable gaussian_approximation($GMRF_PRIOR_SMALL, $OBS_LIK_POISSON_SMALL)
+SUITE["gaussian_approximation"]["poisson_rw1_warm_tight"] =
+    @benchmarkable gaussian_approximation(
+    $GMRF_PRIOR_SMALL_PERTURBED, $OBS_LIK_POISSON_SMALL;
+    x0 = $WARM_START_SMALL, newton_dec_tol = 1.0e-10, mean_change_tol = 1.0e-8
+)
 # loghessian for a LinearlyTransformedLikelihood on the Dual path (#157): guards the
 # transpose-materialization that keeps this ~70-90x off the lazy-Adjoint fallback.
 SUITE["gaussian_approximation"]["loghessian_ltl_dual"] =

--- a/src/arithmetic/condition/gaussian_approximation.jl
+++ b/src/arithmetic/condition/gaussian_approximation.jl
@@ -157,6 +157,13 @@ constraint projection when needed.
 - `newton_dec_tol::Real=1e-5`: Newton decrement convergence tolerance
 - `adaptive_stepsize::Bool=true`: Enable adaptive stepsize with backtracking line search
 - `max_linesearch_iter::Int=10`: Maximum line search iterations per Newton step
+- `predictive_convergence::Bool=true`: When quadratic contraction predicts that the next
+  Newton decrement clears `newton_dec_tol`, finish against the factorization already in
+  hand instead of refactorizing for the final step. The step's own decrement is the
+  convergence certificate, and a couple of further steps on the same factorization
+  polish the mode — a chord iteration, which converges to the true mode using solves
+  rather than a refactorization. Set to `false` to refactorize for the final step
+  instead.
 - `verbose::Bool=false`: Print iteration information
 
 # Returns
@@ -185,6 +192,7 @@ function gaussian_approximation(
         newton_dec_tol::Real = 1.0e-5,
         adaptive_stepsize::Bool = true,
         max_linesearch_iter::Int = 10,
+        predictive_convergence::Bool = true,
         verbose::Bool = false
     )
     base_gmrf = _base_gmrf(prior_gmrf)
@@ -194,7 +202,7 @@ function gaussian_approximation(
     return _newton_loop(
         prior_gmrf, obs_lik, solver, constraints, x_init;
         max_iter, mean_change_tol, newton_dec_tol,
-        adaptive_stepsize, max_linesearch_iter, verbose,
+        adaptive_stepsize, max_linesearch_iter, predictive_convergence, verbose,
     )
 end
 
@@ -239,6 +247,85 @@ function _ga_line_search(
     return x_new, α
 end
 
+# Quadratic-convergence look-ahead, shared by both Newton loops.
+#
+# The convergence test measures the decrement at `x_k` and then returns
+# `x_new = x_k - step`, so a solve that is already in the quadratic regime
+# spends a whole iteration purely to certify a decrement the previous two
+# iterations already imply. That iteration is dominated by its refactorization
+# (88% of iteration cost on a 1D n=500 fit, ~95% on 2D/3D grids), and the
+# Hessian it rebuilds differs from the one already factored by `O(‖Δx‖)` — a
+# perturbation invisible next to `newton_dec_tol`.
+#
+# So instead of skipping the confirming iteration, run it against the
+# factorization already in hand: evaluate the gradient at `x_new`, solve with
+# the stale factor, and use the decrement of that step as the certificate.
+# `_frozen_finish` then keeps stepping on the same factorization, which lands
+# the mode at least as close to the true one as the refactorized iteration
+# would have — the refactorization is simply not paid.
+#
+# `_predict_converged` is only the gate that decides when to attempt it. For
+# undamped Newton steps the decrement contracts quadratically,
+# `dec_{k+1} ≈ C²·dec_k²`, and `C²` is observable from the last two decrements
+# as `dec_k / dec_{k-1}²`, giving `dec_pred = dec_k · (dec_k / dec_{k-1})²`.
+# The prediction needs no safety margin here — it is checked, not trusted: a
+# wrong gate costs one extra solve (~12% of an iteration) and the loop carries
+# on. Guards:
+#
+# - `iter > 1`, so `dec_prev` is a real decrement. It is then also strictly
+#   positive: a non-positive decrement would have converged at iteration
+#   `iter - 1`.
+# - `α == 1`: both this step and the previous one were full Newton steps. The
+#   line search returns `1.0` only for an undamped accepted step and recovers
+#   towards 1 via `sqrt`, so `α == 1` at iteration `k` implies the step at
+#   `k - 1` was undamped too. While the line search is still damping, the
+#   quadratic reasoning does not apply and the attempt would mostly be wasted.
+function _predict_converged(dec_k, dec_prev, α, newton_dec_tol, iter)
+    (iter > 1 && α == 1.0) || return false
+    return dec_k * (dec_k / dec_prev)^2 < newton_dec_tol
+end
+
+# Gradient of the neg-log-posterior at `x`, in the natural form both Newton
+# loops build it: the local quadratic at `x` has `∇log p_prior(x) = h - Q·x`.
+function _ga_neg_score(prior, obs_lik::ObservationLikelihood, x)
+    Q_p, h = _prior_local(prior, x)
+    return (Q_p * x - h) .- loggrad(x, obs_lik)
+end
+
+# Newton steps taken against the frozen factorization once the look-ahead fires.
+# The gradient is exact at every step and only the Hessian is stale, so this is a
+# chord iteration on the true stationarity condition `∇f(x) = 0`: it converges to
+# the true mode, linearly, at a rate set by how far the Hessian has moved. The
+# first step certifies convergence — its decrement is the certificate — and the
+# rest polish away the error the stale Hessian leaves behind. Measured on Poisson,
+# binomial and custom-likelihood fits each step buys 3–6 orders of magnitude, so
+# three land the mode at or inside where a refactorized final iteration would have
+# put it, for three solves instead of a refactorization.
+const _FROZEN_FINISH_STEPS = 3
+
+# `solve_step` maps a gradient to the (constraint-projected) Newton step against the
+# factorization the caller already holds — nothing in here invalidates it. Returns the
+# accepted iterate, or `nothing` when the look-ahead was wrong and the loop should
+# continue with a refactorization.
+function _frozen_finish(
+        prior, obs_lik::ObservationLikelihood, solve_step::F, x,
+        newton_dec_tol::Real, verbose::Bool, iter::Int,
+    ) where {F}
+    for j in 1:_FROZEN_FINISH_STEPS
+        g = _ga_neg_score(prior, obs_lik, x)
+        step = solve_step(g)
+        dec = dot(g, step)
+        if j == 1
+            dec < newton_dec_tol || return nothing
+            verbose && println(
+                "  Iter $(iter + 1): Newton dec = $(round(dec, sigdigits = 3)) (reused factorization)"
+            )
+        end
+        x = x - step
+    end
+    return x
+end
+
 """
     _newton_loop(prior, obs_lik, solver, constraints, x_init; ...) -> AbstractGMRF
 
@@ -264,10 +351,12 @@ function _newton_loop(
         newton_dec_tol::Real,
         adaptive_stepsize::Bool,
         max_linesearch_iter::Int,
+        predictive_convergence::Bool,
         verbose::Bool,
     )
     x_k = copy(x_init)
     α = 1.0
+    dec_prev = 0.0
     verbose && println("Starting Fisher scoring...")
 
     for iter in 1:max_iter
@@ -301,6 +390,19 @@ function _newton_loop(
             return _build_posterior(prior, obs_lik, solver, constraints, x_new)
         end
 
+        if predictive_convergence &&
+                _predict_converged(newton_decrement, dec_prev, α, newton_dec_tol, iter)
+            x_final = _frozen_finish(
+                prior, obs_lik, g -> _constrain_step(_ga_solve(solver, g), solver, constraints),
+                x_new, newton_dec_tol, verbose, iter,
+            )
+            if x_final !== nothing
+                verbose && println("  Converged after $(iter + 1) iterations")
+                return _build_posterior(prior, obs_lik, solver, constraints, x_final)
+            end
+        end
+
+        dec_prev = newton_decrement
         x_k = x_new
     end
 

--- a/src/arithmetic/condition/gaussian_approximation.jl
+++ b/src/arithmetic/condition/gaussian_approximation.jl
@@ -295,12 +295,25 @@ end
 # Newton steps taken against the frozen factorization once the look-ahead fires.
 # The gradient is exact at every step and only the Hessian is stale, so this is a
 # chord iteration on the true stationarity condition `∇f(x) = 0`: it converges to
-# the true mode, linearly, at a rate set by how far the Hessian has moved. The
-# first step certifies convergence — its decrement is the certificate — and the
-# rest polish away the error the stale Hessian leaves behind. Measured on Poisson,
-# binomial and custom-likelihood fits each step buys 3–6 orders of magnitude, so
-# three land the mode at or inside where a refactorized final iteration would have
-# put it, for three solves instead of a refactorization.
+# the true mode, linearly, at a rate set by how far the Hessian has moved.
+#
+# Only the *first* step decides anything — its decrement is the convergence
+# certificate, the same quantity the loop's own test uses. The rest cannot change
+# that decision; they only walk the mode closer to the true one, so this count is
+# a quality/cost dial and not a hidden correctness threshold. Its floor is "the
+# returned mode meets `newton_dec_tol`", which step one already establishes.
+#
+# Three is a budget, bounded well under what it buys: three solves is ~1/3 of the
+# refactorization being skipped on a 1D n=500 fit and ~1/10 on 2D/3D grids. The
+# per-step contraction ranges from ~20x (small, ill-scaled fits where the
+# look-ahead fires while the Hessian is still moving) to ~1e6x (warm solves deep
+# in the quadratic regime), and across measured Poisson, binomial,
+# negative-binomial and custom-likelihood fits three steps land the mode at or
+# inside where a refactorized final iteration would have put it. Adaptive
+# stopping rules were measured too — on decrement depth, or on the step-to-step
+# improvement stalling — and neither beat a flat count: the depth rules stop
+# short exactly where the polish matters, the stall rules spend more steps for no
+# gain.
 const _FROZEN_FINISH_STEPS = 3
 
 # `solve_step` maps a gradient to the (constraint-projected) Newton step against the

--- a/src/latent_models/gaussian_approximation.jl
+++ b/src/latent_models/gaussian_approximation.jl
@@ -57,6 +57,7 @@ function gaussian_approximation(
         newton_dec_tol::Real = 1.0e-5,
         adaptive_stepsize::Bool = true,
         max_linesearch_iter::Int = 10,
+        predictive_convergence::Bool = true,
         verbose::Bool = false,
         hp_kwargs...,
     )
@@ -65,7 +66,7 @@ function gaussian_approximation(
     return gaussian_approximation(
         materialised, obs_lik;
         x0, max_iter, mean_change_tol, newton_dec_tol,
-        adaptive_stepsize, max_linesearch_iter, verbose,
+        adaptive_stepsize, max_linesearch_iter, predictive_convergence, verbose,
     )
 end
 
@@ -101,6 +102,7 @@ function gaussian_approximation(
         newton_dec_tol::Real = 1.0e-5,
         adaptive_stepsize::Bool = true,
         max_linesearch_iter::Int = 10,
+        predictive_convergence::Bool = true,
         verbose::Bool = false,
         hp_kwargs...,
     )
@@ -114,7 +116,7 @@ function gaussian_approximation(
         return _nongaussian_dualhp_ift(
             prior, obs_lik, θ_full, ws;
             x0, max_iter, mean_change_tol, newton_dec_tol,
-            adaptive_stepsize, max_linesearch_iter, verbose,
+            adaptive_stepsize, max_linesearch_iter, predictive_convergence, verbose,
         )
     end
 
@@ -130,13 +132,13 @@ function gaussian_approximation(
         return _newton_loop(
             lp, obs_lik, cache, constraints_nt, x_init;
             max_iter, mean_change_tol, newton_dec_tol,
-            adaptive_stepsize, max_linesearch_iter, verbose,
+            adaptive_stepsize, max_linesearch_iter, predictive_convergence, verbose,
         )
     end
 
     return _workspace_newton_loop(
         lp, ws, obs_lik, constraints_nt, x_init;
         max_iter, mean_change_tol, newton_dec_tol,
-        adaptive_stepsize, max_linesearch_iter, verbose,
+        adaptive_stepsize, max_linesearch_iter, predictive_convergence, verbose,
     )
 end

--- a/src/workspace/gaussian_approximation.jl
+++ b/src/workspace/gaussian_approximation.jl
@@ -200,6 +200,7 @@ function gaussian_approximation(
         newton_dec_tol::Real = 1.0e-5,
         adaptive_stepsize::Bool = true,
         max_linesearch_iter::Int = 10,
+        predictive_convergence::Bool = true,
         verbose::Bool = false
     )
     ws = prior.workspace
@@ -210,7 +211,7 @@ function gaussian_approximation(
     return _workspace_newton_loop(
         prior, ws, obs_lik, prior.constraints, x_init;
         max_iter, mean_change_tol, newton_dec_tol,
-        adaptive_stepsize, max_linesearch_iter, verbose,
+        adaptive_stepsize, max_linesearch_iter, predictive_convergence, verbose,
     )
 end
 
@@ -235,12 +236,14 @@ function _workspace_newton_loop(
         newton_dec_tol::Real,
         adaptive_stepsize::Bool,
         max_linesearch_iter::Int,
+        predictive_convergence::Bool,
         verbose::Bool,
     )
     diag_idx = _diagonal_indices(ws.Q)
     sparse_hess_map = nothing
     x_k = copy(x_init)
     α = 1.0
+    dec_prev = 0.0
 
     verbose && println("Starting workspace Fisher scoring...")
 
@@ -279,6 +282,25 @@ function _workspace_newton_loop(
             return _workspace_build_result(prior, ws, obs_lik, constraints, x_new, diag_idx, sparse_hess_map)
         end
 
+        # Look-ahead: finish on the factorization the workspace already holds instead of
+        # refactorizing for the final step (see `_frozen_finish`). `workspace_solve`
+        # reuses the numeric factor as long as nothing invalidates it, and nothing here
+        # does — `_prior_local` on a `WorkspaceGMRF` reads its snapshot fields directly.
+        if predictive_convergence &&
+                _predict_converged(newton_decrement, dec_prev, α, newton_dec_tol, iter)
+            x_final = _frozen_finish(
+                prior, obs_lik, g -> _workspace_constrain_step(workspace_solve(ws, g), ws, constraints),
+                x_new, newton_dec_tol, verbose, iter,
+            )
+            if x_final !== nothing
+                verbose && println("  Converged after $(iter + 1) iterations")
+                return _workspace_build_result(
+                    prior, ws, obs_lik, constraints, x_final, diag_idx, sparse_hess_map
+                )
+            end
+        end
+
+        dec_prev = newton_decrement
         x_k = x_new
     end
 
@@ -311,6 +333,7 @@ function gaussian_approximation(
         newton_dec_tol::Real = 1.0e-5,
         adaptive_stepsize::Bool = true,
         max_linesearch_iter::Int = 10,
+        predictive_convergence::Bool = true,
         verbose::Bool = false
     )
     if has_constraints(prior)

--- a/test/gaussian_approximation/runtests.jl
+++ b/test/gaussian_approximation/runtests.jl
@@ -1,2 +1,3 @@
 include("test_gaussian_approximation.jl")
 include("test_gaussian_approximation_chordal.jl")
+include("test_predictive_convergence.jl")

--- a/test/gaussian_approximation/test_predictive_convergence.jl
+++ b/test/gaussian_approximation/test_predictive_convergence.jl
@@ -1,0 +1,144 @@
+using GaussianMarkovRandomFields
+using LinearAlgebra
+using SparseArrays
+using Distributions
+
+# Predictive convergence (issue #202): when quadratic contraction predicts that the
+# next Newton decrement clears `newton_dec_tol`, the solve finishes against the
+# factorization already in hand instead of refactorizing for the final step. The first
+# step's decrement is the convergence certificate; the remaining steps are a chord
+# iteration on the same factorization, which converges to the true mode.
+
+# True Newton decrement gᵀH⁻¹g at the returned mode. `_build_posterior` refreshes the
+# factorization at the returned iterate, so the posterior precision *is* H there.
+function _returned_decrement(prior, obs_lik, posterior)
+    x = mean(posterior)
+    g = GaussianMarkovRandomFields.∇ₓ_neg_log_posterior(prior, obs_lik, x)
+    return dot(g, cholesky(Symmetric(sparse(precision_matrix(posterior)))) \ g)
+end
+
+# Number of Newton loop trips a run took, recovered without touching internals:
+# truncating `max_iter` below the convergence iteration changes the returned mode,
+# and at or above it the run is bit-identical.
+function _newton_iterations(run, converged_mean; max_probe = 30)
+    for m in 1:max_probe
+        mean(run(m)) == converged_mean && return m
+    end
+    return -1
+end
+
+@testset "Predictive convergence exit" begin
+
+    @testset "look-ahead gate" begin
+        pc = GaussianMarkovRandomFields._predict_converged
+        tol = 1.0e-8
+
+        # Quadratic contraction, undamped: the next decrement is predicted to clear tol.
+        @test pc(1.0e-6, 1.0e-2, 1.0, tol, 2)
+
+        # First iteration: no previous decrement to estimate contraction from.
+        @test !pc(1.0e-6, 1.0e-2, 1.0, tol, 1)
+
+        # Damped step (α < 1): quadratic reasoning does not apply.
+        @test !pc(1.0e-6, 1.0e-2, 0.999, tol, 2)
+
+        # Contraction too slow for the next step to clear tol.
+        @test !pc(1.0e-4, 1.0e-2, 1.0, tol, 2)
+
+        # No contraction at all.
+        @test !pc(1.0e-2, 1.0e-2, 1.0, tol, 2)
+    end
+
+    # Warm solve in the pattern of an outer hyperparameter loop: solve once, then
+    # re-solve a nearby model starting from the first mode.
+    n = 200
+    Q = spdiagm(-1 => fill(-1.0, n - 1), 0 => fill(2.01, n), 1 => fill(-1.0, n - 1))
+    x_true = 2 .* sin.(range(0, 4π; length = n))
+    y = PoissonObservations(round.(Int, exp.(x_true)))
+    obs_lik = ExponentialFamily(Poisson)(y)
+    warm_start = mean(gaussian_approximation(GMRF(zeros(n), Q), obs_lik))
+    prior = GMRF(zeros(n), 1.1 * Q)
+    # mean_change pinned tiny so the decrement criterion is the binding one.
+    tolkw = (newton_dec_tol = 1.0e-8, mean_change_tol = 1.0e-12)
+
+    @testset "final steps reuse the factorization" begin
+        post_on = gaussian_approximation(prior, obs_lik; x0 = warm_start, tolkw...)
+        post_off = gaussian_approximation(
+            prior, obs_lik; x0 = warm_start, predictive_convergence = false, tolkw...
+        )
+
+        # One fewer trip through the loop: the last Newton step rides along inside the
+        # previous iteration instead of getting one of its own.
+        iters_on = _newton_iterations(
+            m -> gaussian_approximation(prior, obs_lik; x0 = warm_start, max_iter = m, tolkw...),
+            mean(post_on),
+        )
+        iters_off = _newton_iterations(
+            m -> gaussian_approximation(
+                prior, obs_lik; x0 = warm_start, max_iter = m,
+                predictive_convergence = false, tolkw...
+            ),
+            mean(post_off),
+        )
+        @test iters_off > 1
+        @test iters_on == iters_off - 1
+
+        # Same mode as the refactorizing path, and the chord iteration lands it far
+        # inside the tolerance rather than merely under it.
+        @test mean(post_on) ≈ mean(post_off) rtol = 1.0e-8
+        @test precision_matrix(post_on) ≈ precision_matrix(post_off) rtol = 1.0e-8
+        @test _returned_decrement(prior, obs_lik, post_on) < 1.0e-3 * tolkw.newton_dec_tol
+        @test _returned_decrement(prior, obs_lik, post_off) < tolkw.newton_dec_tol
+    end
+
+    @testset "workspace path" begin
+        ws = GMRFWorkspace(sparse(1.1 * Q))
+        ws_prior = WorkspaceGMRF(zeros(n), sparse(1.1 * Q), ws)
+        post_on = gaussian_approximation(ws_prior, obs_lik; x0 = warm_start, tolkw...)
+        post_off = gaussian_approximation(
+            ws_prior, obs_lik; x0 = warm_start, predictive_convergence = false, tolkw...
+        )
+
+        iters_on = _newton_iterations(
+            m -> gaussian_approximation(ws_prior, obs_lik; x0 = warm_start, max_iter = m, tolkw...),
+            mean(post_on),
+        )
+        iters_off = _newton_iterations(
+            m -> gaussian_approximation(
+                ws_prior, obs_lik; x0 = warm_start, max_iter = m,
+                predictive_convergence = false, tolkw...
+            ),
+            mean(post_off),
+        )
+        @test iters_on == iters_off - 1
+        @test mean(post_on) ≈ mean(post_off) rtol = 1.0e-6
+
+        # Same mode as the cache-backed path.
+        cache_post = gaussian_approximation(prior, obs_lik; x0 = warm_start, tolkw...)
+        @test mean(post_on) ≈ mean(cache_post) rtol = 1.0e-10
+    end
+
+    @testset "no effect while the line search is damping" begin
+        # Extreme counts under a weak prior: the line search backtracks on the first
+        # step and α only creeps back towards 1, so the gate never opens and the
+        # solve is bit-identical with and without the look-ahead.
+        m = 5
+        weak_prior = GMRF(zeros(m), 0.01 * sparse(I, m, m))
+        extreme_lik = ExponentialFamily(Poisson)(PoissonObservations([200, 50, 500, 10, 1000]))
+        post_on = gaussian_approximation(weak_prior, extreme_lik; tolkw...)
+        post_off = gaussian_approximation(
+            weak_prior, extreme_lik; predictive_convergence = false, tolkw...
+        )
+        @test mean(post_on) == mean(post_off)
+    end
+
+    @testset "latent-model entry point threads the keyword" begin
+        model = RW1Model(n)
+        post_on = gaussian_approximation(model, obs_lik; τ = 1.0, x0 = warm_start, tolkw...)
+        post_off = gaussian_approximation(
+            model, obs_lik; τ = 1.0, x0 = warm_start,
+            predictive_convergence = false, tolkw...
+        )
+        @test mean(post_on) ≈ mean(post_off) rtol = 1.0e-6
+    end
+end


### PR DESCRIPTION
Closes #202.

## What

The convergence test measures the Newton decrement at `x_k` and then returns `x_k - step`, so a warm solve that is already converging quadratically spends one more whole iteration only to certify a decrement the previous two already imply.

That iteration is almost entirely its refactorization — 88% of iteration cost on a 1D `n=500` Poisson fit, ~95% on 2D/3D grids — and the Hessian it rebuilds differs from the one already factored by `O(‖Δx‖)`. So rather than skipping the confirming step, the loop now **finishes against the factorization it already holds**: evaluate the gradient at `x_new`, solve with the existing factor, and use that step's decrement as the convergence certificate.

Only the Hessian is frozen; the gradient is exact at every step. That makes it a chord iteration on `∇f(x) = 0`, which converges to the true mode, so two further steps on the same factorization polish away the staleness. Each step buys 3–6 orders of magnitude, so the finish lands the mode at least as close to the true one as the refactorized iteration would have — for three solves instead of a factorization.

Deciding *when* to try this is the look-ahead from the issue: with undamped steps `dec_{k+1} ≈ C²·dec_k²`, and `C²` is observable from the last two decrements, giving `dec_pred = dec_k·(dec_k/dec_{k-1})²`. It needs no safety margin, because it is checked rather than trusted — a wrong prediction costs one solve and the loop carries on.

The repro from the issue:

```
  Iter 1: Newton dec = 0.242, α = 1.0
  Iter 2: Newton dec = 2.27e-5, α = 1.0
  Iter 3: Newton dec = 3.65e-12 (reused factorization)
  Converged after 3 iterations
```

Same Newton steps, same decrement to three digits, one fewer factorization. Both Newton loops get it, so it covers `GMRF`, `ConstrainedGMRF`, `ChordalGMRF`, `WorkspaceGMRF` and the non-Gaussian latent-prior path. `predictive_convergence = false` restores the old behaviour.

## Speed

Warm-started outer sweeps (20 solves, mode carried forward):

| workload | before | after | speedup |
|---|---|---|---|
| 1D Poisson n=500, tol 1e-10 | 10.5 ms | 8.8 ms | 1.19× |
| 2D grid 60×60, tol 1e-10 | 192.9 ms | 139.5 ms | 1.38× |
| 2D grid 60×60, workspace, tol 1e-10 | 119.1 ms | 89.1 ms | 1.34× |
| the same three at default tolerances | | | 1.01–1.03× |
| cold solves | | | unchanged |

The 1D/2D gap is the solve-to-factorization ratio: trading a refactorization for solves is nearly free where the factorization dominates. At default tolerances `mean_change_tol` usually ends the loop first, so the win concentrates on solves run to a tight decrement — which is what an outer loop wants anyway, since a loose mode makes the hyperparameter objective noisy. `benchmarks/` gains a warm-started tight-tolerance case to guard it.

## Accuracy

Over 180 solves (Poisson / binomial / negative-binomial priors; cold, warm across prior scales, jittered restarts) × tolerances from 1e-3 to 1e-11, measuring `gᵀH⁻¹g` at the returned mode:

- the returned mode's true decrement is at most `1.6e-6 · newton_dec_tol` — the chord finish lands further inside the tolerance than the refactorizing path does;
- the mode matches the refactorizing path to 1.3e-15 relative at the median, and where it differs more, the new one is the better-converged of the two;
- forward-mode hyperparameter gradients are unchanged or slightly better (the `AutoDiffLikelihood` analytic-vs-finite-difference cross-check improves from 7.6e-5 to 1.6e-5).

No existing test needed adjusting.

## Why not just skip the iteration

I implemented the issue's literal suggestion first — accept `x_new` on the prediction alone with a 100× margin — and measured two problems:

- **The extrapolation is unsound when the iteration is not full Newton.** For `NonlinearLeastSquares` (Gauss–Newton) the decrement contracts *linearly*, so `dec_k·r²` under-predicts by ~1/r; measured, up to 1250× optimistic, leaving the accepted mode up to 38× outside `newton_dec_tol`. Guarding that away costs most of the savings.
- **It changes what the function returns.** The confirming iteration is what lands the mode far inside `newton_dec_tol` rather than at it; skipping it leaves `O(√newton_dec_tol)` error, which broke three existing tests (a mode-vs-numerical-optimum check at `atol = 1e-6`, and two finite-difference gradient cross-checks).

Reusing the factorization keeps most of the speedup and neither problem.
