### PR TITLE
Recover full Newton steps immediately in the GA line search

### DIFF
--- a/benchmarks/benchmarks.jl
+++ b/benchmarks/benchmarks.jl
@@ -72,12 +72,13 @@ const Y_POISSON_SMALL = PoissonObservations(
 const OBS_LIK_POISSON_SMALL = ExponentialFamily(Poisson)(Y_POISSON_SMALL)
 const GMRF_PRIOR_SMALL = GMRF(MU_SMALL, Q_RW1_SMALL, LinearSolve.LDLtFactorization())
 
-# Cold-start Poisson problem whose first Newton step overshoots: the latent field has
-# a large amplitude, so the line search backtracks on iteration 1 and the persistent
+# Cold-start Poisson problem whose first Newton step overshoots hard: the latent field
+# has a large amplitude, so the line search backtracks on iteration 1 and the persistent
 # step scale α drops to 0.1. Guards the step-recovery policy (#203) — under the old
 # `sqrt(α)` recovery this needs ~10 fully factorized Newton iterations, most of them
-# needlessly damped. The mild `poisson_rw1_small` problem above never backtracks, so
-# it cannot see this.
+# needlessly damped. `poisson_rw1_small` above backtracks too, but it is a milder
+# problem on the SymTridiagonal/LDLt path; this one damps harder and runs the sparse
+# CHOLMOD backend.
 const POISSON_LATENT_COLD = 3.0 .* sin.(range(0, 6π; length = N_SMALL))
 const OBS_LIK_POISSON_COLD = ExponentialFamily(Poisson)(
     PoissonObservations(rand.(MersenneTwister(2), Poisson.(exp.(POISSON_LATENT_COLD))))

--- a/benchmarks/benchmarks.jl
+++ b/benchmarks/benchmarks.jl
@@ -72,6 +72,21 @@ const Y_POISSON_SMALL = PoissonObservations(
 const OBS_LIK_POISSON_SMALL = ExponentialFamily(Poisson)(Y_POISSON_SMALL)
 const GMRF_PRIOR_SMALL = GMRF(MU_SMALL, Q_RW1_SMALL, LinearSolve.LDLtFactorization())
 
+# Cold-start Poisson problem whose first Newton step overshoots: the latent field has
+# a large amplitude, so the line search backtracks on iteration 1 and the persistent
+# step scale α drops to 0.1. Guards the step-recovery policy (#203) — under the old
+# `sqrt(α)` recovery this needs ~10 fully factorized Newton iterations, most of them
+# needlessly damped. The mild `poisson_rw1_small` problem above never backtracks, so
+# it cannot see this.
+const POISSON_LATENT_COLD = 3.0 .* sin.(range(0, 6π; length = N_SMALL))
+const OBS_LIK_POISSON_COLD = ExponentialFamily(Poisson)(
+    PoissonObservations(rand.(MersenneTwister(2), Poisson.(exp.(POISSON_LATENT_COLD))))
+)
+const Q_AR1_COLD = spdiagm(
+    -1 => fill(-1.0, N_SMALL - 1), 0 => fill(2.01, N_SMALL), 1 => fill(-1.0, N_SMALL - 1)
+)
+const GMRF_PRIOR_COLD = GMRF(MU_SMALL, Q_AR1_COLD)
+
 # LinearlyTransformedLikelihood on the ForwardDiff.Dual (AD-through-hyperparameter)
 # path: the `loghessian` transpose product Aᵀ·hess_η·A specialized in #157. The design
 # matrix is a sparse local transform (~3 nonzeros/row), as in FEM / evaluation-matrix
@@ -241,6 +256,10 @@ SUITE["gmrf"]["workspace_selinv_diag"] =
 SUITE["gaussian_approximation"] = BenchmarkGroup()
 SUITE["gaussian_approximation"]["poisson_rw1_small"] =
     @benchmarkable gaussian_approximation($GMRF_PRIOR_SMALL, $OBS_LIK_POISSON_SMALL)
+# Cold start that backtracks on iteration 1: tracks how quickly the line search
+# recovers the full Newton step (#203), i.e. the number of damped factorizations.
+SUITE["gaussian_approximation"]["poisson_cold_start"] =
+    @benchmarkable gaussian_approximation($GMRF_PRIOR_COLD, $OBS_LIK_POISSON_COLD)
 # loghessian for a LinearlyTransformedLikelihood on the Dual path (#157): guards the
 # transpose-materialization that keeps this ~70-90x off the lazy-Adjoint fallback.
 SUITE["gaussian_approximation"]["loghessian_ltl_dual"] =

--- a/docs/src/reference/gaussian_approximation.md
+++ b/docs/src/reference/gaussian_approximation.md
@@ -107,6 +107,29 @@ The package includes significant performance optimizations:
 - **MetaGMRF support** preserves metadata through the approximation process
 - **Type consistency** ensures optimal memory usage and dispatch efficiency
 
+### Step-size line search
+
+Each Newton iteration costs a factorization plus a solve; the backtracking line search that
+guards it costs only merit evaluations (`½xᵀQx - hᵀx` for the prior side plus `loglik`, never
+a `logpdf`, hence never a factorization). The step scale `α` persists across iterations —
+a rejected step shrinks it by 10× — so the policy that grows it back decides how many
+*damped* (but fully factorized) iterations a single early backtrack costs:
+
+- `step_recovery = :retry_full` (default) probes the undamped step `α = 1` at the start of
+  every iteration and falls back to the persistent damped scale only if that step is
+  rejected. Cost: one extra merit evaluation on the iterations where the full step is not
+  yet acceptable. Benefit: full Newton steps resume the moment the iterate reaches the basin
+  where they are accepted.
+- `step_recovery = :sqrt` grows `α` as `sqrt(α)` per accepted step. A backtrack down to
+  `α = 0.1` then takes ~8–10 further iterations to recover, each of them a needlessly damped
+  factorize + solve. Use this if the merit is not convex along the Newton direction (e.g. a
+  [`NonGaussianLatentPrior`](@ref) whose log-density is not concave) and the slow recovery is
+  wanted as an oscillation guard.
+
+For canonical-link exponential families the merit is convex along the Newton direction, so
+the default is both faster and — because it stops the mean-change convergence test from
+firing on an artificially damped step — at least as accurate.
+
 ## Iterated linearisation for non-Gaussian priors
 
 `gaussian_approximation` also accepts an [`AbstractLatentPrior`](@ref) directly as the prior side, which is useful in two situations:

--- a/docs/src/reference/gaussian_approximation.md
+++ b/docs/src/reference/gaussian_approximation.md
@@ -130,6 +130,16 @@ For canonical-link exponential families the merit is convex along the Newton dir
 the default is both faster and — because it stops the mean-change convergence test from
 firing on an artificially damped step — at least as accurate.
 
+A step is accepted when it does not *significantly* increase the merit. The tolerance is
+the merit's own rounding-noise floor (a few dozen ULPs of the magnitude of the terms
+summed to form it). It matters only on the convergence plateau: there the true decrease is
+smaller than the noise in evaluating it, so a strict decrease test rejects a perfectly good
+undamped Newton step on a 1–2 ULP artifact and substitutes a 10× damped one. That put a
+floor under the attainable mode — `‖∇ₓ neg-log-posterior‖∞ ≈ 2e-10` on a 200-variable
+Poisson chain, versus `7e-15` with the tolerance — and meant that re-running
+`gaussian_approximation` from an already-converged mode moved away from it instead of
+staying put.
+
 ## Iterated linearisation for non-Gaussian priors
 
 `gaussian_approximation` also accepts an [`AbstractLatentPrior`](@ref) directly as the prior side, which is useful in two situations:

--- a/src/arithmetic/condition/gaussian_approximation.jl
+++ b/src/arithmetic/condition/gaussian_approximation.jl
@@ -157,6 +157,13 @@ constraint projection when needed.
 - `newton_dec_tol::Real=1e-5`: Newton decrement convergence tolerance
 - `adaptive_stepsize::Bool=true`: Enable adaptive stepsize with backtracking line search
 - `max_linesearch_iter::Int=10`: Maximum line search iterations per Newton step
+- `step_recovery::Symbol=:retry_full`: How the line search recovers the step scale `α`
+  after a backtrack. `:retry_full` probes the undamped step (`α = 1`) at the start of
+  every Newton iteration and only falls back to the damped scale if it is rejected;
+  `:sqrt` instead grows `α` as `sqrt(α)` per accepted step, spreading the recovery over
+  ~8–10 damped (and therefore fully factorized) Newton iterations. Use `:sqrt` if the
+  merit is not convex along the Newton direction and the slow recovery is wanted as an
+  oscillation guard.
 - `verbose::Bool=false`: Print iteration information
 
 # Returns
@@ -185,6 +192,7 @@ function gaussian_approximation(
         newton_dec_tol::Real = 1.0e-5,
         adaptive_stepsize::Bool = true,
         max_linesearch_iter::Int = 10,
+        step_recovery::Symbol = :retry_full,
         verbose::Bool = false
     )
     base_gmrf = _base_gmrf(prior_gmrf)
@@ -194,20 +202,54 @@ function gaussian_approximation(
     return _newton_loop(
         prior_gmrf, obs_lik, solver, constraints, x_init;
         max_iter, mean_change_tol, newton_dec_tol,
-        adaptive_stepsize, max_linesearch_iter, verbose,
+        adaptive_stepsize, max_linesearch_iter, step_recovery, verbose,
     )
 end
+
+# Resolve the `step_recovery` keyword to "probe the full Newton step first?".
+# Validated here — the two Newton loops are the single funnel every
+# `gaussian_approximation` entry point passes through.
+function _retry_full_step(step_recovery::Symbol)
+    step_recovery === :retry_full && return true
+    step_recovery === :sqrt && return false
+    throw(
+        ArgumentError(
+            "step_recovery must be :retry_full or :sqrt, got :$step_recovery"
+        )
+    )
+end
+
+# Line-search merit: the neg-log-posterior up to an x-independent constant.
+_ga_merit(prior, Q_p, h, obs_lik, x) = _prior_energy(prior, Q_p, h, x) - loglik(x, obs_lik)
 
 # Backtracking line search shared by the cache- and workspace-backed Newton loops.
 # Returns the accepted iterate `x_new` and the (possibly shrunk) step scale `α`. The
 # merit is `_prior_energy(prior, Q_p, h, ·) - loglik(·, obs_lik)` — the neg-log-posterior
 # up to an x-independent constant, so accept/reject decisions match the full merit while
 # never evaluating `logpdf` (no factorization on a shared workspace).
+#
+# `α` persists across Newton iterations: a backtrack shrinks it 10×, an accepted step
+# grows it back as `sqrt(α)`. With `retry_full` (the `:retry_full` policy) the undamped
+# step is probed before that ladder is descended, which is what keeps a single early
+# backtrack from spreading its recovery over ~8-10 damped Newton iterations. The probe is
+# cheap precisely because the merit never factorizes, whereas a damped iteration costs a
+# full factorize + solve.
 function _ga_line_search(
         prior, Q_p, h, energy_k, obs_lik, x_k, step, α;
         max_linesearch_iter::Int, newton_dec_tol::Real, verbose::Bool,
+        retry_full::Bool,
     )
     obj_current = energy_k - loglik(x_k, obs_lik)
+
+    if retry_full && α < one(α)
+        x_full = x_k - step
+        if _ga_merit(prior, Q_p, h, obs_lik, x_full) <= obj_current
+            verbose && println("    Accepted full step (α=1)")
+            return x_full, one(α)
+        end
+        verbose && println("    Full step rejected, resuming at α=$(round(α, digits = 4))")
+    end
+
     accept = false
     # Pre-initialize so `x_new` is provably defined for static analysis: the loop assigns
     # it only on the accept branch, in a way JET cannot track. Always overwritten below —
@@ -216,7 +258,7 @@ function _ga_line_search(
 
     for ls_iter in 1:max_linesearch_iter
         candidate = x_k - α * step
-        obj_candidate = _prior_energy(prior, Q_p, h, candidate) - loglik(candidate, obs_lik)
+        obj_candidate = _ga_merit(prior, Q_p, h, obs_lik, candidate)
 
         if obj_candidate <= obj_current
             x_new = candidate
@@ -264,8 +306,10 @@ function _newton_loop(
         newton_dec_tol::Real,
         adaptive_stepsize::Bool,
         max_linesearch_iter::Int,
+        step_recovery::Symbol,
         verbose::Bool,
     )
+    retry_full = _retry_full_step(step_recovery)
     x_k = copy(x_init)
     α = 1.0
     verbose && println("Starting Fisher scoring...")
@@ -285,7 +329,7 @@ function _newton_loop(
         if adaptive_stepsize
             x_new, α = _ga_line_search(
                 prior, Q_p, h, energy_k, obs_lik, x_k, step, α;
-                max_linesearch_iter, newton_dec_tol, verbose,
+                max_linesearch_iter, newton_dec_tol, verbose, retry_full,
             )
         else
             x_new = x_k - step

--- a/src/arithmetic/condition/gaussian_approximation.jl
+++ b/src/arithmetic/condition/gaussian_approximation.jl
@@ -222,6 +222,19 @@ end
 # Line-search merit: the neg-log-posterior up to an x-independent constant.
 _ga_merit(prior, Q_p, h, obs_lik, x) = _prior_energy(prior, Q_p, h, x) - loglik(x, obs_lik)
 
+# Rounding-noise floor of a merit evaluation. The merit is a difference of two
+# O(n)-term sums (prior energy and log-likelihood), so its achievable precision
+# scales with the magnitude of *those* terms — `abs(merit)` alone underestimates it
+# whenever the two nearly cancel. A few dozen ULPs: the artifacts measured on the
+# convergence plateau are 1-6 ULPs, while the smallest decrease the line search can
+# still act on there is ~1e-11 relative, so this sits well clear of both.
+#
+# `eps(typeof(scale))` rather than `eps(scale)`: the `ChordalGMRF` hyperparameter path
+# differentiates straight through the Newton loop, so `scale` can be a `ForwardDiff.Dual`
+# (for which the type-based `eps` is the value type's). The tolerance is then a Dual too,
+# which is harmless — `obj_accept` is only ever compared with `<=`, on values alone.
+_merit_atol(scale::Real) = 64 * eps(typeof(scale)) * max(scale, one(scale))
+
 # Backtracking line search shared by the cache- and workspace-backed Newton loops.
 # Returns the accepted iterate `x_new` and the (possibly shrunk) step scale `α`. The
 # merit is `_prior_energy(prior, Q_p, h, ·) - loglik(·, obs_lik)` — the neg-log-posterior
@@ -239,11 +252,20 @@ function _ga_line_search(
         max_linesearch_iter::Int, newton_dec_tol::Real, verbose::Bool,
         retry_full::Bool,
     )
-    obj_current = energy_k - loglik(x_k, obs_lik)
+    loglik_k = loglik(x_k, obs_lik)
+    obj_current = energy_k - loglik_k
+    # Accept anything that is not a *significant* increase. Near the mode the true
+    # decrease falls below the merit's own rounding noise, and a strict `<=` then
+    # rejects a perfectly good undamped Newton step over a 1-2 ULP artifact and
+    # replaces it with a 10x-damped one — which is how a warm start from a converged
+    # mode came back with ‖∇ₓ neg-log-posterior‖∞ ≈ 5e-10 instead of ≈ 8e-15. A step
+    # whose merit change is at the noise floor cannot be an overshoot, so there is
+    # nothing for the line search to guard against.
+    obj_accept = obj_current + _merit_atol(abs(energy_k) + abs(loglik_k))
 
     if retry_full && α < one(α)
         x_full = x_k - step
-        if _ga_merit(prior, Q_p, h, obs_lik, x_full) <= obj_current
+        if _ga_merit(prior, Q_p, h, obs_lik, x_full) <= obj_accept
             verbose && println("    Accepted full step (α=1)")
             return x_full, one(α)
         end
@@ -260,7 +282,7 @@ function _ga_line_search(
         candidate = x_k - α * step
         obj_candidate = _ga_merit(prior, Q_p, h, obs_lik, candidate)
 
-        if obj_candidate <= obj_current
+        if obj_candidate <= obj_accept
             x_new = candidate
             α = sqrt(α)
             accept = true

--- a/src/latent_models/gaussian_approximation.jl
+++ b/src/latent_models/gaussian_approximation.jl
@@ -57,6 +57,7 @@ function gaussian_approximation(
         newton_dec_tol::Real = 1.0e-5,
         adaptive_stepsize::Bool = true,
         max_linesearch_iter::Int = 10,
+        step_recovery::Symbol = :retry_full,
         verbose::Bool = false,
         hp_kwargs...,
     )
@@ -65,7 +66,7 @@ function gaussian_approximation(
     return gaussian_approximation(
         materialised, obs_lik;
         x0, max_iter, mean_change_tol, newton_dec_tol,
-        adaptive_stepsize, max_linesearch_iter, verbose,
+        adaptive_stepsize, max_linesearch_iter, step_recovery, verbose,
     )
 end
 
@@ -101,6 +102,7 @@ function gaussian_approximation(
         newton_dec_tol::Real = 1.0e-5,
         adaptive_stepsize::Bool = true,
         max_linesearch_iter::Int = 10,
+        step_recovery::Symbol = :retry_full,
         verbose::Bool = false,
         hp_kwargs...,
     )
@@ -114,7 +116,7 @@ function gaussian_approximation(
         return _nongaussian_dualhp_ift(
             prior, obs_lik, θ_full, ws;
             x0, max_iter, mean_change_tol, newton_dec_tol,
-            adaptive_stepsize, max_linesearch_iter, verbose,
+            adaptive_stepsize, max_linesearch_iter, step_recovery, verbose,
         )
     end
 
@@ -130,13 +132,13 @@ function gaussian_approximation(
         return _newton_loop(
             lp, obs_lik, cache, constraints_nt, x_init;
             max_iter, mean_change_tol, newton_dec_tol,
-            adaptive_stepsize, max_linesearch_iter, verbose,
+            adaptive_stepsize, max_linesearch_iter, step_recovery, verbose,
         )
     end
 
     return _workspace_newton_loop(
         lp, ws, obs_lik, constraints_nt, x_init;
         max_iter, mean_change_tol, newton_dec_tol,
-        adaptive_stepsize, max_linesearch_iter, verbose,
+        adaptive_stepsize, max_linesearch_iter, step_recovery, verbose,
     )
 end

--- a/src/workspace/gaussian_approximation.jl
+++ b/src/workspace/gaussian_approximation.jl
@@ -200,6 +200,7 @@ function gaussian_approximation(
         newton_dec_tol::Real = 1.0e-5,
         adaptive_stepsize::Bool = true,
         max_linesearch_iter::Int = 10,
+        step_recovery::Symbol = :retry_full,
         verbose::Bool = false
     )
     ws = prior.workspace
@@ -210,7 +211,7 @@ function gaussian_approximation(
     return _workspace_newton_loop(
         prior, ws, obs_lik, prior.constraints, x_init;
         max_iter, mean_change_tol, newton_dec_tol,
-        adaptive_stepsize, max_linesearch_iter, verbose,
+        adaptive_stepsize, max_linesearch_iter, step_recovery, verbose,
     )
 end
 
@@ -235,8 +236,10 @@ function _workspace_newton_loop(
         newton_dec_tol::Real,
         adaptive_stepsize::Bool,
         max_linesearch_iter::Int,
+        step_recovery::Symbol,
         verbose::Bool,
     )
+    retry_full = _retry_full_step(step_recovery)
     diag_idx = _diagonal_indices(ws.Q)
     sparse_hess_map = nothing
     x_k = copy(x_init)
@@ -259,7 +262,7 @@ function _workspace_newton_loop(
         if adaptive_stepsize
             x_new, α = _ga_line_search(
                 prior, Q_p, h, energy_k, obs_lik, x_k, step, α;
-                max_linesearch_iter, newton_dec_tol, verbose,
+                max_linesearch_iter, newton_dec_tol, verbose, retry_full,
             )
         else
             x_new = x_k - step
@@ -311,6 +314,7 @@ function gaussian_approximation(
         newton_dec_tol::Real = 1.0e-5,
         adaptive_stepsize::Bool = true,
         max_linesearch_iter::Int = 10,
+        step_recovery::Symbol = :retry_full,
         verbose::Bool = false
     )
     if has_constraints(prior)

--- a/test/gaussian_approximation/test_gaussian_approximation.jl
+++ b/test/gaussian_approximation/test_gaussian_approximation.jl
@@ -384,7 +384,7 @@ using Distributions
         end
     end
 
-    @testset "Step recovery policies" begin
+    @testset "Line search behaviour" begin
         # Issue #203: an early backtrack shrinks the persistent step scale to α = 0.1.
         # `:sqrt` then spends ~8-10 further Newton iterations — each a full factorize
         # + solve — crawling back to α ≈ 1, while `:retry_full` re-probes the undamped
@@ -435,6 +435,22 @@ using Distributions
             @test_throws ArgumentError gaussian_approximation(
                 prior_gmrf, obs_lik; step_recovery = :bogus
             )
+        end
+
+        @testset "convergence is not capped by merit rounding noise" begin
+            # Near the mode the merit's true decrease (≈ half the Newton decrement)
+            # falls below the rounding noise of evaluating it, and a strict decrease
+            # test then rejects the undamped Newton step on a 1-2 ULP artifact and
+            # takes a 10x-damped one instead. That put a floor under how close to the
+            # mode the loop could get — ‖∇ₓ neg-log-posterior‖∞ ≈ 2e-10 here — and made
+            # a converged mode fail to be a fixed point of the iteration.
+            res = gaussian_approximation(prior_gmrf, obs_lik; tight...)
+            x_star = mean(res)
+            @test ∇norm(x_star) < 1.0e-12
+
+            res_warm = gaussian_approximation(prior_gmrf, obs_lik; x0 = x_star, tight...)
+            @test mean(res_warm) ≈ x_star atol = 1.0e-10
+            @test ∇norm(mean(res_warm)) < 1.0e-12
         end
     end
 

--- a/test/gaussian_approximation/test_gaussian_approximation.jl
+++ b/test/gaussian_approximation/test_gaussian_approximation.jl
@@ -384,6 +384,60 @@ using Distributions
         end
     end
 
+    @testset "Step recovery policies" begin
+        # Issue #203: an early backtrack shrinks the persistent step scale to α = 0.1.
+        # `:sqrt` then spends ~8-10 further Newton iterations — each a full factorize
+        # + solve — crawling back to α ≈ 1, while `:retry_full` re-probes the undamped
+        # step every iteration and resumes full Newton as soon as it is accepted.
+        n = 200
+        Q_prior = spdiagm(-1 => fill(-1.0, n - 1), 0 => fill(2.01, n), 1 => fill(-1.0, n - 1))
+        prior_gmrf = GMRF(zeros(n), Q_prior)
+        counts = round.(Int, exp.(3 .* sin.(range(0, 6π; length = n))))
+        obs_lik = ExponentialFamily(Poisson)(PoissonObservations(counts))
+
+        # Distance to the true mode, independent of the iteration path taken there.
+        ∇norm(x) = norm(
+            GaussianMarkovRandomFields.∇ₓ_neg_log_posterior(prior_gmrf, obs_lik, x), Inf
+        )
+        tight = (newton_dec_tol = 1.0e-12, mean_change_tol = 1.0e-12)
+
+        @testset "both policies converge to the same mode" begin
+            res_sqrt = gaussian_approximation(prior_gmrf, obs_lik; step_recovery = :sqrt, tight...)
+            res_full = gaussian_approximation(prior_gmrf, obs_lik; step_recovery = :retry_full, tight...)
+
+            @test mean(res_sqrt) ≈ mean(res_full) atol = 1.0e-6
+            @test precision_matrix(res_sqrt) ≈ precision_matrix(res_full) atol = 1.0e-6
+            @test ∇norm(mean(res_full)) < 1.0e-8
+            @test ∇norm(mean(res_sqrt)) < 1.0e-8
+        end
+
+        @testset ":retry_full is the default" begin
+            res_default = gaussian_approximation(prior_gmrf, obs_lik; max_iter = 8, tight...)
+            res_full = gaussian_approximation(
+                prior_gmrf, obs_lik; max_iter = 8, step_recovery = :retry_full, tight...
+            )
+            @test mean(res_default) == mean(res_full)
+        end
+
+        @testset ":retry_full gets far closer to the mode per iteration" begin
+            # Same iteration budget => same number of factorizations. `:sqrt` is still
+            # taking damped steps at iteration 8; `:retry_full` has already converged.
+            res_sqrt = gaussian_approximation(
+                prior_gmrf, obs_lik; max_iter = 8, step_recovery = :sqrt, tight...
+            )
+            res_full = gaussian_approximation(
+                prior_gmrf, obs_lik; max_iter = 8, step_recovery = :retry_full, tight...
+            )
+            @test ∇norm(mean(res_full)) < 1.0e-3 * ∇norm(mean(res_sqrt))
+        end
+
+        @testset "unknown policy is rejected" begin
+            @test_throws ArgumentError gaussian_approximation(
+                prior_gmrf, obs_lik; step_recovery = :bogus
+            )
+        end
+    end
+
     @testset "Adaptive stepsize - multiple extreme Poisson" begin
         # Multi-dimensional case with varying extreme counts
         n = 5

--- a/test/latent_models/test_local_quadratic_nongaussian.jl
+++ b/test/latent_models/test_local_quadratic_nongaussian.jl
@@ -171,6 +171,18 @@ GaussianMarkovRandomFields.prior_logdensity(
         @test mean(post) ≈ x_gt atol = 1.0e-6
         Q_post_expected = _qd_neg_hessian(x_gt, τ, a) + (1 / σ^2) * sparse(1.0I, n, n)
         @test Matrix(precision_matrix(post)) ≈ Matrix(Q_post_expected) atol = 1.0e-4
+
+        # `step_recovery` reaches the iterated-linearisation loop, whose line-search
+        # merit is the exact (non-concave) `log p(x | θ)`. Both policies must find the
+        # same mode; `:sqrt` is the opt-out for priors where probing the undamped step
+        # is not wanted.
+        post_sqrt = gaussian_approximation(
+            model, obs_lik; τ = τ, a = a, step_recovery = :sqrt
+        )
+        @test mean(post_sqrt) ≈ x_gt atol = 1.0e-6
+        @test_throws ArgumentError gaussian_approximation(
+            model, obs_lik; τ = τ, a = a, step_recovery = :bogus
+        )
     end
 
     @testset "Laplace marginal: non-Gaussian-prior bias is bounded" begin

--- a/test/workspace/test_workspace_gaussian_approximation.jl
+++ b/test/workspace/test_workspace_gaussian_approximation.jl
@@ -206,6 +206,11 @@ using SparseArrays
         )
         @test ∇norm(mean(ws_full)) < 1.0e-3 * ∇norm(mean(ws_sqrt))
 
+        # The merit-rounding-noise tolerance lives in the shared line search, so the
+        # workspace loop reaches the same numerical floor at the mode.
+        ws_converged = gaussian_approximation(WorkspaceGMRF(μ_prior, Q_prior), obs_lik; tight...)
+        @test ∇norm(collect(mean(ws_converged))) < 1.0e-12
+
         @test_throws ArgumentError gaussian_approximation(
             WorkspaceGMRF(μ_prior, Q_prior), obs_lik; step_recovery = :bogus
         )

--- a/test/workspace/test_workspace_gaussian_approximation.jl
+++ b/test/workspace/test_workspace_gaussian_approximation.jl
@@ -172,4 +172,42 @@ using SparseArrays
         @test mean(ws_result) ≈ mean(ref_result) rtol = 1.0e-6
         @test precision_matrix(ws_result) ≈ precision_matrix(ref_result) rtol = 1.0e-6
     end
+
+    @testset "Step recovery policies (workspace loop)" begin
+        n = 200
+        Q_prior = spdiagm(-1 => fill(-1.0, n - 1), 0 => fill(2.01, n), 1 => fill(-1.0, n - 1))
+        μ_prior = zeros(n)
+        counts = round.(Int, exp.(3 .* sin.(range(0, 6π; length = n))))
+        obs_lik = ExponentialFamily(Distributions.Poisson)(PoissonObservations(counts))
+        tight = (newton_dec_tol = 1.0e-12, mean_change_tol = 1.0e-12)
+
+        ref_gmrf = GMRF(μ_prior, Q_prior)
+        ∇norm(x) = norm(
+            GaussianMarkovRandomFields.∇ₓ_neg_log_posterior(ref_gmrf, obs_lik, x), Inf
+        )
+
+        # The workspace loop runs the same line search as the cache-backed one, so
+        # every policy must land on the same mode as the GMRF path.
+        for policy in (:retry_full, :sqrt)
+            ref = gaussian_approximation(ref_gmrf, obs_lik; step_recovery = policy, tight...)
+            ws = gaussian_approximation(
+                WorkspaceGMRF(μ_prior, Q_prior), obs_lik; step_recovery = policy, tight...
+            )
+            @test mean(ws) ≈ mean(ref) rtol = 1.0e-8
+        end
+
+        # ... and the default policy must actually be in force here too (issue #203).
+        ws_sqrt = gaussian_approximation(
+            WorkspaceGMRF(μ_prior, Q_prior), obs_lik;
+            max_iter = 8, step_recovery = :sqrt, tight...
+        )
+        ws_full = gaussian_approximation(
+            WorkspaceGMRF(μ_prior, Q_prior), obs_lik; max_iter = 8, tight...
+        )
+        @test ∇norm(mean(ws_full)) < 1.0e-3 * ∇norm(mean(ws_sqrt))
+
+        @test_throws ArgumentError gaussian_approximation(
+            WorkspaceGMRF(μ_prior, Q_prior), obs_lik; step_recovery = :bogus
+        )
+    end
 end


### PR DESCRIPTION
Closes #203.

## Step recovery

`_ga_line_search` carries its step scale `α` across Newton iterations: a backtrack multiplies it by 0.1, and each accepted step recovers it via `α = sqrt(α)`. One early backtrack therefore spread the recovery over ~8–10 further iterations — each a full factorize + solve taking a needlessly damped step, long after the iterate had re-entered the basin where the undamped step is fine.

The merit (`_prior_energy` + `loglik`) never factorizes, so probing `α = 1` first costs one cheap evaluation and saves an expensive damped iteration. The probe runs only when `α` has been damped; on rejection the backtracking ladder proceeds exactly as before.

New `step_recovery` keyword on every `gaussian_approximation` entry point: `:retry_full` (default) probes the full step, `:sqrt` keeps the old policy as an opt-out for priors whose merit is not convex along the Newton direction.

## Acceptance test

Measuring the above turned up something worse. Near the mode the merit's true decrease drops below the rounding noise of evaluating it, so the strict `obj_candidate <= obj_current` test was rejecting a perfectly good full Newton step on a **1–2 ULP artifact** and substituting a 10× damped one. That put a floor under how close to the mode the loop could get, and meant re-running `gaussian_approximation` from an already-converged mode moved away from it instead of staying put.

Acceptance now allows an increase up to the merit's own noise floor — a few dozen ULPs of the magnitude of the terms summed to form it. A step whose merit change sits at the noise floor cannot be an overshoot, so there is nothing for the line search to guard against.

## Numbers

Ten scenarios; `‖g‖∞` is `‖∇ₓ neg-log-posterior‖∞` at the returned mode.

| scenario | iterations | time | ‖g‖∞ |
| --- | --- | --- | --- |
| issue repro, n=500, tight tol | 10 → 9 | 1.35 → 1.16 ms | 2.1e-9 → 7.5e-15 |
| same, workspace-backed | 10 → 9 | 0.60 → 0.55 ms | 2.1e-9 → 7.5e-15 |
| 60×60 grid Poisson | 10 → 8 | 28.9 → 22.7 ms | 2.2e-8 → 2.9e-15 |
| weak-prior chain | 11 → 9 | 0.96 → 0.74 ms | 1.7e-7 → 6.9e-12 |
| Poisson, extreme counts, n=1 | 7 → 4 | 0.049 → 0.047 ms | 9.8e-4 → 4.5e-7 |
| Poisson, extreme counts, n=5 | 11 → 11 | 0.131 → 0.125 ms | 8.4e-4 → 7.5e-9 |

Nothing got slower or less accurate. Where the iteration count is unchanged the mode is markedly more accurate for the same number of factorizations — damped steps shrink `mean_change`, which fires the convergence test early. The acceptance-tolerance change on its own leaves 7 of the 10 scenarios bit-identical; the 3 that move are exactly the ones that hit the plateau.

## Also here

- `poisson_cold_start` added to the CI regression benchmark — a harder cold start on the sparse/CHOLMOD path (`poisson_rw1_small` backtracks too, but is milder and runs the SymTridiagonal/LDLt backend).
- Tests for both policies on the cache- and workspace-backed loops and through the non-Gaussian latent prior path, plus a regression test that a converged mode is a fixed point of the iteration (it lands at ~2e-10 under the old acceptance test).
