### PR TITLE
Fix the Runic.jl link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ which includes tutorials and a full API reference, and searching existing issues
 
 - Follow the [Julia Style Guide](https://docs.julialang.org/en/v1/manual/style-guide/).
 - Use meaningful variable names and avoid excessive abbreviations.
-- Format your code using [Runic](https://github.com/fredrikekre/runic):
+- Format your code using [Runic](https://github.com/fredrikekre/Runic.jl):
   ```sh
   make format
   # or


### PR DESCRIPTION
CONTRIBUTING.md links the formatter as `github.com/fredrikekre/runic`, which 404s. The repository is `Runic.jl`.

Checked that the corrected URL returns 200.